### PR TITLE
SNT-87: Fix ordinal scale color mapping

### DIFF
--- a/management/commands/support/legend.py
+++ b/management/commands/support/legend.py
@@ -79,6 +79,7 @@ ORDINAL = {
     4: [RISK_LOW, RISK_MEDIUM, RISK_HIGH, RISK_VERY_HIGH],
 }
 
+
 def get_legend_config(metric_type, scale):
     # Temporary: use old way as fallback if legend_type was not defined
     if metric_type.legend_type is None or metric_type.legend_type == "":
@@ -168,7 +169,13 @@ def get_scales_from_list_or_json_str(scale):
 
     if str.startswith(scale, "[") and str.endswith(scale, "]"):
         strScale = scale.replace("[", "").replace("]", "")
-        return str.split(strScale, ",")
+        scales = [s.strip() for s in str.split(strScale, ",")]
+        if isFloat(scales[0]):
+            return [float(s) for s in scales]
+        if isInt(scales[0]):
+            return [int(s) for s in scales]
+
+        return scales
 
     try:
         return json.loads(scale)
@@ -203,3 +210,19 @@ def get_range_from_count(count):
     if count == 9:
         return list(TEN_SHADES)
     return list(SEVEN_SHADES)
+
+
+def isFloat(value):
+    try:
+        float(value)
+        return True
+    except ValueError:
+        return False
+
+
+def isInt(value):
+    try:
+        int(value)
+        return True
+    except ValueError:
+        return False

--- a/management/commands/support/metrics_importer.py
+++ b/management/commands/support/metrics_importer.py
@@ -116,9 +116,8 @@ class MetricsImporter:
                     )
 
                     self.stdout_write(f"Created metric: {metric_type.name} with legend type: {metric_type.legend_type}")
-                    scale = row["SCALE"]
 
-                    self.metric_type_scales[metric_type.code] = scale
+                    self.metric_type_scales[metric_type.code] = row["SCALE"]
                     metric_types[metric_type.code] = metric_type
                 except Exception as e:
                     self.stdout_write(f"ERROR: Error creating MetricType: {row['LABEL']}")


### PR DESCRIPTION
Fix metric importer to remove trailing spaces from legend values and convert to int / float when needed

Related JIRA tickets : SNT-87

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

## Changes

There was some issues when handling metadata with scale looking like : [1, 2, 3]
It was converted to : ["1", " 2", " 3"]
So additional space and numbers as string.

With this PR this should be changed to [1, 2, 3]

## How to test

Got to ant-malaria, open a scenario and change the layer to Length of Tansmission Season by Rainfall (ERA5)
It should render properly (Especially for BFA)

## Print screen / video

<img width="963" height="377" alt="image" src="https://github.com/user-attachments/assets/f133b24e-a577-4363-967e-7cadf0a8a5f0" />

## Notes

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
