### PR TITLE
SNT-73: Handle ordinal metric type

### DIFF
--- a/js/src/domains/planning/components/map.tsx
+++ b/js/src/domains/planning/components/map.tsx
@@ -83,7 +83,7 @@ export const Map: FC<Props> = ({
             const metricValue = displayedMetricValues?.find(
                 m => m.org_unit === orgUnitId,
             );
-            return metricValue?.value;
+            return metricValue?.value ?? metricValue?.string_value;
         },
         [displayedMetricValues],
     );

--- a/js/src/domains/planning/types/metrics.ts
+++ b/js/src/domains/planning/types/metrics.ts
@@ -22,10 +22,11 @@ export type MetricValue = {
     org_unit: number;
     year: number | null;
     value: number;
+    string_value: string;
 };
 
 export type ScaleDomainRange = {
-    domain: number[];
+    domain: number[] | string[];
     range: string[];
 };
 

--- a/management/commands/support/legend.py
+++ b/management/commands/support/legend.py
@@ -55,16 +55,16 @@ RISK_HIGH = "#FECDD2"
 RISK_VERY_HIGH = "#FFAB91"
 
 
-def get_legend_config(metric_type, json_scale):
+def get_legend_config(metric_type, scale):
     # Temporary: use old way as fallback if legend_type was not defined
     if metric_type.legend_type is None or metric_type.legend_type == "":
         return __get_legend_config(metric_type)
 
     if metric_type.legend_type == "threshold":
-        scales = get_scales_from_json_str(json_scale)
+        scales = get_scales_from_list_or_json_str(scale)
         return {"domain": scales, "range": get_range_from_count(len(scales))}
     if metric_type.legend_type == "ordinal":
-        return {"domain": [0, 1], "range": [RISK_LOW, RISK_VERY_HIGH]}
+        return {"domain": scale, "range": [RISK_LOW, RISK_VERY_HIGH]}
     if metric_type.legend_type == "linear":
         max_value = get_max_range_value(metric_type)
         return {"domain": [0, max_value], "range": [NINE_SHADES[0], NINE_SHADES[-1]]}
@@ -125,16 +125,18 @@ def get_steps(min, max, count):
     return steps
 
 
-def get_scales_from_json_str(jsonstr):
-    if jsonstr:
-        try:
-            scales = json.loads(jsonstr)
-        except Exception as e:
-            print(f"Exception while parsing json: {e}")
-            scales = []
-    else:
-        scales = []
-    return scales
+def get_scales_from_list_or_json_str(scale):
+    if not scale or scale == "":
+        return []
+
+    if isinstance(scale, list):
+        return scale
+
+    try:
+        return json.loads(scale)
+    except Exception as e:
+        print(f"Exception while parsing json: {e}")
+        return []
 
 
 def get_max_range_value(metric_type):


### PR DESCRIPTION
Handle ordinal metric type and accept string values. 
At the moment, the scale is hardcoded as it is empty when importing.
I suggest we ask OH team to add it as a scale ?

![image](https://github.com/user-attachments/assets/27cd8d1a-a211-42d7-8175-2261eb323cfd)
