### PR TITLE
Snt 57 update colors for covariants and layouts on map

### DIFF
--- a/js/src/constants/map-theme.tsx
+++ b/js/src/constants/map-theme.tsx
@@ -1,0 +1,11 @@
+import theme from './theme';
+
+export const mapTheme = {
+    backgroundColor: '#CFD8DC',
+    shapeColor: '#263238',
+    shapeWeight: 1,
+    selectedShapeColor: '#263238',
+    selectedShapeWeight: 3,
+    activeShapeColor: theme.palette.secondary.main,
+    activeShapeWeight: 4,
+};

--- a/js/src/domains/planning/components/map.tsx
+++ b/js/src/domains/planning/components/map.tsx
@@ -1,6 +1,5 @@
 import React, { FC, useCallback, useMemo, useState } from 'react';
-import { Box, useTheme, Theme } from '@mui/material';
-import * as d3 from 'd3-scale';
+import { Box, Theme } from '@mui/material';
 
 import L from 'leaflet';
 import {
@@ -10,13 +9,14 @@ import {
     Tooltip,
     ZoomControl,
 } from 'react-leaflet';
-import { useGetLegend } from 'Iaso/components/LegendBuilder/Legend';
 import { Tile } from 'Iaso/components/maps/tools/TilesSwitchControl';
 import { GeoJson } from 'Iaso/components/maps/types';
 import tiles from 'Iaso/constants/mapTiles';
 import { OrgUnit } from 'Iaso/domains/orgUnits/types/orgUnit';
 import { SxStyles } from 'Iaso/types/general';
 import { Bounds } from 'Iaso/utils/map/mapUtils';
+import { mapTheme } from '../../../constants/map-theme';
+import { getStyleForShape } from '../libs/map-utils';
 import { MetricType, MetricValue } from '../types/metrics';
 import { MapLegend } from './MapLegend';
 import { MapOrgUnitDetails } from './MapOrgUnitDetails';
@@ -61,7 +61,6 @@ export const Map: FC<Props> = ({
     onClearSelection,
 }) => {
     const [currentTile] = useState<Tile>(tiles.osm);
-    const theme = useTheme();
     const boundsOptions: Record<string, any> = {
         padding: [10, 10],
         maxZoom: currentTile.maxZoom,
@@ -77,21 +76,6 @@ export const Map: FC<Props> = ({
     }, [orgUnits]);
 
     // Displaying metrics on the map
-    const getLegend = useGetLegend(displayedMetric?.legend_config);
-    const getColorForShape = useCallback(
-        (value, _orgUnitId) => {
-            if (displayedMetric?.legend_type === 'linear') {
-                const legend = displayedMetric.legend_config;
-                const colorScale = d3
-                    .scaleLinear()
-                    .domain(legend.domain)
-                    .range(legend.range);
-                return colorScale(value);
-            }
-            return getLegend(value);
-        },
-        [displayedMetric, getLegend],
-    );
     const getSelectedMetricValue = useCallback(
         (orgUnitId: number) => {
             const metricValue = displayedMetricValues?.find(
@@ -121,31 +105,24 @@ export const Map: FC<Props> = ({
         [selectedOrgUnits],
     );
 
-    const getStyleForShape = (orgUnitId: number) => {
-        let color: string;
-        let weight: number;
-
-        if (orgUnitId === clickedOrgUnit?.id) {
-            color = theme.palette.secondary.main;
-            weight = 4;
-        } else if (selectedOrgUnitIds.includes(orgUnitId)) {
-            color = '#000000';
-            weight = 3;
-        } else {
-            color = '#546E7A';
-            weight = 1;
-        }
-
-        return {
-            color,
-            weight,
-            fillColor: getColorForShape(
-                getSelectedMetricValue(orgUnitId),
-                orgUnitId,
-            ),
-            fillOpacity: 1,
-        };
-    };
+    const getMapStyleForOrgUnit = useCallback(
+        (orgUnitId: number) => {
+            const selectedMetricValue = getSelectedMetricValue(orgUnitId);
+            return getStyleForShape(
+                selectedMetricValue,
+                displayedMetric?.legend_type,
+                displayedMetric?.legend_config,
+                orgUnitId === clickedOrgUnit?.id,
+                selectedOrgUnitIds.includes(orgUnitId),
+            );
+        },
+        [
+            getSelectedMetricValue,
+            displayedMetric,
+            clickedOrgUnit,
+            selectedOrgUnitIds,
+        ],
+    );
 
     return (
         <Box height="100%" sx={styles.mainBox}>
@@ -162,7 +139,10 @@ export const Map: FC<Props> = ({
                         doubleClickZoom
                         scrollWheelZoom={false}
                         maxZoom={currentTile.maxZoom}
-                        style={{ height: '100%', backgroundColor: '#B0BEC5' }}
+                        style={{
+                            height: '100%',
+                            backgroundColor: mapTheme.backgroundColor,
+                        }}
                         center={[0, 0]}
                         keyboard={false}
                         bounds={bounds}
@@ -174,7 +154,7 @@ export const Map: FC<Props> = ({
                         {orgUnits.map(orgUnit => (
                             <GeoJSON
                                 key={orgUnit.id}
-                                style={getStyleForShape(orgUnit.id)}
+                                style={getMapStyleForOrgUnit(orgUnit.id)}
                                 data={orgUnit.geo_json as unknown as GeoJson}
                                 eventHandlers={{
                                     click: () => onOrgUnitClick(orgUnit.id),

--- a/js/src/domains/planning/libs/map-utils.tsx
+++ b/js/src/domains/planning/libs/map-utils.tsx
@@ -1,0 +1,56 @@
+import { scaleThreshold } from '@visx/scale';
+import * as d3 from 'd3-scale';
+import { mapTheme } from '../../../constants/map-theme';
+import { ScaleDomainRange } from '../types/metrics';
+
+const getLegend = (legend_config: ScaleDomainRange, value) => {
+    return scaleThreshold(legend_config)(value);
+};
+
+const getColorForShape = (
+    value: number,
+    legend_type: string,
+    legend_config: ScaleDomainRange,
+) => {
+    if (legend_type === 'linear') {
+        const legend = legend_config;
+        const colorScale = d3
+            .scaleLinear()
+            .domain(legend.domain)
+            .range(legend.range);
+        return colorScale(value);
+    }
+
+    return getLegend(legend_config, value);
+};
+
+export const getStyleForShape = (
+    value: number | undefined,
+    legend_type: string | undefined,
+    legend_config: ScaleDomainRange | undefined,
+    isActive = false,
+    isSelected = false,
+) => {
+    let color: string;
+    let weight: number;
+
+    if (isActive) {
+        color = mapTheme.activeShapeColor;
+        weight = mapTheme.activeShapeWeight;
+    } else if (isSelected) {
+        color = mapTheme.selectedShapeColor;
+        weight = mapTheme.selectedShapeWeight;
+    } else {
+        color = mapTheme.shapeColor;
+        weight = mapTheme.shapeWeight;
+    }
+
+    return {
+        color,
+        weight,
+        fillColor:
+            legend_config &&
+            getColorForShape(value ?? 0, legend_type ?? '', legend_config),
+        fillOpacity: 1,
+    };
+};

--- a/management/commands/support/legend.py
+++ b/management/commands/support/legend.py
@@ -53,8 +53,7 @@ def get_legend_config(metric_type):
     max_value = result["max_value"]
 
     if metric_type.category == "Mortality":
-        steps = get_steps(0, max_value, len(SEVEN_SHADES))
-        return {"domain": steps, "range": SEVEN_SHADES}
+        return {"domain": [0, max_value], "range": [NINE_SHADES[0], NINE_SHADES[-1]]}
     if metric_type.category == "Composite risk":
         return {
             "domain": list(range(int(min_value), int(max_value))),

--- a/management/commands/support/legend.py
+++ b/management/commands/support/legend.py
@@ -84,9 +84,6 @@ def get_steps(min, max, count):
     round_digits = 2 if min < 1 else 0
     if count == 1:
         return [round(min, round_digits)]
-    print(f"{min}, {max}, {count}")
     step_size = (max - min) / (count - 1)
-    print(step_size)
     steps = [round(min + i * step_size, round_digits) for i in range(count)]
-    print(len(steps))
     return steps

--- a/management/commands/support/legend.py
+++ b/management/commands/support/legend.py
@@ -1,25 +1,25 @@
 from django.db.models import Max, Min
 
 
-NINE_SHADES_OF_RED = [
-    "#FFCCBC",
-    "#FFAB91",
-    "#FF8A65",
-    "#FF7043",
-    "#FF5722",
-    "#DB3C0B",
-    "#B83B14",
-    "#8B2B0E",
-    "#601B06",
+NINE_SHADES = [
+    "#EDE7F6",
+    "#D1C4E9",
+    "#B39DDB",
+    "#9575CD",
+    "#7E57C2",
+    "#673AB7",
+    "#5E35B1",
+    "#512DA8",
+    "#4527A0",
 ]
-SEVEN_SHADES_OF_RED = [
-    "#FFCCBC",
-    "#FFAB91",
-    "#FF8A65",
-    "#FF5722",
-    "#DB3C0B",
-    "#8B2B0E",
-    "#601B06",
+SEVEN_SHADES = [
+    "#EDE7F6",
+    "#D1C4E9",
+    "#B39DDB",
+    "#7E57C2",
+    "#673AB7",
+    "#512DA8",
+    "#4527A0",
 ]
 RISK_LOW = "#A5D6A7"
 RISK_MEDIUM = "#FFECB3"
@@ -31,17 +31,17 @@ def get_legend_config(metric_type):
     if metric_type.category == "Incidence":
         return {
             "domain": [5, 50, 100, 200, 300, 500],
-            "range": SEVEN_SHADES_OF_RED,
+            "range": SEVEN_SHADES,
         }
     if metric_type.category == "Prevalence":
         return {
             "domain": [10, 20, 30, 40, 50, 60, 70, 80],
-            "range": NINE_SHADES_OF_RED,
+            "range": NINE_SHADES,
         }
     if metric_type.category in ["Bednet coverage", "DHS DTP3 Vaccine"]:
         return {
             "domain": [40, 50, 60, 70, 80, 90],
-            "range": list(reversed(SEVEN_SHADES_OF_RED)),
+            "range": list(reversed(SEVEN_SHADES)),
         }
     values_qs = metric_type.metricvalue_set.all()
 
@@ -53,7 +53,8 @@ def get_legend_config(metric_type):
     max_value = result["max_value"]
 
     if metric_type.category == "Mortality":
-        return {"domain": [0, max_value], "range": ["#FFCCBC", "#601B06"]}
+        steps = get_steps(0, max_value, len(SEVEN_SHADES))
+        return {"domain": steps, "range": SEVEN_SHADES}
     if metric_type.category == "Composite risk":
         return {
             "domain": list(range(int(min_value), int(max_value))),
@@ -65,7 +66,8 @@ def get_legend_config(metric_type):
             "domain": list(choices),
             "range": [RISK_LOW, RISK_MEDIUM, RISK_HIGH, RISK_VERY_HIGH],
         }
-    return {"domain": [min_value, max_value], "range": ["#FFCCBC", "#601B06"]}
+
+    return {"domain": get_steps(min_value, max_value, len(SEVEN_SHADES)), "range": SEVEN_SHADES}
 
 
 def get_legend_type(metric_type):
@@ -74,3 +76,17 @@ def get_legend_type(metric_type):
     if metric_type.category in ["Composite risk", "Seasonality"]:
         return "ordinal"
     return "threshold"
+
+
+def get_steps(min, max, count):
+    if not min or not max:
+        return []
+    round_digits = 2 if min < 1 else 0
+    if count == 1:
+        return [round(min, round_digits)]
+    print(f"{min}, {max}, {count}")
+    step_size = (max - min) / (count - 1)
+    print(step_size)
+    steps = [round(min + i * step_size, round_digits) for i in range(count)]
+    print(len(steps))
+    return steps

--- a/management/commands/support/metrics_importer.py
+++ b/management/commands/support/metrics_importer.py
@@ -6,6 +6,7 @@ into MetricType and MetricValue models, including legend configuration.
 """
 
 import csv
+
 from pathlib import Path
 
 from django.core.management.base import CommandError
@@ -109,7 +110,7 @@ class MetricsImporter:
         self.stdout_write("Adding threshold scales...")
         self._configure_legends()
 
-        self.stdout_write(f"Metrics import completed successfully!")
+        self.stdout_write("Metrics import completed successfully!")
         return value_count
 
     def _create_metric_types(self, metadata_file):


### PR DESCRIPTION
Updating colors based on this : 
https://bluesquare.atlassian.net/browse/SNT-57

For ranges, calculate 7 steps for the legend to have something a bit smoother than only two.

This is how it looks on RDC:
https://files.slack.com/files-pri/T02T1R13H-F0938PL8KFW/image.png