### PR TITLE
Snt 58 district detail popup

### DIFF
--- a/js/src/domains/planning/components/MapOrgUnitDetails.tsx
+++ b/js/src/domains/planning/components/MapOrgUnitDetails.tsx
@@ -74,7 +74,6 @@ const styles: SxStyles = {
     }),
     closeIconButton: (theme: Theme) => ({
         color: theme.palette.text.primary,
-        // paddingLeft: 0,
         paddingRight: 0,
     }),
     closeIcon: {

--- a/js/src/domains/planning/components/MapOrgUnitDetails.tsx
+++ b/js/src/domains/planning/components/MapOrgUnitDetails.tsx
@@ -1,6 +1,4 @@
 import React, { FC, useMemo } from 'react';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import ArrowForward from '@mui/icons-material/ArrowForward';
 import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
 import {
     Box,
@@ -11,6 +9,8 @@ import {
     IconButton,
     Tooltip,
     Typography,
+    Theme,
+    styled,
 } from '@mui/material';
 
 import { useSafeIntl } from 'bluesquare-components';
@@ -22,58 +22,64 @@ import {
     useGetMetricValues,
 } from '../hooks/useGetMetrics';
 import { MESSAGES } from '../messages';
-import { MetricType, MetricTypeCategory } from '../types/metrics';
+import { MetricType, MetricTypeCategory, MetricValue } from '../types/metrics';
 
 type Props = {
     clickedOrgUnit: OrgUnit;
     onClear: () => void;
     onAddRemoveOrgUnitToMix: (selectedOrgUnit: any) => void;
     selectedOrgUnits: OrgUnit[];
+    highlightMetricType: MetricType | null;
 };
 
+const ListItemStyled = styled(ListItem)`
+    &:nth-of-type(odd) {
+        background-color: #eceff1;
+    }
+`;
+
 const styles: SxStyles = {
-    mainBox: {
+    mainBox: (theme: Theme) => ({
         position: 'absolute',
-        top: 10,
-        right: 10,
-        backgroundColor: '#333D43',
-        color: 'white',
+        top: 72,
+        left: 8,
+        backgroundColor: 'white',
+        color: theme.palette.text.primary,
         padding: '10px',
         borderRadius: '16px',
         boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
         zIndex: 1000,
-        minWidth: '280px',
-    },
+        maxWidth: '356px',
+        maxHeight: 'calc(100% - 90px)',
+        overflow: 'auto',
+    }),
     buttonsBox: {
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
         width: '100%',
     },
-    title: {
-        marginTop: '8px',
-        fontSize: '1rem',
-        textTransform: 'none',
-    },
-    listItem: {
-        display: 'flex',
-        justifyContent: 'space-between',
-        width: '100%',
-        gap: '2rem',
-        padding: 0,
-    },
-    metricValue: {
-        color: 'white',
-    },
     button: {
-        color: 'white',
-        fontSize: '0.875rem',
-        fontWeight: 'bold',
+        fontSize: '0.8125rem',
+        fontWeight: 'medium',
         textTransform: 'none',
+        minWidth: 80,
     },
+    title: (theme: Theme) => ({
+        marginRight: theme.spacing(1),
+        flexGrow: 1,
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+    }),
+    closeIconButton: (theme: Theme) => ({
+        color: theme.palette.text.primary,
+        // paddingLeft: 0,
+        paddingRight: 0,
+    }),
     closeIcon: {
-        color: 'white',
-        paddingLeft: 0,
+        height: '.8em',
+        width: '.8em',
     },
 };
 
@@ -82,6 +88,7 @@ export const MapOrgUnitDetails: FC<Props> = ({
     onClear,
     onAddRemoveOrgUnitToMix,
     selectedOrgUnits,
+    highlightMetricType,
 }) => {
     const { data: metricCategories } = useGetMetricCategories();
     const flatMetricTypes = useMemo(() => {
@@ -107,23 +114,22 @@ export const MapOrgUnitDetails: FC<Props> = ({
 
     const { formatMessage } = useSafeIntl();
 
+    const getMetricFontWeight = (orgUnitMetric: MetricValue) =>
+        highlightMetricType &&
+        orgUnitMetric.metric_type === highlightMetricType.id
+            ? 'bold'
+            : 'normal';
+
     return (
         <Box sx={styles.mainBox}>
             <Box sx={styles.buttonsBox}>
-                <IconButton
-                    aria-label="close"
-                    onClick={onClear}
-                    sx={styles.closeIcon}
-                >
-                    <CloseOutlinedIcon />
-                </IconButton>
+                <Typography variant="body1" sx={styles.title}>
+                    {clickedOrgUnit.name}
+                </Typography>
                 <Button
-                    variant="contained"
+                    variant="text"
                     color="primary"
                     size="small"
-                    endIcon={
-                        isOrgUnitSelected ? <ArrowBackIcon /> : <ArrowForward />
-                    }
                     onClick={() => onAddRemoveOrgUnitToMix(clickedOrgUnit)}
                     sx={styles.button}
                 >
@@ -131,12 +137,17 @@ export const MapOrgUnitDetails: FC<Props> = ({
                         ? formatMessage(MESSAGES.removeOrgUnitFromMix)
                         : formatMessage(MESSAGES.addOrgUnitFromMix)}
                 </Button>
+                <IconButton
+                    className="Mui-focusVisible"
+                    size="small"
+                    disableRipple={true}
+                    aria-label="close"
+                    onClick={onClear}
+                    sx={styles.closeIconButton}
+                >
+                    <CloseOutlinedIcon sx={styles.closeIcon} />
+                </IconButton>
             </Box>
-
-            <Typography variant="h6" sx={styles.title}>
-                {clickedOrgUnit.name}
-            </Typography>
-
             {isLoading && <CircularProgress size={24} />}
             <List>
                 {!isLoading &&
@@ -154,22 +165,32 @@ export const MapOrgUnitDetails: FC<Props> = ({
                                 }
                                 arrow
                             >
-                                <ListItem
+                                <ListItemStyled
                                     key={metricValue.id}
-                                    sx={styles.listItem}
+                                    sx={(theme: Theme) => ({
+                                        display: 'flex',
+                                        justifyContent: 'space-between',
+                                        width: '100%',
+                                        gap: '2rem',
+                                        padding: theme.spacing(1),
+                                        borderRadius: 1,
+                                        ' > *': {
+                                            fontWeight:
+                                                getMetricFontWeight(
+                                                    metricValue,
+                                                ),
+                                        },
+                                    })}
                                 >
                                     <Typography variant="caption">
                                         {metricDetails.name || 'Unknown Metric'}
                                     </Typography>
-                                    <Typography
-                                        variant="caption"
-                                        sx={styles.metricValue}
-                                    >
+                                    <Typography variant="caption">
                                         {Intl.NumberFormat().format(
                                             metricValue.value,
                                         )}
                                     </Typography>
-                                </ListItem>
+                                </ListItemStyled>
                             </Tooltip>
                         );
                     })}

--- a/js/src/domains/planning/components/MapSelectionWidget.tsx
+++ b/js/src/domains/planning/components/MapSelectionWidget.tsx
@@ -1,13 +1,13 @@
 import React, { FC, useState } from 'react';
-import { Box, Button, Theme, Typography } from '@mui/material';
 import CancelOutlined from '@mui/icons-material/CancelOutlined';
 import TuneOutlined from '@mui/icons-material/TuneOutlined';
+import { Box, Button, Theme, Typography } from '@mui/material';
 import { IconButton, useSafeIntl } from 'bluesquare-components';
 
 import { SxStyles } from 'Iaso/types/general';
 import { MESSAGES } from '../messages';
-import { FilterQueryBuilder } from './maps/FilterQueryBuilder';
 import { MetricsFilters } from '../types/metrics';
+import { FilterQueryBuilder } from './maps/FilterQueryBuilder';
 
 const styles: SxStyles = {
     mainBox: (theme: Theme) => ({

--- a/js/src/domains/planning/components/interventionMix/InterventionsMix.tsx
+++ b/js/src/domains/planning/components/interventionMix/InterventionsMix.tsx
@@ -22,6 +22,7 @@ import { SelectedDistricts } from './SelectedDistricts';
 type Props = {
     scenarioId: number | undefined;
     selectedOrgUnits: OrgUnit[];
+    setSelectedOrgUnits: any;
     setSelectedInterventions: any;
     selectedInterventions: any;
     mixName: string;
@@ -133,6 +134,7 @@ const InterventionList = ({ interventions }) => (
 export const InterventionsMix: FC<Props> = ({
     scenarioId,
     selectedOrgUnits,
+    setSelectedOrgUnits,
     setSelectedInterventions,
     selectedInterventions,
     mixName,
@@ -148,15 +150,18 @@ export const InterventionsMix: FC<Props> = ({
         setSelectedDistricts(selectedOrgUnits);
     }, [selectedOrgUnits]);
 
-    const removeDistrict = useCallback(id => {
-        setSelectedDistricts(prev =>
-            prev.filter(district => district.id !== id),
-        );
-    }, []);
+    const removeDistrict = useCallback(
+        id => {
+            setSelectedOrgUnits(prev =>
+                prev.filter(district => district.id !== id),
+            );
+        },
+        [setSelectedOrgUnits],
+    );
 
     const clearAllSelectedDistricts = useCallback(
-        () => setSelectedDistricts([]),
-        [],
+        () => setSelectedOrgUnits([]),
+        [setSelectedOrgUnits],
     );
 
     const { data: interventionMixes } = useGetInterventionMixes(scenarioId);

--- a/js/src/domains/planning/components/map.tsx
+++ b/js/src/domains/planning/components/map.tsx
@@ -41,7 +41,8 @@ type Props = {
     orgUnits?: OrgUnit[];
     displayedMetric: MetricType | null;
     displayedMetricValues?: MetricValue[];
-    selectedOrgUnits: OrgUnit[];
+    orgUnitsOnMap: OrgUnit[];
+    orgUnitsOnMix: OrgUnit[];
     onAddRemoveOrgUnitToMix: (orgUnit: any) => void;
     onApplyFilters: () => void;
     onAddToMix: () => void;
@@ -53,7 +54,8 @@ export const Map: FC<Props> = ({
     orgUnits,
     displayedMetric,
     displayedMetricValues,
-    selectedOrgUnits,
+    orgUnitsOnMap,
+    orgUnitsOnMix,
     onAddRemoveOrgUnitToMix,
     onApplyFilters,
     onAddToMix,
@@ -100,9 +102,9 @@ export const Map: FC<Props> = ({
         onAddRemoveOrgUnitToMix(orgUnit);
     };
 
-    const selectedOrgUnitIds = useMemo(
-        () => selectedOrgUnits.map(ou => ou.id),
-        [selectedOrgUnits],
+    const orgUnitIdsOnMap = useMemo(
+        () => orgUnitsOnMap.map(ou => ou.id),
+        [orgUnitsOnMap],
     );
 
     const getMapStyleForOrgUnit = useCallback(
@@ -113,21 +115,21 @@ export const Map: FC<Props> = ({
                 displayedMetric?.legend_type,
                 displayedMetric?.legend_config,
                 orgUnitId === clickedOrgUnit?.id,
-                selectedOrgUnitIds.includes(orgUnitId),
+                orgUnitIdsOnMap.includes(orgUnitId),
             );
         },
         [
             getSelectedMetricValue,
             displayedMetric,
             clickedOrgUnit,
-            selectedOrgUnitIds,
+            orgUnitIdsOnMap,
         ],
     );
 
     return (
         <Box height="100%" sx={styles.mainBox}>
             <MapSelectionWidget
-                selectionCount={selectedOrgUnits.length}
+                selectionCount={orgUnitIdsOnMap.length}
                 onApplyFilters={onApplyFilters}
                 onAddToMix={onAddToMix}
                 onClearSelection={onClearSelection}
@@ -176,7 +178,7 @@ export const Map: FC<Props> = ({
                                 onUnclickAndAddRemoveOrgUnitToMix
                             }
                             onClear={onClearOrgUnitSelection}
-                            selectedOrgUnits={selectedOrgUnits}
+                            selectedOrgUnits={orgUnitsOnMix}
                             highlightMetricType={displayedMetric}
                         />
                     )}

--- a/js/src/domains/planning/components/map.tsx
+++ b/js/src/domains/planning/components/map.tsx
@@ -177,6 +177,7 @@ export const Map: FC<Props> = ({
                             }
                             onClear={onClearOrgUnitSelection}
                             selectedOrgUnits={selectedOrgUnits}
+                            highlightMetricType={displayedMetric}
                         />
                     )}
                     <Box sx={styles.layerSelectBox}>

--- a/js/src/domains/planning/index.tsx
+++ b/js/src/domains/planning/index.tsx
@@ -161,7 +161,8 @@ export const Planning: FC = () => {
                                     displayedMetricValues={
                                         displayedMetricValues
                                     }
-                                    selectedOrgUnits={selectionOnMap}
+                                    orgUnitsOnMap={selectionOnMap}
+                                    orgUnitsOnMix={selectionOnInterventionMix}
                                     onApplyFilters={handleApplyFilters}
                                     onClearSelection={handleClearSelectionOnMap}
                                     onChangeMetricLayer={

--- a/js/src/domains/planning/index.tsx
+++ b/js/src/domains/planning/index.tsx
@@ -194,6 +194,9 @@ export const Planning: FC = () => {
                             <InterventionsMix
                                 scenarioId={scenario?.id}
                                 selectedOrgUnits={selectionOnInterventionMix}
+                                setSelectedOrgUnits={
+                                    setSelectionOnInterventionMix
+                                }
                                 setSelectedInterventions={
                                     setSelectedInterventions
                                 }


### PR DESCRIPTION
Story: https://bluesquare.atlassian.net/browse/SNT-58

- Layout for org unit details on map.
- Selection from filter is not linked to selection on the mix.
- When one item is selected from map, property display add to / remove from mix.
- When removing from mix directly, update map state.
- Selected items on map are now related to filter and not selection on mix.


https://github.com/user-attachments/assets/3ab55bb8-84b0-46cf-a4a6-edbd4728416d

