### PR TITLE
Add page allow manual run of the import_openhexa_metrics Django command

### DIFF
--- a/templates/import_openhexa_metrics.html
+++ b/templates/import_openhexa_metrics.html
@@ -1,0 +1,169 @@
+<html>
+    <head>
+        <title>Import OpenHEXA Metrics</title>
+        <style>
+            body {
+                font-family: Arial, sans-serif;
+                max-width: 600px;
+                margin: 50px auto;
+                padding: 20px;
+                background-color: #f5f5f5;
+            }
+            .form-container {
+                background-color: white;
+                padding: 30px;
+                border-radius: 8px;
+                box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+            }
+            h1 {
+                color: #333;
+                text-align: center;
+                margin-bottom: 30px;
+            }
+            .form-group {
+                margin-bottom: 20px;
+            }
+            label {
+                display: block;
+                margin-bottom: 5px;
+                font-weight: bold;
+                color: #555;
+            }
+            input[type='text'],
+            select {
+                width: 100%;
+                padding: 10px;
+                border: 1px solid #ddd;
+                border-radius: 4px;
+                font-size: 16px;
+                box-sizing: border-box;
+            }
+            .submit-btn {
+                background-color: #007cba;
+                color: white;
+                padding: 12px 30px;
+                border: none;
+                border-radius: 4px;
+                font-size: 16px;
+                cursor: pointer;
+                width: 100%;
+                margin-top: 20px;
+            }
+            .submit-btn:hover {
+                background-color: #005a87;
+            }
+            .warning {
+                background-color: #fff3cd;
+                color: #856404;
+                padding: 12px;
+                border-radius: 4px;
+                margin-bottom: 20px;
+                border: 1px solid #ffeaa7;
+            }
+            .required {
+                color: #e74c3c;
+            }
+            .submit-btn:disabled {
+                background-color: #95a5a6;
+                cursor: not-allowed;
+            }
+            .spinner {
+                display: inline-block;
+                width: 16px;
+                height: 16px;
+                border: 2px solid #ffffff;
+                border-radius: 50%;
+                border-top-color: transparent;
+                animation: spin 1s ease-in-out infinite;
+                margin-right: 8px;
+            }
+            @keyframes spin {
+                to { transform: rotate(360deg); }
+            }
+        </style>
+    </head>
+    <body>
+        <div class="form-container">
+            <h1>Import OpenHEXA Metrics</h1>
+
+            <div class="warning">
+                <strong>⚠️ Admin Only:</strong> This action will download and
+                import metrics data from OpenHEXA workspace. Ensure you have the
+                correct workspace and dataset slugs before proceeding.
+            </div>
+
+            <form method="post">
+                {% csrf_token %}
+
+                <div class="form-group">
+                    <label for="workspace_slug"
+                        >Workspace Slug <span class="required">*</span></label
+                    >
+                    <input
+                        type="text"
+                        id="workspace_slug"
+                        name="workspace_slug"
+                        required
+                        placeholder="e.g., my-workspace-slug"
+                    />
+                </div>
+
+                <div class="form-group">
+                    <label for="dataset_slug"
+                        >Dataset Slug <span class="required">*</span></label
+                    >
+                    <input
+                        type="text"
+                        id="dataset_slug"
+                        name="dataset_slug"
+                        required
+                        placeholder="e.g., my-dataset-slug"
+                    />
+                </div>
+
+                <div class="form-group">
+                    <label for="account_id"
+                        >Account <span class="required">*</span></label
+                    >
+                    <select id="account_id" name="account_id" required>
+                        <option value="">Select an account</option>
+                        {% for account in accounts %}
+                        <option value="{{ account.id }}">
+                            {{ account.name }} (ID: {{ account.id }})
+                        </option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <button
+                    type="submit"
+                    class="submit-btn"
+                    id="submit-btn"
+                >
+                    Import OpenHEXA Metrics
+                </button>
+            </form>
+        </div>
+        
+        <script>
+            document.getElementById('submit-btn').addEventListener('click', function(e) {
+                // Validate form before submitting
+                const form = this.closest('form');
+                if (!form.checkValidity()) {
+                    return; // Let browser handle validation
+                }
+                
+                // Show loading state
+                this.disabled = true;
+                this.innerHTML = '<span class="spinner"></span>Importing...';
+                
+                // Submit the form after a brief delay to ensure UI updates
+                setTimeout(() => {
+                    form.submit();
+                }, 50);
+                
+                e.preventDefault();
+            });
+        </script>
+    </body>
+</html>

--- a/templates/import_openhexa_metrics_error.html
+++ b/templates/import_openhexa_metrics_error.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+    <head>
+        <title>OpenHEXA Metrics Import Error</title>
+        <style>
+            body {
+                font-family: Arial, sans-serif;
+                max-width: 800px;
+                margin: 20px auto;
+                padding: 20px;
+                background-color: #f5f5f5;
+            }
+            .error {
+                background-color: white;
+                padding: 20px;
+                border-radius: 8px;
+                box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+            }
+            .error-title {
+                color: #e74c3c;
+                font-weight: bold;
+            }
+            .error-details {
+                background-color: #ffeaa7;
+                padding: 15px;
+                border-radius: 4px;
+                border-left: 4px solid #e74c3c;
+                font-family: monospace;
+                white-space: pre-wrap;
+                margin: 20px 0;
+            }
+            .back-link {
+                display: inline-block;
+                margin-top: 20px;
+                color: #007cba;
+                text-decoration: none;
+            }
+            .back-link:hover {
+                text-decoration: underline;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="error">
+            <h1 class="error-title">❌ OpenHEXA Metrics Import Failed</h1>
+            <p><strong>Workspace:</strong> {{ workspace_slug }}</p>
+            <p><strong>Dataset:</strong> {{ dataset_slug }}</p>
+            <p><strong>Account ID:</strong> {{ account_id }}</p>
+
+            <h2>Error Details:</h2>
+            <div class="error-details">{{ error_message }}</div>
+
+            <a href="/snt_malaria/import_openhexa_metrics/" class="back-link"
+                >← Back to Import Form</a
+            >
+        </div>
+    </body>
+</html>

--- a/templates/import_openhexa_metrics_success.html
+++ b/templates/import_openhexa_metrics_success.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+    <head>
+        <title>OpenHEXA Metrics Import Results</title>
+        <style>
+            body {
+                font-family: Arial, sans-serif;
+                max-width: 1000px;
+                margin: 20px auto;
+                padding: 20px;
+                background-color: #f5f5f5;
+            }
+            .results {
+                background-color: white;
+                padding: 20px;
+                border-radius: 8px;
+                box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+            }
+            .success {
+                color: #27ae60;
+                font-weight: bold;
+            }
+            .command-output {
+                background-color: #f8f9fa;
+                padding: 15px;
+                border-radius: 4px;
+                border-left: 4px solid #007cba;
+                font-family: monospace;
+                white-space: pre-wrap;
+                margin: 20px 0;
+            }
+            .back-link {
+                display: inline-block;
+                margin-top: 20px;
+                color: #007cba;
+                text-decoration: none;
+            }
+            .back-link:hover {
+                text-decoration: underline;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="results">
+            <h1 class="success">✅ OpenHEXA Metrics Import Completed</h1>
+            <p><strong>Workspace:</strong> {{ workspace_slug }}</p>
+            <p><strong>Dataset:</strong> {{ dataset_slug }}</p>
+            <p><strong>Account ID:</strong> {{ account_id }}</p>
+
+            <h2>Command Output:</h2>
+            <div class="command-output">{{ output }}</div>
+
+            <a href="/snt_malaria/import_openhexa_metrics/" class="back-link"
+                >← Back to Import Form</a
+            >
+        </div>
+    </body>
+</html>

--- a/urls.py
+++ b/urls.py
@@ -1,0 +1,16 @@
+"""
+URL patterns for SNT Malaria plugin admin functionality.
+"""
+
+from django.urls import path
+
+from .views import import_openhexa_metrics
+
+urlpatterns = [
+    # Admin tools
+    path(
+        "import_openhexa_metrics/",
+        import_openhexa_metrics,
+        name="import_openhexa_metrics",
+    ),
+]

--- a/views.py
+++ b/views.py
@@ -1,0 +1,186 @@
+"""
+Views for SNT Malaria plugin admin functionality.
+"""
+
+import io
+
+from django.contrib.admin.views.decorators import staff_member_required
+from django.core.management import call_command
+from django.http import HttpResponse
+from django.template import loader
+
+from iaso.models import Account
+
+
+@staff_member_required
+def import_openhexa_metrics(request):
+    """
+    Admin-only view to import OpenHEXA metrics data via web interface.
+
+    Provides a form to execute the import_openhexa_metrics management command
+    with workspace_slug, dataset_slug, and account_id parameters.
+    """
+    if request.method == "POST":
+        # Get form data
+        workspace_slug = request.POST.get("workspace_slug", "").strip()
+        dataset_slug = request.POST.get("dataset_slug", "").strip()
+        account_id = request.POST.get("account_id", "")
+
+        # Validate form data
+        if not workspace_slug:
+            return HttpResponse("Error: workspace_slug is required", status=400)
+        if not dataset_slug:
+            return HttpResponse("Error: dataset_slug is required", status=400)
+        if not account_id:
+            return HttpResponse("Error: account_id is required", status=400)
+
+        try:
+            account_id = int(account_id)
+        except ValueError:
+            return HttpResponse("Error: account_id must be a valid integer", status=400)
+
+        # Execute the management command
+        try:
+            out = io.StringIO()
+            call_command(
+                "import_openhexa_metrics",
+                workspace_slug=workspace_slug,
+                dataset_slug=dataset_slug,
+                account_id=account_id,
+                stdout=out,
+                stderr=out,
+            )
+            output = out.getvalue()
+
+            # Format output for HTML display
+            html_output = f"""
+            <html>
+                <head>
+                    <title>OpenHEXA Metrics Import Results</title>
+                    <style>
+                        body {{
+                            font-family: Arial, sans-serif;
+                            max-width: 1000px;
+                            margin: 20px auto;
+                            padding: 20px;
+                            background-color: #f5f5f5;
+                        }}
+                        .results {{
+                            background-color: white;
+                            padding: 20px;
+                            border-radius: 8px;
+                            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+                        }}
+                        .success {{
+                            color: #27ae60;
+                            font-weight: bold;
+                        }}
+                        .command-output {{
+                            background-color: #f8f9fa;
+                            padding: 15px;
+                            border-radius: 4px;
+                            border-left: 4px solid #007cba;
+                            font-family: monospace;
+                            white-space: pre-wrap;
+                            margin: 20px 0;
+                        }}
+                        .back-link {{
+                            display: inline-block;
+                            margin-top: 20px;
+                            color: #007cba;
+                            text-decoration: none;
+                        }}
+                        .back-link:hover {{
+                            text-decoration: underline;
+                        }}
+                    </style>
+                </head>
+                <body>
+                    <div class="results">
+                        <h1 class="success">✅ OpenHEXA Metrics Import Completed</h1>
+                        <p><strong>Workspace:</strong> {workspace_slug}</p>
+                        <p><strong>Dataset:</strong> {dataset_slug}</p>
+                        <p><strong>Account ID:</strong> {account_id}</p>
+
+                        <h2>Command Output:</h2>
+                        <div class="command-output">{output}</div>
+
+                        <a href="/snt_malaria/import_openhexa_metrics/" class="back-link">← Back to Import Form</a>
+                    </div>
+                </body>
+            </html>
+            """
+
+            return HttpResponse(html_output)
+
+        except Exception as e:
+            # Handle command execution errors
+            error_html = f"""
+            <html>
+                <head>
+                    <title>OpenHEXA Metrics Import Error</title>
+                    <style>
+                        body {{
+                            font-family: Arial, sans-serif;
+                            max-width: 800px;
+                            margin: 20px auto;
+                            padding: 20px;
+                            background-color: #f5f5f5;
+                        }}
+                        .error {{
+                            background-color: white;
+                            padding: 20px;
+                            border-radius: 8px;
+                            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+                        }}
+                        .error-title {{
+                            color: #e74c3c;
+                            font-weight: bold;
+                        }}
+                        .error-details {{
+                            background-color: #ffeaa7;
+                            padding: 15px;
+                            border-radius: 4px;
+                            border-left: 4px solid #e74c3c;
+                            font-family: monospace;
+                            white-space: pre-wrap;
+                            margin: 20px 0;
+                        }}
+                        .back-link {{
+                            display: inline-block;
+                            margin-top: 20px;
+                            color: #007cba;
+                            text-decoration: none;
+                        }}
+                        .back-link:hover {{
+                            text-decoration: underline;
+                        }}
+                    </style>
+                </head>
+                <body>
+                    <div class="error">
+                        <h1 class="error-title">❌ OpenHEXA Metrics Import Failed</h1>
+                        <p><strong>Workspace:</strong> {workspace_slug}</p>
+                        <p><strong>Dataset:</strong> {dataset_slug}</p>
+                        <p><strong>Account ID:</strong> {account_id}</p>
+
+                        <h2>Error Details:</h2>
+                        <div class="error-details">{str(e)}</div>
+
+                        <a href="/snt_malaria/import_openhexa_metrics/" class="back-link">← Back to Import Form</a>
+                    </div>
+                </body>
+            </html>
+            """
+
+            return HttpResponse(error_html, status=500)
+
+    # GET request - display the form
+    # Get all accounts to populate the select dropdown
+    accounts = Account.objects.all().order_by("name")
+
+    template = loader.get_template("import_openhexa_metrics.html")
+    context = {
+        "accounts": accounts,
+    }
+    return HttpResponse(template.render(context, request))

--- a/views.py
+++ b/views.py
@@ -1,7 +1,3 @@
-"""
-Views for SNT Malaria plugin admin functionality.
-"""
-
 import io
 
 from django.contrib.admin.views.decorators import staff_member_required
@@ -21,12 +17,10 @@ def import_openhexa_metrics(request):
     with workspace_slug, dataset_slug, and account_id parameters.
     """
     if request.method == "POST":
-        # Get form data
         workspace_slug = request.POST.get("workspace_slug", "").strip()
         dataset_slug = request.POST.get("dataset_slug", "").strip()
         account_id = request.POST.get("account_id", "")
 
-        # Validate form data
         if not workspace_slug:
             return HttpResponse("Error: workspace_slug is required", status=400)
         if not dataset_slug:
@@ -39,7 +33,6 @@ def import_openhexa_metrics(request):
         except ValueError:
             return HttpResponse("Error: account_id must be a valid integer", status=400)
 
-        # Execute the management command
         try:
             out = io.StringIO()
             call_command(
@@ -52,135 +45,30 @@ def import_openhexa_metrics(request):
             )
             output = out.getvalue()
 
-            # Format output for HTML display
-            html_output = f"""
-            <html>
-                <head>
-                    <title>OpenHEXA Metrics Import Results</title>
-                    <style>
-                        body {{
-                            font-family: Arial, sans-serif;
-                            max-width: 1000px;
-                            margin: 20px auto;
-                            padding: 20px;
-                            background-color: #f5f5f5;
-                        }}
-                        .results {{
-                            background-color: white;
-                            padding: 20px;
-                            border-radius: 8px;
-                            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-                        }}
-                        .success {{
-                            color: #27ae60;
-                            font-weight: bold;
-                        }}
-                        .command-output {{
-                            background-color: #f8f9fa;
-                            padding: 15px;
-                            border-radius: 4px;
-                            border-left: 4px solid #007cba;
-                            font-family: monospace;
-                            white-space: pre-wrap;
-                            margin: 20px 0;
-                        }}
-                        .back-link {{
-                            display: inline-block;
-                            margin-top: 20px;
-                            color: #007cba;
-                            text-decoration: none;
-                        }}
-                        .back-link:hover {{
-                            text-decoration: underline;
-                        }}
-                    </style>
-                </head>
-                <body>
-                    <div class="results">
-                        <h1 class="success">✅ OpenHEXA Metrics Import Completed</h1>
-                        <p><strong>Workspace:</strong> {workspace_slug}</p>
-                        <p><strong>Dataset:</strong> {dataset_slug}</p>
-                        <p><strong>Account ID:</strong> {account_id}</p>
-
-                        <h2>Command Output:</h2>
-                        <div class="command-output">{output}</div>
-
-                        <a href="/snt_malaria/import_openhexa_metrics/" class="back-link">← Back to Import Form</a>
-                    </div>
-                </body>
-            </html>
-            """
-
-            return HttpResponse(html_output)
+            # Render success template
+            template = loader.get_template("import_openhexa_metrics_success.html")
+            context = {
+                "workspace_slug": workspace_slug,
+                "dataset_slug": dataset_slug,
+                "account_id": account_id,
+                "output": output,
+            }
+            return HttpResponse(template.render(context, request))
 
         except Exception as e:
-            # Handle command execution errors
-            error_html = f"""
-            <html>
-                <head>
-                    <title>OpenHEXA Metrics Import Error</title>
-                    <style>
-                        body {{
-                            font-family: Arial, sans-serif;
-                            max-width: 800px;
-                            margin: 20px auto;
-                            padding: 20px;
-                            background-color: #f5f5f5;
-                        }}
-                        .error {{
-                            background-color: white;
-                            padding: 20px;
-                            border-radius: 8px;
-                            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-                        }}
-                        .error-title {{
-                            color: #e74c3c;
-                            font-weight: bold;
-                        }}
-                        .error-details {{
-                            background-color: #ffeaa7;
-                            padding: 15px;
-                            border-radius: 4px;
-                            border-left: 4px solid #e74c3c;
-                            font-family: monospace;
-                            white-space: pre-wrap;
-                            margin: 20px 0;
-                        }}
-                        .back-link {{
-                            display: inline-block;
-                            margin-top: 20px;
-                            color: #007cba;
-                            text-decoration: none;
-                        }}
-                        .back-link:hover {{
-                            text-decoration: underline;
-                        }}
-                    </style>
-                </head>
-                <body>
-                    <div class="error">
-                        <h1 class="error-title">❌ OpenHEXA Metrics Import Failed</h1>
-                        <p><strong>Workspace:</strong> {workspace_slug}</p>
-                        <p><strong>Dataset:</strong> {dataset_slug}</p>
-                        <p><strong>Account ID:</strong> {account_id}</p>
-
-                        <h2>Error Details:</h2>
-                        <div class="error-details">{str(e)}</div>
-
-                        <a href="/snt_malaria/import_openhexa_metrics/" class="back-link">← Back to Import Form</a>
-                    </div>
-                </body>
-            </html>
-            """
-
-            return HttpResponse(error_html, status=500)
+            template = loader.get_template("import_openhexa_metrics_error.html")
+            context = {
+                "workspace_slug": workspace_slug,
+                "dataset_slug": dataset_slug,
+                "account_id": account_id,
+                "error_message": str(e),
+            }
+            return HttpResponse(template.render(context, request), status=500)
 
     # GET request - display the form
     # Get all accounts to populate the select dropdown
     accounts = Account.objects.all().order_by("name")
 
     template = loader.get_template("import_openhexa_metrics.html")
-    context = {
-        "accounts": accounts,
-    }
-    return HttpResponse(template.render(context, request))
+
+    return HttpResponse(template.render({"accounts": accounts}, request))


### PR DESCRIPTION
This adds a "hidden" page to `/snt_malaria/import_openhexa_metrics/` that allows an admin user to manually launch the Django command to import the metrics into a specific account.

Thanks to Claude Code for the nice interface :pray: 

<img width="4337" height="2039" alt="image" src="https://github.com/user-attachments/assets/21bf054f-1edf-479c-8898-ae6f9ba19add" />

<img width="4334" height="2041" alt="image" src="https://github.com/user-attachments/assets/7b29ec61-056f-40eb-9e32-84534760eb4a" />
