### PR TITLE
SNT-83: Display legend units

### DIFF
--- a/js/src/domains/planning/components/MapLegend.tsx
+++ b/js/src/domains/planning/components/MapLegend.tsx
@@ -26,6 +26,9 @@ const styles: SxStyles = {
         gap: 2,
         flexFlow: 'wrap',
     }),
+    legendUnit: (theme: Theme) => ({
+        padding: theme.spacing(0.5, 1),
+    }),
 };
 
 type Props = {
@@ -35,6 +38,7 @@ type Props = {
 export const MapLegend: FunctionComponent<Props> = ({ metric }) => {
     return (
         <Paper elevation={1} sx={styles.root}>
+            <Box sx={styles.legendUnit}>{metric.units}</Box>
             <Box sx={styles.legendContainer}>
                 {(() => {
                     if (metric.legend_type === 'linear') {


### PR DESCRIPTION
Display legend units in map legend

Related JIRA tickets : [SNT-83](https://bluesquare.atlassian.net/browse/SNT-83)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc


## Changes

Added a box in the legend with legend unit

## How to test

Go to ant-malaria, and check a map with legends

## Print screen / video

<img width="674" height="64" alt="image" src="https://github.com/user-attachments/assets/0fcfc8a1-ad75-4b07-a4d6-c05ef1a08127" />

## Notes


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[SNT-83]: https://bluesquare.atlassian.net/browse/SNT-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ