### PR TITLE
SNT-87: Fix ordinal scale color mapping 

### DIFF
--- a/js/src/domains/planning/libs/map-utils.tsx
+++ b/js/src/domains/planning/libs/map-utils.tsx
@@ -27,14 +27,30 @@ export const shouldReverse = (threshold: ScaleDomainRange) => {
     return threshold.domain[0] > threshold.domain[threshold.domain.length - 1];
 };
 
+const getColorForOrdinalScale = (
+    value: string | number,
+    legend_config: ScaleDomainRange,
+) => {
+    const numericValue = Number(value);
+    let index: number;
+    if (Number.isNaN(numericValue)) {
+        index = legend_config.domain.indexOf(value as never);
+    } else {
+        index = legend_config.domain.findIndex(
+            (d: number | string) => Number(d) === numericValue,
+        );
+    }
+
+    return legend_config.range[index];
+};
+
 const getColorForShape = (
     value: number | string,
     legend_type: string,
     legend_config: ScaleDomainRange,
 ) => {
     if (legend_type === 'ordinal') {
-        const index = legend_config.domain.indexOf(value as never);
-        return legend_config.range[index];
+        return getColorForOrdinalScale(value, legend_config);
     }
 
     const numericValue = Number(value);


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [SNT-87](https://bluesquare.atlassian.net/browse/SNT-87)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

When mapping ordinal metrics to color, we have mismatch if value is an actual number.
For this specific case, legend is using plain numbers (2, 3, 4) but values are formatted using floats (2.0, 3.0, 4.0).
Currently the comparison was done expecting two strings.
Changed that to compare as numbers if value is an actual number.

## How to test

If you have data for Congo, you can just go to a scenario and check layer from group "ENVIRONMENTAL INDICATOR", Metric tope: "Length of Tansmission Season by Rainfall (ERA5)"

## Print screen / video

<img width="948" height="385" alt="image" src="https://github.com/user-attachments/assets/aed4b4c1-e2bc-4f60-8d5a-7bcaede3e439" />



[SNT-87]: https://bluesquare.atlassian.net/browse/SNT-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ