### PR TITLE
SNT-27 Import metrics form OpenHEXA

### DIFF
--- a/management/commands/import_openhexa_metrics.py
+++ b/management/commands/import_openhexa_metrics.py
@@ -1,27 +1,28 @@
 """
-Django management command to fetch and download a dataset from OpenHEXA workspace.
+Django management command to import metrics from OpenHEXA datasets.
+
+Downloads dataset files from OpenHEXA workspace and imports metrics data
+into Django models for the specified account.
 
 Usage:
-    python manage.py fetch_dataset <workspace_slug> <dataset_slug>
+    python manage.py import_openhexa_metrics --workspace_slug <slug> --dataset_slug <slug> --account-id <id>
 
 Environment variables required:
-    OPENHEXA_SERVER_URL - OpenHEXA server URL
-    OPENHEXA_USERNAME - Username (optional if using token)
-    OPENHEXA_PASSWORD - Password (optional if using token)
-    OPENHEXA_TOKEN - API token (optional if using username/password)
+    OPENHEXA_URL - OpenHEXA server URL
+    OPENHEXA_TOKEN - API authentication token
 """
 
-import csv
-import json
 import os
+
 from pathlib import Path
 
 from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
 
-from iaso.models import Account, MetricType, MetricValue, OrgUnit
-from .support.openhexa_client import OpenHEXAClient
+from iaso.models import Account
+
 from .support.file_downloader import FileDownloader
+from .support.metrics_importer import MetricsImporter
+from .support.openhexa_client import OpenHEXAClient
 
 
 class Command(BaseCommand):
@@ -33,16 +34,28 @@ class Command(BaseCommand):
         parser.add_argument("--account-id", type=int, help="Account ID for importing metrics (required)")
 
     def handle(self, *args, **options):
+        # Validate arguments and environment
+        workspace_slug, dataset_slug, account = self._validate_arguments(options)
+        download_path = self._setup_download_directory(account.id)
+        openhexa_client = self._setup_openhexa_client()
+
+        # Orchestrate the full process
+        self._list_available_datasets(openhexa_client, workspace_slug)
+        dataset_info = self._fetch_dataset_info(openhexa_client, workspace_slug, dataset_slug)
+        files = self._download_dataset_files(openhexa_client, dataset_info, download_path)
+        self._display_dataset_summary(dataset_info, files)
+        self._import_metrics(account, download_path)
+
+    def _validate_arguments(self, options):
+        """Validate command arguments and return validated values."""
         workspace_slug = options["workspace_slug"]
         dataset_slug = options["dataset_slug"]
         account_id = options["account_id"]
 
         if not workspace_slug:
             raise CommandError("--workspace_slug is required. Specify the workspace slug containing the dataset.")
-
         if not dataset_slug:
             raise CommandError("--dataset_slug is required. Specify the slug of the dataset to fetch.")
-
         if not account_id:
             raise CommandError("--account-id is required. Specify the account ID for importing metrics.")
 
@@ -50,28 +63,32 @@ class Command(BaseCommand):
         try:
             account = Account.objects.get(id=account_id)
             self.stdout.write(f"Using account: {account.name} (ID: {account.id})")
+            return workspace_slug, dataset_slug, account
         except Account.DoesNotExist:
             raise CommandError(f"Account with ID {account_id} not found.")
 
-        # Set download directory
+    def _setup_download_directory(self, account_id):
+        """Set up and return the download directory path."""
         download_path = Path(f"/tmp/openhexa-metrics/{account_id}")
         download_path.mkdir(parents=True, exist_ok=True)
         self.stdout.write(f"Download directory: {download_path}")
+        return download_path
 
+    def _setup_openhexa_client(self):
+        """Set up and return the OpenHEXA client."""
         server_url = os.getenv("OPENHEXA_URL")
         token = os.getenv("OPENHEXA_TOKEN")
 
         if not server_url:
-            raise CommandError("OPENHEXA_SERVER_URL environment variable is required")
-
+            raise CommandError("OPENHEXA_URL environment variable is required")
         if not token:
             raise CommandError("OPENHEXA_TOKEN environment variable is required")
 
-        # Initialize OpenHEXA client
-        openhexa_client = OpenHEXAClient(server_url, token)
         self.stdout.write(f"Connecting to {server_url} with token authentication...")
+        return OpenHEXAClient(server_url, token)
 
-        # List available datasets for easy debugging
+    def _list_available_datasets(self, openhexa_client, workspace_slug):
+        """List available datasets in the workspace for debugging."""
         self.stdout.write(f'Checking available datasets in workspace "{workspace_slug}"...')
         datasets = openhexa_client.list_workspace_datasets(workspace_slug)
         if datasets:
@@ -81,6 +98,8 @@ class Command(BaseCommand):
         else:
             self.stdout.write("No datasets found in this workspace (or insufficient permissions to list).")
 
+    def _fetch_dataset_info(self, openhexa_client, workspace_slug, dataset_slug):
+        """Fetch dataset information and return dataset info with version and files."""
         self.stdout.write(f'Fetching dataset "{dataset_slug}" from workspace "{workspace_slug}"...')
         dataset_link = openhexa_client.get_dataset_link(workspace_slug, dataset_slug)
 
@@ -88,30 +107,31 @@ class Command(BaseCommand):
             raise CommandError(f'Dataset "{dataset_slug}" not found in workspace "{workspace_slug}".')
 
         dataset = dataset_link["dataset"]
-
         dataset_version = openhexa_client.get_latest_version(dataset["id"])
         if not dataset_version:
             raise CommandError(f'No versions found for dataset "{dataset_slug}"')
 
         self.stdout.write(f"Using version: {dataset_version['name']}")
-
-        # Get files for the version
         files = openhexa_client.get_version_files(dataset_version["id"])
 
-        # Download files
+        return {"dataset": dataset, "version": dataset_version, "files": files}
+
+    def _download_dataset_files(self, openhexa_client, dataset_info, download_path):
+        """Download dataset files and return file list."""
         file_downloader = FileDownloader(openhexa_client, download_path, self.stdout.write)
-        file_downloader.download_dataset_files(files)
-        metadata = {"dataset": dataset, "version": dataset_version, "files": files}
+        file_downloader.download_dataset_files(dataset_info["files"])
+        return dataset_info["files"]
+
+    def _display_dataset_summary(self, dataset_info, files):
+        """Display dataset information summary."""
+        metadata = {"dataset": dataset_info["dataset"], "version": dataset_info["version"], "files": files}
         self.stdout.write(self._format_as_table(metadata))
 
-        # Import metrics
+    def _import_metrics(self, account, download_path):
+        """Import metrics from downloaded files."""
         self.stdout.write(f"Starting metrics import for account {account.name} ({account.pk})...")
-        self._import_metrics(download_path, account)
-
-
-
-
-
+        metrics_importer = MetricsImporter(account, download_path, self.stdout.write)
+        metrics_importer.import_metrics()
 
     def _format_as_table(self, metadata):
         """Format dataset information as a readable table."""
@@ -154,156 +174,3 @@ class Command(BaseCommand):
             )
 
         return "\n".join(lines)
-
-    def _find_csv_files(self, download_path):
-        """Find metadata and dataset CSV files in the download directory."""
-        # Find metadata file (*metadata.csv)
-        metadata_files = list(download_path.glob("*metadata.csv"))
-        if not metadata_files:
-            raise CommandError("No metadata CSV file (*metadata.csv) found in download directory")
-        if len(metadata_files) > 1:
-            raise CommandError(f"Multiple metadata CSV files found: {[f.name for f in metadata_files]}")
-
-        # Find dataset file (*dataset.csv)
-        dataset_files = list(download_path.glob("*dataset.csv"))
-        if not dataset_files:
-            raise CommandError("No dataset CSV file (*dataset.csv) found in download directory")
-        if len(dataset_files) > 1:
-            raise CommandError(f"Multiple dataset CSV files found: {[f.name for f in dataset_files]}")
-
-        return metadata_files[0], dataset_files[0]
-
-    def _import_metrics(self, download_path, account):
-        """Import metrics from downloaded CSV files."""
-        try:
-            # Find the CSV files
-            metadata_file, dataset_file = self._find_csv_files(download_path)
-
-            self.stdout.write(f"Using metadata file: {metadata_file.name}")
-            self.stdout.write(f"Using dataset file: {dataset_file.name}")
-
-            # Import the metrics
-            self._process_metrics_import(metadata_file, dataset_file, account)
-
-        except Exception as e:
-            raise CommandError(f"Failed to import metrics: {str(e)}")
-
-    def _process_metrics_import(self, metadata_file, dataset_file, account):
-        """Process the actual metrics import."""
-        # Validate CSV files first
-        self._validate_csv_files(metadata_file, dataset_file)
-
-        self.stdout.write("Clearing existing metrics...")
-        MetricValue.objects.filter(metric_type__account=account).delete()
-        MetricType.objects.filter(account=account).delete()
-
-        self.stdout.write("Creating MetricTypes from metadata file...")
-        metric_types = {}
-
-        with open(metadata_file, newline="", encoding="utf-8") as metafile:
-            metareader = csv.DictReader(metafile)
-            for row in metareader:
-                metric_type = MetricType.objects.create(
-                    account=account,
-                    name=row["LABEL"],
-                    code=row["VARIABLE"],
-                    description=row["DESCRIPTION"],
-                    source=row["SOURCE"],
-                    units=row["UNITS"],
-                    comments=row["COMMENTS"],
-                    category=row["CATEGORY"],
-                    unit_symbol=row["UNIT_SYMBOL"],
-                )
-                self.stdout.write(self.style.SUCCESS(f"Created metric: {metric_type.name}"))
-                metric_types[metric_type.code] = metric_type
-
-        self.stdout.write("Reading values from dataset file...")
-        with open(dataset_file, newline="", encoding="utf-8") as csvfile:
-            csvreader = csv.DictReader(csvfile)
-
-            try:
-                with transaction.atomic():
-                    row_count = 0
-                    value_count = 0
-                    for row in csvreader:
-                        row_count += 1
-                        try:
-                            # Get the OrgUnit by source_ref using ADM2_ID
-                            org_unit = OrgUnit.objects.get(source_ref=row["ADM2_ID"])
-                        except OrgUnit.DoesNotExist:
-                            self.stdout.write(
-                                self.style.WARNING(
-                                    f"Row {row_count}: OrgUnit not found for source_ref: {row['ADM2_ID']}"
-                                )
-                            )
-                            continue
-
-                        # Create MetricValue for each metric type
-                        for column, metric_type in metric_types.items():
-                            if column not in row:
-                                continue
-                            if not row[column]:
-                                continue
-
-                            try:
-                                # Parse the value as a fload and round to max 3 behind the comma
-                                value = round(float(row[column]), 3)
-
-                            except ValueError:
-                                self.stdout.write(
-                                    self.style.WARNING(f"Row {row_count}: Invalid value for {column}: {row[column]}")
-                                )
-                                continue
-
-                            # Create the MetricValue
-                            MetricValue.objects.create(
-                                metric_type=metric_type,
-                                org_unit=org_unit,
-                                value=value,
-                            )
-                            value_count += 1
-
-                    self.stdout.write(f"Processed {row_count} rows, created {value_count} metric values")
-
-            except Exception as e:
-                self.stdout.write(self.style.ERROR(f"Error during import, rolling back transaction: {str(e)}"))
-                raise
-
-        self.stdout.write("Adding threshold scales...")
-        # Import legend functionality here
-        from .support.legend import get_legend_config, get_legend_type
-
-        for metric_type in MetricType.objects.filter(account=account):
-            metric_type.legend_config = get_legend_config(metric_type)
-            metric_type.legend_type = get_legend_type(metric_type)
-            metric_type.save()
-
-        self.stdout.write(self.style.SUCCESS("Metrics import completed successfully!"))
-
-    def _validate_csv_files(self, metadata_file, dataset_file):
-        """Validate that CSV files have the expected structure."""
-        # Validate metadata file
-        required_metadata_columns = [
-            "VARIABLE",
-            "LABEL",
-            "DESCRIPTION",
-            "SOURCE",
-            "UNITS",
-            "COMMENTS",
-            "CATEGORY",
-            "UNIT_SYMBOL",
-        ]
-
-        with open(metadata_file, newline="", encoding="utf-8") as metafile:
-            metareader = csv.DictReader(metafile)
-            missing_columns = set(required_metadata_columns) - set(metareader.fieldnames)
-            if missing_columns:
-                raise CommandError(f"Metadata file missing required columns: {', '.join(missing_columns)}")
-
-        # Validate dataset file has ADM2_ID column
-        with open(dataset_file, newline="", encoding="utf-8") as csvfile:
-            csvreader = csv.DictReader(csvfile)
-            if "ADM2_ID" not in csvreader.fieldnames:
-                raise CommandError("Dataset file missing required column: ADM2_ID")
-
-        self.stdout.write("CSV file validation passed")

--- a/management/commands/import_openhexa_metrics.py
+++ b/management/commands/import_openhexa_metrics.py
@@ -47,7 +47,6 @@ class Command(BaseCommand):
         self._import_metrics(account, download_path)
 
     def _validate_arguments(self, options):
-        """Validate command arguments and return validated values."""
         workspace_slug = options["workspace_slug"]
         dataset_slug = options["dataset_slug"]
         account_id = options["account_id"]
@@ -68,14 +67,12 @@ class Command(BaseCommand):
             raise CommandError(f"Account with ID {account_id} not found.")
 
     def _setup_download_directory(self, account_id):
-        """Set up and return the download directory path."""
         download_path = Path(f"/tmp/openhexa-metrics/{account_id}")
         download_path.mkdir(parents=True, exist_ok=True)
         self.stdout.write(f"Download directory: {download_path}")
         return download_path
 
     def _setup_openhexa_client(self):
-        """Set up and return the OpenHEXA client."""
         server_url = os.getenv("OPENHEXA_URL")
         token = os.getenv("OPENHEXA_TOKEN")
 
@@ -88,7 +85,6 @@ class Command(BaseCommand):
         return OpenHEXAClient(server_url, token)
 
     def _list_available_datasets(self, openhexa_client, workspace_slug):
-        """List available datasets in the workspace for debugging."""
         self.stdout.write(f'Checking available datasets in workspace "{workspace_slug}"...')
         datasets = openhexa_client.list_workspace_datasets(workspace_slug)
         if datasets:
@@ -99,7 +95,6 @@ class Command(BaseCommand):
             self.stdout.write("No datasets found in this workspace (or insufficient permissions to list).")
 
     def _fetch_dataset_info(self, openhexa_client, workspace_slug, dataset_slug):
-        """Fetch dataset information and return dataset info with version and files."""
         self.stdout.write(f'Fetching dataset "{dataset_slug}" from workspace "{workspace_slug}"...')
         dataset_link = openhexa_client.get_dataset_link(workspace_slug, dataset_slug)
 
@@ -117,24 +112,20 @@ class Command(BaseCommand):
         return {"dataset": dataset, "version": dataset_version, "files": files}
 
     def _download_dataset_files(self, openhexa_client, dataset_info, download_path):
-        """Download dataset files and return file list."""
         file_downloader = FileDownloader(openhexa_client, download_path, self.stdout.write)
         file_downloader.download_dataset_files(dataset_info["files"])
         return dataset_info["files"]
 
     def _display_dataset_summary(self, dataset_info, files):
-        """Display dataset information summary."""
         metadata = {"dataset": dataset_info["dataset"], "version": dataset_info["version"], "files": files}
         self.stdout.write(self._format_as_table(metadata))
 
     def _import_metrics(self, account, download_path):
-        """Import metrics from downloaded files."""
         self.stdout.write(f"Starting metrics import for account {account.name} ({account.pk})...")
         metrics_importer = MetricsImporter(account, download_path, self.stdout.write)
         metrics_importer.import_metrics()
 
     def _format_as_table(self, metadata):
-        """Format dataset information as a readable table."""
         dataset = metadata["dataset"]
         version = metadata["version"]
         files = metadata["files"]

--- a/management/commands/import_openhexa_metrics.py
+++ b/management/commands/import_openhexa_metrics.py
@@ -1,0 +1,306 @@
+"""
+Django management command to fetch and download a dataset from OpenHEXA workspace.
+
+Usage:
+    python manage.py fetch_dataset <workspace_slug> <dataset_slug>
+
+Environment variables required:
+    OPENHEXA_SERVER_URL - OpenHEXA server URL
+    OPENHEXA_USERNAME - Username (optional if using token)
+    OPENHEXA_PASSWORD - Password (optional if using token)
+    OPENHEXA_TOKEN - API token (optional if using username/password)
+"""
+
+import json
+import os
+
+from pathlib import Path
+
+import requests
+
+from django.core.management.base import BaseCommand, CommandError
+from openhexa.toolbox.hexa import NotFound, OpenHEXA
+
+
+class Command(BaseCommand):
+    help = "Fetch a specific dataset from an OpenHEXA workspace"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--workspace_slug", type=str, help="The slug of the workspace containing the dataset")
+        parser.add_argument("--dataset_slug", type=str, help="The slug of the dataset to fetch")
+        parser.add_argument("--download", action="store_true", help="Download dataset files to local directory")
+        parser.add_argument(
+            "--download-dir",
+            type=str,
+            default="./datasets",
+            help="Directory to download files to (default: ./datasets)",
+        )
+        parser.add_argument(
+            "--format", choices=["json", "table"], default="json", help="Output format for metadata (default: json)"
+        )
+        parser.add_argument("--output", type=str, help="Output file path for metadata (optional)")
+
+    def handle(self, *args, **options):
+        workspace_slug = options["workspace_slug"]
+        dataset_slug = options["dataset_slug"]
+        should_download = options["download"]
+        download_dir = options["download_dir"]
+        output_format = options["format"]
+        output_file = options.get("output")
+
+        # Get credentials from environment
+        server_url = os.getenv("OPENHEXA_URL")
+        username = os.getenv("OPENHEXA_USERNAME")
+        password = os.getenv("OPENHEXA_PASSWORD")
+        token = os.getenv("OPENHEXA_TOKEN")
+
+        if not server_url:
+            raise CommandError("OPENHEXA_SERVER_URL environment variable is required")
+
+        if not token and not (username and password):
+            raise CommandError(
+                "Either OPENHEXA_TOKEN or both OPENHEXA_USERNAME and OPENHEXA_PASSWORD "
+                "environment variables are required"
+            )
+
+        try:
+            # Initialize OpenHEXA client
+            if token:
+                hexa = OpenHEXA(server_url, token=token)
+                self.stdout.write(f"Connecting to {server_url} with token authentication...")
+            else:
+                hexa = OpenHEXA(server_url, username=username, password=password)
+                self.stdout.write(f"Connecting to {server_url} with credentials...")
+
+            # Fetch the dataset link
+            self.stdout.write(f'Fetching dataset "{dataset_slug}" from workspace "{workspace_slug}"...')
+
+            dataset_link = self._get_dataset_link(hexa, workspace_slug, dataset_slug)
+
+            if not dataset_link:
+                raise CommandError(f'Dataset "{dataset_slug}" not found in workspace "{workspace_slug}"')
+
+            dataset = dataset_link["dataset"]
+
+            dataset_version = self._get_latest_version(hexa, dataset["id"])
+            if not dataset_version:
+                raise CommandError(f'No versions found for dataset "{dataset_slug}"')
+
+            self.stdout.write(f"Using version: {dataset_version['name']}")
+
+            # Get files for the version
+            files = self._get_version_files(hexa, dataset_version["id"])
+
+            # Download files if requested
+            if should_download:
+                self._download_files(hexa, files, download_dir, workspace_slug, dataset_slug, dataset_version["name"])
+
+            # Prepare metadata output
+            metadata = {"dataset": dataset, "version": dataset_version, "files": files}
+
+            # Format and output metadata
+            if output_format == "json":
+                output_data = json.dumps(metadata, indent=2)
+            else:  # table format
+                output_data = self._format_as_table(metadata)
+
+            if output_file:
+                with open(output_file, "w") as f:
+                    f.write(output_data)
+                self.stdout.write(self.style.SUCCESS(f"Dataset metadata saved to {output_file}"))
+            else:
+                self.stdout.write(output_data)
+
+        except NotFound as e:
+            raise CommandError(str(e))
+        except Exception as e:
+            raise CommandError(f"Error fetching dataset: {str(e)}")
+
+    def _get_dataset_link(self, hexa, workspace_slug, dataset_slug):
+        """Fetch dataset link by slug from the workspace."""
+        try:
+            result = hexa.query(
+                """
+                query getDatasetLinkBySlug($workspaceSlug: String!, $datasetSlug: String!) {
+                    datasetLinkBySlug(workspaceSlug: $workspaceSlug, datasetSlug: $datasetSlug) {
+                        id
+                        dataset {
+                            id
+                            slug
+                            name
+                            description
+                            createdAt
+                            updatedAt
+                        }
+                    }
+                }
+                """,
+                {"workspaceSlug": workspace_slug, "datasetSlug": dataset_slug},
+            )
+            return result.get("datasetLinkBySlug")
+        except Exception as e:
+            if "not found" in str(e).lower():
+                return None
+            raise
+
+    def _get_latest_version(self, hexa, dataset_id):
+        """Get the latest version of a dataset."""
+        try:
+            result = hexa.query(
+                """
+                query getDatasetLatestVersion($id: ID!) {
+                    dataset(id: $id) {
+                        latestVersion {
+                            id
+                            name
+                            changelog
+                            createdAt
+                            createdBy {
+                                displayName
+                            }
+                        }
+                    }
+                }
+                """,
+                {"id": dataset_id},
+            )
+            dataset = result.get("dataset")
+            return dataset.get("latestVersion") if dataset else None
+        except Exception as e:
+            if "not found" in str(e).lower():
+                return None
+            raise
+
+    def _get_version_files(self, hexa, version_id):
+        """Get all files for a dataset version."""
+        try:
+            result = hexa.query(
+                """
+                query getDatasetVersionFiles($id: ID!, $page: Int, $perPage: Int) {
+                    datasetVersion(id: $id) {
+                        files(page: $page, perPage: $perPage) {
+                            items {
+                                id
+                                filename
+                                contentType
+                                size
+                                createdAt
+                                downloadUrl
+                            }
+                            totalItems
+                        }
+                    }
+                }
+                """,
+                {"id": version_id, "page": 1, "perPage": 100},
+            )
+            version = result.get("datasetVersion")
+            return version["files"]["items"] if version else []
+        except Exception as e:
+            self.stdout.write(self.style.WARNING(f"Could not fetch files: {str(e)}"))
+            return []
+
+    def _download_files(self, hexa, files, download_dir, workspace_slug, dataset_slug, version_name):
+        """Download all files in the dataset version."""
+        if not files:
+            self.stdout.write(self.style.WARNING("No files to download"))
+            return
+
+        # Create download directory structure
+        download_path = Path(download_dir) / workspace_slug / dataset_slug / version_name
+        download_path.mkdir(parents=True, exist_ok=True)
+
+        self.stdout.write(f"Downloading {len(files)} files to {download_path}...")
+
+        for file_info in files:
+            try:
+                # Get download URL for the file
+                download_url = self._get_file_download_url(hexa, file_info["id"])
+                if not download_url:
+                    self.stdout.write(self.style.WARNING(f"Could not get download URL for {file_info['filename']}"))
+                    continue
+
+                # Download the file
+                file_path = download_path / file_info["filename"]
+                self._download_file(download_url, file_path, file_info)
+                self.stdout.write(self.style.SUCCESS(f"Downloaded: {file_info['filename']}"))
+
+            except Exception as e:
+                self.stdout.write(self.style.ERROR(f"Failed to download {file_info['filename']}: {str(e)}"))
+
+    def _get_file_download_url(self, hexa, file_id):
+        """Get download URL for a specific file."""
+        try:
+            result = hexa.query(
+                """
+                mutation prepareFileDownload($input: PrepareVersionFileDownloadInput!) {
+                    prepareVersionFileDownload(input: $input) {
+                        success
+                        downloadUrl
+                        errors
+                    }
+                }
+                """,
+                {"input": {"fileId": file_id}},
+            )
+
+            response = result.get("prepareVersionFileDownload")
+            if response and response.get("success"):
+                return response.get("downloadUrl")
+            else:
+                self.stdout.write(self.style.WARNING(f"Download preparation failed: {response.get('errors', [])}"))
+                return None
+        except Exception as e:
+            self.stdout.write(self.style.WARNING(f"Error getting download URL: {str(e)}"))
+            return None
+
+    def _download_file(self, url, file_path, file_info):
+        """Download a file from URL to local path."""
+        response = requests.get(url, stream=True)
+        response.raise_for_status()
+
+        with open(file_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+
+    def _format_as_table(self, metadata):
+        """Format dataset information as a readable table."""
+        dataset = metadata["dataset"]
+        version = metadata["version"]
+        files = metadata["files"]
+
+        lines = [
+            "Dataset Information",
+            "=" * 50,
+            f"ID:          {dataset.get('id', 'N/A')}",
+            f"Slug:        {dataset.get('slug', 'N/A')}",
+            f"Name:        {dataset.get('name', 'N/A')}",
+            f"Description: {dataset.get('description', 'N/A')}",
+            f"Created:     {dataset.get('createdAt', 'N/A')}",
+            f"Updated:     {dataset.get('updatedAt', 'N/A')}",
+            "",
+            "Version Information",
+            "=" * 50,
+            f"ID:          {version.get('id', 'N/A')}",
+            f"Name:        {version.get('name', 'N/A')}",
+            f"Changelog:   {version.get('changelog', 'N/A')}",
+            f"Created:     {version.get('createdAt', 'N/A')}",
+            f"Created By:  {version.get('createdBy', {}).get('displayName', 'N/A')}",
+            "",
+            f"Files ({len(files)})",
+            "=" * 50,
+        ]
+
+        for file_info in files:
+            size_mb = int(file_info.get("size", 0)) / (1024 * 1024) if file_info.get("size") else 0
+            lines.extend(
+                [
+                    f"• {file_info.get('filename', 'N/A')}",
+                    f"  Type: {file_info.get('contentType', 'N/A')}",
+                    f"  Size: {size_mb:.2f} MB",
+                    f"  Created: {file_info.get('createdAt', 'N/A')}",
+                    "",
+                ]
+            )
+
+        return "\n".join(lines)

--- a/management/commands/support/file_downloader.py
+++ b/management/commands/support/file_downloader.py
@@ -1,0 +1,96 @@
+"""
+File downloader for OpenHEXA datasets.
+
+This module handles downloading files from OpenHEXA datasets to local storage,
+including progress reporting and error handling.
+"""
+
+from pathlib import Path
+import requests
+
+
+class FileDownloader:
+    """Handles downloading files from OpenHEXA datasets."""
+
+    def __init__(self, openhexa_client, download_path, stdout_writer=None):
+        """Initialize the file downloader.
+        
+        Args:
+            openhexa_client: OpenHEXA client instance for API calls
+            download_path: Path object for download directory
+            stdout_writer: Optional writer for progress output (e.g., self.stdout.write)
+        """
+        self.openhexa_client = openhexa_client
+        self.download_path = Path(download_path)
+        self.stdout_write = stdout_writer or print
+        
+        # Ensure download directory exists
+        self.download_path.mkdir(parents=True, exist_ok=True)
+
+    def download_dataset_files(self, files):
+        """Download all files in the dataset version.
+        
+        Args:
+            files: List of file information dictionaries
+            
+        Returns:
+            Number of successfully downloaded files
+        """
+        if not files:
+            self.stdout_write("WARNING: No files to download")
+            return 0
+
+        self.stdout_write(f"Downloading {len(files)} files to {self.download_path}...")
+        
+        success_count = 0
+        for file_info in files:
+            try:
+                if self._download_single_file(file_info):
+                    success_count += 1
+                    self.stdout_write(f"SUCCESS: Downloaded: {file_info['filename']}")
+                else:
+                    self.stdout_write(f"WARNING: Could not get download URL for {file_info['filename']}")
+
+            except Exception as e:
+                self.stdout_write(f"ERROR: Failed to download {file_info['filename']}: {str(e)}")
+        
+        self.stdout_write(f"Downloaded {success_count}/{len(files)} files successfully")
+        return success_count
+
+    def _download_single_file(self, file_info):
+        """Download a single file.
+        
+        Args:
+            file_info: File information dictionary
+            
+        Returns:
+            True if successful, False otherwise
+        """
+        # Get download URL for the file
+        download_url = self.openhexa_client.get_file_download_url(file_info["id"])
+        if not download_url:
+            return False
+
+        # Download the file
+        file_path = self.download_path / file_info["filename"]
+        self._download_file_from_url(download_url, file_path, file_info)
+        return True
+
+    def _download_file_from_url(self, url, file_path, file_info):
+        """Download a file from URL to local path.
+        
+        Args:
+            url: Download URL
+            file_path: Local file path
+            file_info: File information for error reporting
+        """
+        response = requests.get(url, stream=True)
+        response.raise_for_status()
+
+        with open(file_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+
+    def get_download_path(self):
+        """Get the download directory path."""
+        return self.download_path

--- a/management/commands/support/file_downloader.py
+++ b/management/commands/support/file_downloader.py
@@ -14,7 +14,7 @@ class FileDownloader:
 
     def __init__(self, openhexa_client, download_path, stdout_writer=None):
         """Initialize the file downloader.
-        
+
         Args:
             openhexa_client: OpenHEXA client instance for API calls
             download_path: Path object for download directory
@@ -23,16 +23,16 @@ class FileDownloader:
         self.openhexa_client = openhexa_client
         self.download_path = Path(download_path)
         self.stdout_write = stdout_writer or print
-        
+
         # Ensure download directory exists
         self.download_path.mkdir(parents=True, exist_ok=True)
 
     def download_dataset_files(self, files):
         """Download all files in the dataset version.
-        
+
         Args:
             files: List of file information dictionaries
-            
+
         Returns:
             Number of successfully downloaded files
         """
@@ -41,7 +41,7 @@ class FileDownloader:
             return 0
 
         self.stdout_write(f"Downloading {len(files)} files to {self.download_path}...")
-        
+
         success_count = 0
         for file_info in files:
             try:
@@ -53,16 +53,16 @@ class FileDownloader:
 
             except Exception as e:
                 self.stdout_write(f"ERROR: Failed to download {file_info['filename']}: {str(e)}")
-        
+
         self.stdout_write(f"Downloaded {success_count}/{len(files)} files successfully")
         return success_count
 
     def _download_single_file(self, file_info):
         """Download a single file.
-        
+
         Args:
             file_info: File information dictionary
-            
+
         Returns:
             True if successful, False otherwise
         """
@@ -78,7 +78,7 @@ class FileDownloader:
 
     def _download_file_from_url(self, url, file_path, file_info):
         """Download a file from URL to local path.
-        
+
         Args:
             url: Download URL
             file_path: Local file path

--- a/management/commands/support/file_downloader.py
+++ b/management/commands/support/file_downloader.py
@@ -58,14 +58,6 @@ class FileDownloader:
         return success_count
 
     def _download_single_file(self, file_info):
-        """Download a single file.
-
-        Args:
-            file_info: File information dictionary
-
-        Returns:
-            True if successful, False otherwise
-        """
         # Get download URL for the file
         download_url = self.openhexa_client.get_file_download_url(file_info["id"])
         if not download_url:
@@ -77,20 +69,9 @@ class FileDownloader:
         return True
 
     def _download_file_from_url(self, url, file_path, file_info):
-        """Download a file from URL to local path.
-
-        Args:
-            url: Download URL
-            file_path: Local file path
-            file_info: File information for error reporting
-        """
         response = requests.get(url, stream=True)
         response.raise_for_status()
 
         with open(file_path, "wb") as f:
             for chunk in response.iter_content(chunk_size=8192):
                 f.write(chunk)
-
-    def get_download_path(self):
-        """Get the download directory path."""
-        return self.download_path

--- a/management/commands/support/metrics_importer.py
+++ b/management/commands/support/metrics_importer.py
@@ -49,11 +49,6 @@ class MetricsImporter:
             raise CommandError(f"Failed to import metrics: {str(e)}")
 
     def _find_csv_files(self):
-        """Find metadata and dataset CSV files in the download directory.
-
-        Returns:
-            Tuple of (metadata_file_path, dataset_file_path)
-        """
         # Find metadata file (*metadata.csv)
         metadata_files = list(self.download_path.glob("*metadata.csv"))
         if not metadata_files:
@@ -71,12 +66,6 @@ class MetricsImporter:
         return metadata_files[0], dataset_files[0]
 
     def _validate_csv_files(self, metadata_file, dataset_file):
-        """Validate that CSV files have the expected structure.
-
-        Args:
-            metadata_file: Path to metadata CSV file
-            dataset_file: Path to dataset CSV file
-        """
         # Validate metadata file
         required_metadata_columns = [
             "VARIABLE",
@@ -104,15 +93,6 @@ class MetricsImporter:
         self.stdout_write("CSV file validation passed")
 
     def _process_metrics_import(self, metadata_file, dataset_file):
-        """Process the actual metrics import.
-
-        Args:
-            metadata_file: Path to metadata CSV file
-            dataset_file: Path to dataset CSV file
-
-        Returns:
-            Number of metric values created
-        """
         # Validate CSV files first
         self._validate_csv_files(metadata_file, dataset_file)
 
@@ -133,14 +113,6 @@ class MetricsImporter:
         return value_count
 
     def _create_metric_types(self, metadata_file):
-        """Create MetricType objects from metadata CSV.
-
-        Args:
-            metadata_file: Path to metadata CSV file
-
-        Returns:
-            Dictionary mapping metric codes to MetricType objects
-        """
         metric_types = {}
 
         with open(metadata_file, newline="", encoding="utf-8") as metafile:
@@ -163,15 +135,6 @@ class MetricsImporter:
         return metric_types
 
     def _create_metric_values(self, dataset_file, metric_types):
-        """Create MetricValue objects from dataset CSV.
-
-        Args:
-            dataset_file: Path to dataset CSV file
-            metric_types: Dictionary of metric type code -> MetricType object
-
-        Returns:
-            Number of metric values created
-        """
         with open(dataset_file, newline="", encoding="utf-8") as csvfile:
             csvreader = csv.DictReader(csvfile)
 
@@ -219,7 +182,6 @@ class MetricsImporter:
                 raise
 
     def _configure_legends(self):
-        """Configure legend settings for all metric types."""
         # Import legend functionality
         from .legend import get_legend_config, get_legend_type
 
@@ -227,9 +189,3 @@ class MetricsImporter:
             metric_type.legend_config = get_legend_config(metric_type)
             metric_type.legend_type = get_legend_type(metric_type)
             metric_type.save()
-
-    def clear_existing_metrics(self):
-        """Clear existing metrics for the account."""
-        self.stdout_write("Clearing existing metrics...")
-        MetricValue.objects.filter(metric_type__account=self.account).delete()
-        MetricType.objects.filter(account=self.account).delete()

--- a/management/commands/support/metrics_importer.py
+++ b/management/commands/support/metrics_importer.py
@@ -1,0 +1,235 @@
+"""
+Metrics importer for processing CSV files and importing data into Django models.
+
+This module handles finding, validating, and importing metrics data from CSV files
+into MetricType and MetricValue models, including legend configuration.
+"""
+
+import csv
+from pathlib import Path
+
+from django.core.management.base import CommandError
+from django.db import transaction
+
+from iaso.models import MetricType, MetricValue, OrgUnit
+
+
+class MetricsImporter:
+    """Handles importing metrics data from CSV files."""
+
+    def __init__(self, account, download_path, stdout_writer=None):
+        """Initialize the metrics importer.
+
+        Args:
+            account: Account instance for importing metrics
+            download_path: Path object for download directory
+            stdout_writer: Optional writer for progress output (e.g., self.stdout.write)
+        """
+        self.account = account
+        self.download_path = Path(download_path)
+        self.stdout_write = stdout_writer or print
+
+    def import_metrics(self):
+        """Import metrics from downloaded CSV files.
+
+        Returns:
+            Number of metric values created
+        """
+        try:
+            # Find the CSV files
+            metadata_file, dataset_file = self._find_csv_files()
+
+            self.stdout_write(f"Using metadata file: {metadata_file.name}")
+            self.stdout_write(f"Using dataset file: {dataset_file.name}")
+
+            # Import the metrics
+            return self._process_metrics_import(metadata_file, dataset_file)
+
+        except Exception as e:
+            raise CommandError(f"Failed to import metrics: {str(e)}")
+
+    def _find_csv_files(self):
+        """Find metadata and dataset CSV files in the download directory.
+
+        Returns:
+            Tuple of (metadata_file_path, dataset_file_path)
+        """
+        # Find metadata file (*metadata.csv)
+        metadata_files = list(self.download_path.glob("*metadata.csv"))
+        if not metadata_files:
+            raise CommandError("No metadata CSV file (*metadata.csv) found in download directory")
+        if len(metadata_files) > 1:
+            raise CommandError(f"Multiple metadata CSV files found: {[f.name for f in metadata_files]}")
+
+        # Find dataset file (*dataset.csv)
+        dataset_files = list(self.download_path.glob("*dataset.csv"))
+        if not dataset_files:
+            raise CommandError("No dataset CSV file (*dataset.csv) found in download directory")
+        if len(dataset_files) > 1:
+            raise CommandError(f"Multiple dataset CSV files found: {[f.name for f in dataset_files]}")
+
+        return metadata_files[0], dataset_files[0]
+
+    def _validate_csv_files(self, metadata_file, dataset_file):
+        """Validate that CSV files have the expected structure.
+
+        Args:
+            metadata_file: Path to metadata CSV file
+            dataset_file: Path to dataset CSV file
+        """
+        # Validate metadata file
+        required_metadata_columns = [
+            "VARIABLE",
+            "LABEL",
+            "DESCRIPTION",
+            "SOURCE",
+            "UNITS",
+            "COMMENTS",
+            "CATEGORY",
+            "UNIT_SYMBOL",
+        ]
+
+        with open(metadata_file, newline="", encoding="utf-8") as metafile:
+            metareader = csv.DictReader(metafile)
+            missing_columns = set(required_metadata_columns) - set(metareader.fieldnames)
+            if missing_columns:
+                raise CommandError(f"Metadata file missing required columns: {', '.join(missing_columns)}")
+
+        # Validate dataset file has ADM2_ID column
+        with open(dataset_file, newline="", encoding="utf-8") as csvfile:
+            csvreader = csv.DictReader(csvfile)
+            if "ADM2_ID" not in csvreader.fieldnames:
+                raise CommandError("Dataset file missing required column: ADM2_ID")
+
+        self.stdout_write("CSV file validation passed")
+
+    def _process_metrics_import(self, metadata_file, dataset_file):
+        """Process the actual metrics import.
+
+        Args:
+            metadata_file: Path to metadata CSV file
+            dataset_file: Path to dataset CSV file
+
+        Returns:
+            Number of metric values created
+        """
+        # Validate CSV files first
+        self._validate_csv_files(metadata_file, dataset_file)
+
+        self.stdout_write("Clearing existing metrics...")
+        MetricValue.objects.filter(metric_type__account=self.account).delete()
+        MetricType.objects.filter(account=self.account).delete()
+
+        self.stdout_write("Creating MetricTypes from metadata file...")
+        metric_types = self._create_metric_types(metadata_file)
+
+        self.stdout_write("Reading values from dataset file...")
+        value_count = self._create_metric_values(dataset_file, metric_types)
+
+        self.stdout_write("Adding threshold scales...")
+        self._configure_legends()
+
+        self.stdout_write(f"Metrics import completed successfully!")
+        return value_count
+
+    def _create_metric_types(self, metadata_file):
+        """Create MetricType objects from metadata CSV.
+
+        Args:
+            metadata_file: Path to metadata CSV file
+
+        Returns:
+            Dictionary mapping metric codes to MetricType objects
+        """
+        metric_types = {}
+
+        with open(metadata_file, newline="", encoding="utf-8") as metafile:
+            metareader = csv.DictReader(metafile)
+            for row in metareader:
+                metric_type = MetricType.objects.create(
+                    account=self.account,
+                    name=row["LABEL"],
+                    code=row["VARIABLE"],
+                    description=row["DESCRIPTION"],
+                    source=row["SOURCE"],
+                    units=row["UNITS"],
+                    comments=row["COMMENTS"],
+                    category=row["CATEGORY"],
+                    unit_symbol=row["UNIT_SYMBOL"],
+                )
+                self.stdout_write(f"Created metric: {metric_type.name}")
+                metric_types[metric_type.code] = metric_type
+
+        return metric_types
+
+    def _create_metric_values(self, dataset_file, metric_types):
+        """Create MetricValue objects from dataset CSV.
+
+        Args:
+            dataset_file: Path to dataset CSV file
+            metric_types: Dictionary of metric type code -> MetricType object
+
+        Returns:
+            Number of metric values created
+        """
+        with open(dataset_file, newline="", encoding="utf-8") as csvfile:
+            csvreader = csv.DictReader(csvfile)
+
+            try:
+                with transaction.atomic():
+                    row_count = 0
+                    value_count = 0
+                    for row in csvreader:
+                        row_count += 1
+                        try:
+                            # Get the OrgUnit by source_ref using ADM2_ID
+                            org_unit = OrgUnit.objects.get(source_ref=row["ADM2_ID"])
+                        except OrgUnit.DoesNotExist:
+                            self.stdout_write(f"Row {row_count}: OrgUnit not found for source_ref: {row['ADM2_ID']}")
+                            continue
+
+                        # Create MetricValue for each metric type
+                        for column, metric_type in metric_types.items():
+                            if column not in row:
+                                continue
+                            if not row[column]:
+                                continue
+
+                            try:
+                                # Parse the value as a float and round to max 3 behind the comma
+                                value = round(float(row[column]), 3)
+
+                            except ValueError:
+                                self.stdout_write(f"Row {row_count}: Invalid value for {column}: {row[column]}")
+                                continue
+
+                            # Create the MetricValue
+                            MetricValue.objects.create(
+                                metric_type=metric_type,
+                                org_unit=org_unit,
+                                value=value,
+                            )
+                            value_count += 1
+
+                    self.stdout_write(f"Processed {row_count} rows, created {value_count} metric values")
+                    return value_count
+
+            except Exception as e:
+                self.stdout_write(f"ERROR: Error during import, rolling back transaction: {str(e)}")
+                raise
+
+    def _configure_legends(self):
+        """Configure legend settings for all metric types."""
+        # Import legend functionality
+        from .legend import get_legend_config, get_legend_type
+
+        for metric_type in MetricType.objects.filter(account=self.account):
+            metric_type.legend_config = get_legend_config(metric_type)
+            metric_type.legend_type = get_legend_type(metric_type)
+            metric_type.save()
+
+    def clear_existing_metrics(self):
+        """Clear existing metrics for the account."""
+        self.stdout_write("Clearing existing metrics...")
+        MetricValue.objects.filter(metric_type__account=self.account).delete()
+        MetricType.objects.filter(account=self.account).delete()

--- a/management/commands/support/openhexa_client.py
+++ b/management/commands/support/openhexa_client.py
@@ -13,7 +13,7 @@ class OpenHEXAClient:
 
     def __init__(self, server_url, token):
         """Initialize the OpenHEXA client.
-        
+
         Args:
             server_url: The OpenHEXA server URL
             token: API authentication token
@@ -23,10 +23,10 @@ class OpenHEXAClient:
 
     def list_workspace_datasets(self, workspace_slug):
         """List all datasets in a workspace.
-        
+
         Args:
             workspace_slug: The slug of the workspace
-            
+
         Returns:
             List of dataset items or empty list if none found/error
         """
@@ -60,11 +60,11 @@ class OpenHEXAClient:
 
     def get_dataset_link(self, workspace_slug, dataset_slug):
         """Fetch dataset link by slug from the workspace.
-        
+
         Args:
             workspace_slug: The workspace slug
             dataset_slug: The dataset slug
-            
+
         Returns:
             Dataset link information or None if not found
         """
@@ -95,10 +95,10 @@ class OpenHEXAClient:
 
     def get_latest_version(self, dataset_id):
         """Get the latest version of a dataset.
-        
+
         Args:
             dataset_id: The dataset ID
-            
+
         Returns:
             Latest version information or None if not found
         """
@@ -130,10 +130,10 @@ class OpenHEXAClient:
 
     def get_version_files(self, version_id):
         """Get all files for a dataset version.
-        
+
         Args:
             version_id: The dataset version ID
-            
+
         Returns:
             List of file information or empty list if error
         """
@@ -165,10 +165,10 @@ class OpenHEXAClient:
 
     def get_file_download_url(self, file_id):
         """Get download URL for a specific file.
-        
+
         Args:
             file_id: The file ID
-            
+
         Returns:
             Download URL string or None if error
         """

--- a/management/commands/support/openhexa_client.py
+++ b/management/commands/support/openhexa_client.py
@@ -1,0 +1,194 @@
+"""
+OpenHEXA API client for dataset operations.
+
+This module provides a clean interface for interacting with the OpenHEXA API,
+including workspace and dataset queries, file listings, and authentication.
+"""
+
+from openhexa.toolbox.hexa import OpenHEXA
+
+
+class OpenHEXAClient:
+    """Client for OpenHEXA API interactions."""
+
+    def __init__(self, server_url, token):
+        """Initialize the OpenHEXA client.
+        
+        Args:
+            server_url: The OpenHEXA server URL
+            token: API authentication token
+        """
+        self.hexa = OpenHEXA(server_url, token=token)
+        self.server_url = server_url
+
+    def list_workspace_datasets(self, workspace_slug):
+        """List all datasets in a workspace.
+        
+        Args:
+            workspace_slug: The slug of the workspace
+            
+        Returns:
+            List of dataset items or empty list if none found/error
+        """
+        try:
+            result = self.hexa.query(
+                """
+                query getWorkspaceDatasets($slug: String!, $page: Int, $perPage: Int) {
+                    workspace(slug: $slug) {
+                        datasets(page: $page, perPage: $perPage) {
+                            items {
+                                id
+                                dataset {
+                                    id
+                                    slug
+                                    name
+                                    description
+                                }
+                            }
+                        }
+                    }
+                }
+                """,
+                {"slug": workspace_slug, "page": 1, "perPage": 100},
+            )
+            workspace = result.get("workspace")
+            if workspace and workspace.get("datasets"):
+                return workspace["datasets"]["items"]
+            return []
+        except Exception:
+            return []
+
+    def get_dataset_link(self, workspace_slug, dataset_slug):
+        """Fetch dataset link by slug from the workspace.
+        
+        Args:
+            workspace_slug: The workspace slug
+            dataset_slug: The dataset slug
+            
+        Returns:
+            Dataset link information or None if not found
+        """
+        try:
+            result = self.hexa.query(
+                """
+                query getDatasetLinkBySlug($workspaceSlug: String!, $datasetSlug: String!) {
+                    datasetLinkBySlug(workspaceSlug: $workspaceSlug, datasetSlug: $datasetSlug) {
+                        id
+                        dataset {
+                            id
+                            slug
+                            name
+                            description
+                            createdAt
+                            updatedAt
+                        }
+                    }
+                }
+                """,
+                {"workspaceSlug": workspace_slug, "datasetSlug": dataset_slug},
+            )
+            return result.get("datasetLinkBySlug")
+        except Exception as e:
+            if "not found" in str(e).lower():
+                return None
+            raise
+
+    def get_latest_version(self, dataset_id):
+        """Get the latest version of a dataset.
+        
+        Args:
+            dataset_id: The dataset ID
+            
+        Returns:
+            Latest version information or None if not found
+        """
+        try:
+            result = self.hexa.query(
+                """
+                query getDatasetLatestVersion($id: ID!) {
+                    dataset(id: $id) {
+                        latestVersion {
+                            id
+                            name
+                            changelog
+                            createdAt
+                            createdBy {
+                                displayName
+                            }
+                        }
+                    }
+                }
+                """,
+                {"id": dataset_id},
+            )
+            dataset = result.get("dataset")
+            return dataset.get("latestVersion") if dataset else None
+        except Exception as e:
+            if "not found" in str(e).lower():
+                return None
+            raise
+
+    def get_version_files(self, version_id):
+        """Get all files for a dataset version.
+        
+        Args:
+            version_id: The dataset version ID
+            
+        Returns:
+            List of file information or empty list if error
+        """
+        try:
+            result = self.hexa.query(
+                """
+                query getDatasetVersionFiles($id: ID!, $page: Int, $perPage: Int) {
+                    datasetVersion(id: $id) {
+                        files(page: $page, perPage: $perPage) {
+                            items {
+                                id
+                                filename
+                                contentType
+                                size
+                                createdAt
+                                downloadUrl
+                            }
+                            totalItems
+                        }
+                    }
+                }
+                """,
+                {"id": version_id, "page": 1, "perPage": 100},
+            )
+            version = result.get("datasetVersion")
+            return version["files"]["items"] if version else []
+        except Exception:
+            return []
+
+    def get_file_download_url(self, file_id):
+        """Get download URL for a specific file.
+        
+        Args:
+            file_id: The file ID
+            
+        Returns:
+            Download URL string or None if error
+        """
+        try:
+            result = self.hexa.query(
+                """
+                mutation prepareFileDownload($input: PrepareVersionFileDownloadInput!) {
+                    prepareVersionFileDownload(input: $input) {
+                        success
+                        downloadUrl
+                        errors
+                    }
+                }
+                """,
+                {"input": {"fileId": file_id}},
+            )
+
+            response = result.get("prepareVersionFileDownload")
+            if response and response.get("success"):
+                return response.get("downloadUrl")
+            return None
+        except Exception:
+            return None


### PR DESCRIPTION
Script to fetch a specific dataset from an OpenHEXA workspace and import it into the `MetricType` and `MetricValue` tables:

```shell
./manage.py import_openhexa_metrics --workspace_slug <slug> --dataset_slug <slug> --account-id <id>

# Example for RDC data:
./manage.py import_openhexa_metrics --workspace_slug snt-development --dataset_slug snt-results --account-id 2
```

To test make sure you set the env variables:
```.env
OPENHEXA_URL="https://api.openhexa.org/graphql/"
OPENHEXA_TOKEN = "XXX"
```
You can get the OpenHEXA token by going to the pipelines page, create a new one and choose "From OpenHEXA CLI" -> "Show" access token
![image](https://github.com/user-attachments/assets/0b960325-ef52-4e97-acf3-89cd24dc9cde)


Result for RDC:
![image](https://github.com/user-attachments/assets/f9522164-fdc3-4526-9b33-ee85de79aece)
Note that legends need to be improved, that can be done in ticket https://bluesquare.atlassian.net/browse/SNT-57

For now we can run this command manually, later we can add this to a cron job to run once a day for example.
