### PR TITLE
SNT-71: Add scale and legend type when importing metrics

### DIFF
--- a/management/commands/support/legend.py
+++ b/management/commands/support/legend.py
@@ -55,13 +55,13 @@ RISK_HIGH = "#FECDD2"
 RISK_VERY_HIGH = "#FFAB91"
 
 
-def get_legend_config(metric_type):
+def get_legend_config(metric_type, json_scale):
     # Temporary: use old way as fallback if legend_type was not defined
     if metric_type.legend_type is None or metric_type.legend_type == "":
         return __get_legend_config(metric_type)
 
     if metric_type.legend_type == "threshold":
-        scales = get_scales_from_json_str(metric_type.scale)
+        scales = get_scales_from_json_str(json_scale)
         return {"domain": scales, "range": get_range_from_count(len(scales))}
     if metric_type.legend_type == "ordinal":
         return {"domain": [0, 1], "range": [RISK_LOW, RISK_VERY_HIGH]}

--- a/management/commands/support/legend.py
+++ b/management/commands/support/legend.py
@@ -27,7 +27,7 @@ SEVEN_SHADES = [
     "#512DA8",
     "#4527A0",
 ]
-HEIGHT_SHADES = [
+EIGHT_SHADES = [
     "#EDE7F6",
     "#B39DDB",
     "#9575CD",
@@ -154,7 +154,7 @@ def get_range_from_count(count):
     if count == 7:
         return list(SEVEN_SHADES)
     if count == 8:
-        return list(HEIGHT_SHADES)
+        return list(EIGHT_SHADES)
     if count == 9:
         return list(NINE_SHADES)
     return list(SEVEN_SHADES)

--- a/management/commands/support/legend.py
+++ b/management/commands/support/legend.py
@@ -1,14 +1,20 @@
+import json
+
 from django.db.models import Max, Min
 
 
-NINE_SHADES = [
-    "#EDE7F6",
+FIVE_SHADES = {
     "#D1C4E9",
     "#B39DDB",
-    "#9575CD",
     "#7E57C2",
     "#673AB7",
-    "#5E35B1",
+    "#4527A0",
+}
+SIX_SHADES = [
+    "#EDE7F6",
+    "#B39DDB",
+    "#7E57C2",
+    "#673AB7",
     "#512DA8",
     "#4527A0",
 ]
@@ -21,6 +27,28 @@ SEVEN_SHADES = [
     "#512DA8",
     "#4527A0",
 ]
+HEIGHT_SHADES = [
+    "#EDE7F6",
+    "#B39DDB",
+    "#9575CD",
+    "#7E57C2",
+    "#673AB7",
+    "#5E35B1",
+    "#512DA8",
+    "#4527A0",
+]
+NINE_SHADES = [
+    "#EDE7F6",
+    "#D1C4E9",
+    "#B39DDB",
+    "#9575CD",
+    "#7E57C2",
+    "#673AB7",
+    "#5E35B1",
+    "#512DA8",
+    "#4527A0",
+]
+
 RISK_LOW = "#A5D6A7"
 RISK_MEDIUM = "#FFECB3"
 RISK_HIGH = "#FECDD2"
@@ -28,6 +56,23 @@ RISK_VERY_HIGH = "#FFAB91"
 
 
 def get_legend_config(metric_type):
+    # Temporary: use old way as fallback if legend_type was not defined
+    if metric_type.legend_type is None or metric_type.legend_type == "":
+        return __get_legend_config(metric_type)
+
+    if metric_type.legend_type == "threshold":
+        scales = get_scales_from_json_str(metric_type.scale)
+        return {"domain": scales, "range": get_range_from_count(len(scales))}
+    if metric_type.legend_type == "ordinal":
+        return {"domain": [0, 1], "range": [RISK_LOW, RISK_VERY_HIGH]}
+    if metric_type.legend_type == "linear":
+        max_value = get_max_range_value(metric_type)
+        return {"domain": [0, max_value], "range": [NINE_SHADES[0], NINE_SHADES[-1]]}
+
+    return __get_legend_config(metric_type)
+
+
+def __get_legend_config(metric_type):
     if metric_type.category == "Incidence":
         return {
             "domain": [5, 50, 100, 200, 300, 500],
@@ -69,14 +114,6 @@ def get_legend_config(metric_type):
     return {"domain": get_steps(min_value, max_value, len(SEVEN_SHADES)), "range": SEVEN_SHADES}
 
 
-def get_legend_type(metric_type):
-    if metric_type.category == "Mortality":
-        return "linear"
-    if metric_type.category in ["Composite risk", "Seasonality"]:
-        return "ordinal"
-    return "threshold"
-
-
 def get_steps(min, max, count):
     if not min or not max:
         return []
@@ -86,3 +123,38 @@ def get_steps(min, max, count):
     step_size = (max - min) / (count - 1)
     steps = [round(min + i * step_size, round_digits) for i in range(count)]
     return steps
+
+
+def get_scales_from_json_str(jsonstr):
+    if jsonstr:
+        try:
+            scales = json.loads(jsonstr)
+        except Exception as e:
+            print(f"Exception while parsing json: {e}")
+            scales = []
+    else:
+        scales = []
+    return scales
+
+
+def get_max_range_value(metric_type):
+    values_qs = metric_type.metricvalue_set.all()
+
+    result = values_qs.aggregate(
+        max_value=Max("value"),
+    )
+    return result["max_value"]
+
+
+def get_range_from_count(count):
+    if count == 5:
+        return list(FIVE_SHADES)
+    if count == 6:
+        return list(SIX_SHADES)
+    if count == 7:
+        return list(SEVEN_SHADES)
+    if count == 8:
+        return list(HEIGHT_SHADES)
+    if count == 9:
+        return list(NINE_SHADES)
+    return list(SEVEN_SHADES)

--- a/management/commands/support/metrics_importer.py
+++ b/management/commands/support/metrics_importer.py
@@ -29,6 +29,7 @@ class MetricsImporter:
         self.account = account
         self.download_path = Path(download_path)
         self.stdout_write = stdout_writer or print
+        self.metric_type_scales = {}
 
     def import_metrics(self):
         """Import metrics from downloaded CSV files.
@@ -130,8 +131,9 @@ class MetricsImporter:
                     category=row["CATEGORY"],
                     unit_symbol=row["UNIT_SYMBOL"],
                     legend_type=row["TYPE"].lower(),
-                    scale=row["SCALE"],
                 )
+
+                self.metric_type_scales[metric_type.code] = row["SCALE"]
                 self.stdout_write(f"Created metric: {metric_type.name} with legend type: {metric_type.legend_type}")
                 metric_types[metric_type.code] = metric_type
 
@@ -189,5 +191,5 @@ class MetricsImporter:
         from .legend import get_legend_config
 
         for metric_type in MetricType.objects.filter(account=self.account):
-            metric_type.legend_config = get_legend_config(metric_type)
+            metric_type.legend_config = get_legend_config(metric_type, self.metric_type_scales[metric_type.code])
             metric_type.save()

--- a/management/commands/support/metrics_importer.py
+++ b/management/commands/support/metrics_importer.py
@@ -69,13 +69,14 @@ class MetricsImporter:
     def _validate_csv_files(self, metadata_file, dataset_file):
         # Validate metadata file
         required_metadata_columns = [
-            "VARIABLE",
+            "TYPE",
             "LABEL",
-            "DESCRIPTION",
-            "SOURCE",
+            "SCALE",
             "UNITS",
-            "COMMENTS",
+            "SOURCE",
             "CATEGORY",
+            "VARIABLE",
+            "DESCRIPTION",
             "UNIT_SYMBOL",
         ]
 
@@ -126,11 +127,12 @@ class MetricsImporter:
                     description=row["DESCRIPTION"],
                     source=row["SOURCE"],
                     units=row["UNITS"],
-                    comments=row["COMMENTS"],
                     category=row["CATEGORY"],
                     unit_symbol=row["UNIT_SYMBOL"],
+                    legend_type=row["TYPE"].lower(),
+                    scale=row["SCALE"],
                 )
-                self.stdout_write(f"Created metric: {metric_type.name}")
+                self.stdout_write(f"Created metric: {metric_type.name} with legend type: {metric_type.legend_type}")
                 metric_types[metric_type.code] = metric_type
 
         return metric_types
@@ -184,9 +186,8 @@ class MetricsImporter:
 
     def _configure_legends(self):
         # Import legend functionality
-        from .legend import get_legend_config, get_legend_type
+        from .legend import get_legend_config
 
         for metric_type in MetricType.objects.filter(account=self.account):
             metric_type.legend_config = get_legend_config(metric_type)
-            metric_type.legend_type = get_legend_type(metric_type)
             metric_type.save()


### PR DESCRIPTION
[SNT-71](https://bluesquare.atlassian.net/browse/SNT-71?atlOrigin=eyJpIjoiNDRkZThkOGY2ZGIxNGU5Nzg3MjhmNjIwYzBiZTE2MmQiLCJwIjoiaiJ9)

When importing metrics, use legend type and scale from OpenHexa instead of calculating it.
Use new legend type to define legend data, no visible change for the end user at the moment

[SNT-71]: https://bluesquare.atlassian.net/browse/SNT-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ