### PR TITLE
Snt 103 add loader when deleting org units from plan

### DIFF
--- a/js/src/constants/translations/fr.json
+++ b/js/src/constants/translations/fr.json
@@ -28,7 +28,7 @@
     "iaso.snt_malaria.interventionAssignment.removeAllTitle": "Supprimer tous les districts",
     "iaso.snt_malaria.interventionAssignment.removeAllMessage":"Voulez-vous vraiment supprimer tous les districts de cette intervention ?",
     "iaso.snt_malaria.interventionAssignment.removeTitle":"Supprimer un district",
-    "iaso.snt_malaria.interventionAssignment.removeMessage":"Voulez-vous vraiment supprimer tous les districts de cette intervention ?",
+    "iaso.snt_malaria.interventionAssignment.removeMessage":"Voulez-vous vraiment supprimer ce district de cette intervention ?",
     "iaso.snt_malaria.label.allInterventions": "Toutes interventions",
     "iaso.snt_malaria.label.editedOn": "Modifié le {date}",
     "iaso.snt_malaria.label.resolveConflictTile": "Résoudre les conflits",

--- a/js/src/domains/planning/components/ScenarioTopBar.tsx
+++ b/js/src/domains/planning/components/ScenarioTopBar.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
 import { useNavigate } from 'react-router-dom';
-import { DeleteModal } from 'Iaso/components/DeleteRestoreModals/DeleteModal';
+import DeleteDialog from 'Iaso/components/dialogs/DeleteDialogComponent';
 import { SxStyles } from 'Iaso/types/general';
 import { baseUrls } from '../../../constants/urls';
 
@@ -177,18 +177,14 @@ export const ScenarioTopBar: FC<Props> = ({ scenario }) => {
                         <CopyAllOutlinedIcon sx={styles.icon} />
                         Duplicate
                     </Button>
-                    <DeleteModal
-                        type="icon"
-                        onConfirm={() => handleDeleteClick()}
+                    <DeleteDialog
+                        onConfirm={handleDeleteClick}
                         titleMessage={formatMessage(
                             MESSAGES.modalDeleteScenarioTitle,
                         )}
-                        iconProps={{ color: 'primary' }}
-                    >
-                        <p>
-                            {formatMessage(MESSAGES.modalDeleteScenarioConfirm)}
-                        </p>
-                    </DeleteModal>
+                        iconColor={'primary'}
+                        message={MESSAGES.modalDeleteScenarioConfirm}
+                    />
                 </Box>
             </Box>
         );

--- a/js/src/domains/planning/components/interventionPlan/InterventionsPlan.tsx
+++ b/js/src/domains/planning/components/interventionPlan/InterventionsPlan.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useMemo, useState } from 'react';
 import { TabContext, TabPanel } from '@mui/lab';
 import { Divider, Box, CardHeader, CardContent, Card } from '@mui/material';
 import { UseRemoveManyOrgUnitsFromInterventionPlan } from '../../hooks/UseRemoveOrgUnitFromInterventionPlan';
@@ -21,11 +21,19 @@ export const InterventionsPlan: FC<Props> = ({
 }) => {
     const [tabValue, setTabValue] = useState<string>('list');
 
-    const [selectedInterventionPlan, setSelectedInterventionPlan] =
-        useState<InterventionPlan | null>(null);
-
     const [isRemovingOrgUnits, setIsRemovingOrgUnits] =
         useState<boolean>(false);
+    const [selectedInterventionId, setSelectedInterventionId] = useState<
+        number | null
+    >(null);
+
+    const selectedInterventionPlan: InterventionPlan | null = useMemo(() => {
+        return (
+            interventionPlans.find(
+                plan => plan.intervention.id === selectedInterventionId,
+            ) || null
+        );
+    }, [interventionPlans, selectedInterventionId]);
 
     const { mutateAsync: removeManyOrgUnitsFromPlan } =
         UseRemoveManyOrgUnitsFromInterventionPlan();
@@ -45,11 +53,11 @@ export const InterventionsPlan: FC<Props> = ({
     const onShowInterventionPlanDetails = (
         interventionPlan: InterventionPlan,
     ) => {
-        setSelectedInterventionPlan(interventionPlan);
+        setSelectedInterventionId(interventionPlan.intervention.id);
     };
 
     const onCloseInterventionPlanDetails = () => {
-        setSelectedInterventionPlan(null);
+        setSelectedInterventionId(null);
     };
 
     return (

--- a/js/src/domains/planning/components/interventionPlan/InterventionsPlan.tsx
+++ b/js/src/domains/planning/components/interventionPlan/InterventionsPlan.tsx
@@ -24,14 +24,22 @@ export const InterventionsPlan: FC<Props> = ({
     const [selectedInterventionPlan, setSelectedInterventionPlan] =
         useState<InterventionPlan | null>(null);
 
+    const [isRemovingOrgUnits, setIsRemovingOrgUnits] =
+        useState<boolean>(false);
+
     const { mutateAsync: removeManyOrgUnitsFromPlan } =
         UseRemoveManyOrgUnitsFromInterventionPlan();
 
     const onRemoveOrgUnitsFromPlan = async (
         interventionAssignmentIds: number[],
+        shouldCloseDrawer: boolean,
     ) => {
+        setIsRemovingOrgUnits(true);
         await removeManyOrgUnitsFromPlan(interventionAssignmentIds);
-        setSelectedInterventionPlan(null);
+        setIsRemovingOrgUnits(false);
+        if (shouldCloseDrawer) {
+            onCloseInterventionPlanDetails();
+        }
     };
 
     const onShowInterventionPlanDetails = (
@@ -105,6 +113,7 @@ export const InterventionsPlan: FC<Props> = ({
                 interventionPlan={selectedInterventionPlan}
                 removeOrgUnitsFromPlan={onRemoveOrgUnitsFromPlan}
                 closeInterventionPlanDetails={onCloseInterventionPlanDetails}
+                isRemovingOrgUnits={isRemovingOrgUnits}
             />
         </Box>
     );


### PR DESCRIPTION
Improve flow when deleting a org unit

Related JIRA tickets : SNT-103

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- Close the deleteDialog on confirm
- Display a loader when deleting batch and close the side panel
- Don't close side panel when removing a single org unit, except if it was the last one for an intervention
- Refresh side panel org units when deleting one

## How to test

In snt-malaria: 
- create a scenario
- select some org units on the map
- add them to the selection
- Select some interventions and apply them
- On intervention plan, click on X District, drawer will be shown.
- Delete all should look as a text button
- Click delete all, a confirmation dialog should be shown.
- On canceling, dialog is closed and the rest look the same as before
- On validating, dialog is closed, a spinner is shown and all fields disabled
- Once completed, the drawer is closed and intervention plan has disappeared from the view.

Single delete:
- Same steps as above, but instead of delete all, hover a org unit and click the trash icon
- A confirmation dialog should be prompted
- On confirm, dialog should close and org unit removed
- A success message should be displayed

## Print screen / video



https://github.com/user-attachments/assets/ad03f505-2f90-4acb-a53d-0d89a2933b60


## Notes

Depends on a IASO PR: https://github.com/BLSQ/iaso/pull/2391

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
