### PR TITLE
Fix import openhexa metrics script

### DIFF
--- a/management/commands/import_openhexa_metrics.py
+++ b/management/commands/import_openhexa_metrics.py
@@ -13,9 +13,6 @@ Environment variables required:
 """
 
 import os
-import tempfile
-
-from pathlib import Path
 
 from django.core.management.base import BaseCommand, CommandError
 

--- a/management/commands/support/file_downloader.py
+++ b/management/commands/support/file_downloader.py
@@ -1,13 +1,7 @@
-"""
-Selective CSV file downloader for OpenHEXA datasets.
-
-This module handles downloading only the required CSV files (metadata and dataset)
-from OpenHEXA datasets to temporary files, eliminating the need for temporary directories.
-"""
-
 import tempfile
-from pathlib import Path
+
 import requests
+
 from django.core.management.base import CommandError
 
 
@@ -15,12 +9,6 @@ class FileDownloader:
     """Handles selective downloading of files from OpenHEXA datasets."""
 
     def __init__(self, openhexa_client, stdout_writer=None):
-        """Initialize the CSV downloader.
-
-        Args:
-            openhexa_client: OpenHEXA client instance for API calls
-            stdout_writer: Optional writer for progress output (e.g., self.stdout.write)
-        """
         self.openhexa_client = openhexa_client
         self.stdout_write = stdout_writer or print
 

--- a/management/commands/support/metrics_importer.py
+++ b/management/commands/support/metrics_importer.py
@@ -7,8 +7,6 @@ into MetricType and MetricValue models, including legend configuration.
 
 import csv
 
-from pathlib import Path
-
 from django.core.management.base import CommandError
 from django.db import transaction
 


### PR DESCRIPTION
This simplifies the script:
- only download the 2 .csv files that we need
- use Django temp files instead of writing directly to /tmp