### PR TITLE
SNT-121 Add run budget button no action yet

### DIFF
--- a/js/src/constants/translations/en.json
+++ b/js/src/constants/translations/en.json
@@ -52,5 +52,6 @@
     "iaso.snt_malaria.settings.intervention.detailedCostUnitLabel":"Cost Unit",
     "iaso.snt_malaria.settings.intervention.detailedCostCategoryLabel":"Category",
     "iaso.snt_malaria.settings.intervention.errors.required": "Required",
-    "iaso.snt_malaria.settings.intervention.errors.negativeValueNotAllowed": "Negative value not allowed"
+    "iaso.snt_malaria.settings.intervention.errors.negativeValueNotAllowed": "Negative value not allowed",
+    "iaso.snt_malaria.label.runInterventionPlanBudget": "Run Budget"
 }

--- a/js/src/constants/translations/fr.json
+++ b/js/src/constants/translations/fr.json
@@ -52,5 +52,6 @@
     "iaso.snt_malaria.settings.intervention.detailedCostUnitLabel":"Unité",
     "iaso.snt_malaria.settings.intervention.detailedCostCategoryLabel":"Catégorie",
     "iaso.snt_malaria.settings.intervention.errors.required": "Requis",
-    "iaso.snt_malaria.settings.intervention.errors.negativeValueNotAllowed": "La valeur négative n'est pas autorisée"
+    "iaso.snt_malaria.settings.intervention.errors.negativeValueNotAllowed": "La valeur négative n'est pas autorisée",
+    "iaso.snt_malaria.label.runInterventionPlanBudget": "Exécuter Budget"
 }

--- a/js/src/domains/messages.ts
+++ b/js/src/domains/messages.ts
@@ -150,6 +150,10 @@ export const MESSAGES = defineMessages({
         defaultMessage:
             'Some districts already have an intervention from the samegroup.{br} Choose which one to apply, or decide to apply both.',
     },
+    runInterventionPlanBudget: {
+        id: 'iaso.snt_malaria.label.runInterventionPlanBudget',
+        defaultMessage: 'Run Budget',
+    },
     selectAll: {
         id: 'iaso.snt_malaria.label.selectAll',
         defaultMessage: 'Select All',

--- a/js/src/domains/planning/components/interventionPlan/InterventionplanSummary.tsx
+++ b/js/src/domains/planning/components/interventionPlan/InterventionplanSummary.tsx
@@ -11,10 +11,14 @@ export type TabValue = 'map' | 'list';
 type Props = {
     setTabValue: Dispatch<SetStateAction<TabValue>>;
     tabValue: TabValue;
+    assignedOrgUnits: number;
+    totalOrgUnits: number;
 };
 export const InterventionPlanSummary: FC<Props> = ({
     setTabValue,
     tabValue,
+    assignedOrgUnits = 0,
+    totalOrgUnits = 0,
 }) => {
     const { formatMessage } = useSafeIntl();
     return (
@@ -41,10 +45,13 @@ export const InterventionPlanSummary: FC<Props> = ({
             <Grid item>
                 <Stack
                     direction="row"
-                    spacing={4}
+                    spacing={2}
                     alignItems="center"
                     sx={{ color: '#1F2B3D99' }}
                 >
+                    <Typography variant="body2">
+                        {assignedOrgUnits} / {totalOrgUnits}
+                    </Typography>
                     <Tabs
                         onChange={(_event, newValue) => setTabValue(newValue)}
                         value={tabValue}
@@ -57,6 +64,9 @@ export const InterventionPlanSummary: FC<Props> = ({
                         <Tab value="map" label={<MapIcon />} />
                         <Tab value="list" label={<TableRowsIcon />} />
                     </Tabs>
+                    <Button variant="contained" color="primary">
+                        {formatMessage(MESSAGES.runInterventionPlanBudget)}
+                    </Button>
                 </Stack>
             </Grid>
         </Grid>

--- a/js/src/domains/planning/components/interventionPlan/InterventionplanSummary.tsx
+++ b/js/src/domains/planning/components/interventionPlan/InterventionplanSummary.tsx
@@ -2,7 +2,7 @@ import React, { Dispatch, FC, SetStateAction } from 'react';
 import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
 import MapIcon from '@mui/icons-material/Map';
 import TableRowsIcon from '@mui/icons-material/TableRows';
-import { Box, Grid, Stack, Tab, Tabs, Typography } from '@mui/material';
+import { Box, Button, Grid, Stack, Tab, Tabs, Typography } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
 import { MESSAGES } from '../../../messages';
 import { containerBoxStyles } from '../styles';

--- a/js/src/domains/planning/components/interventionPlan/InterventionsPlan.tsx
+++ b/js/src/domains/planning/components/interventionPlan/InterventionsPlan.tsx
@@ -12,12 +12,14 @@ type Props = {
     scenarioId: number | undefined;
     interventionPlans: InterventionPlan[];
     isLoadingPlans: boolean;
+    totalOrgUnitCount: number;
 };
 
 export const InterventionsPlan: FC<Props> = ({
     scenarioId,
     interventionPlans,
     isLoadingPlans,
+    totalOrgUnitCount = 0,
 }) => {
     const [tabValue, setTabValue] = useState<TabValue>('map');
 
@@ -26,6 +28,17 @@ export const InterventionsPlan: FC<Props> = ({
     const [selectedInterventionId, setSelectedInterventionId] = useState<
         number | null
     >(null);
+
+    const assignedOrgUnitCount = useMemo(() => {
+        return interventionPlans.reduce((acc, plan) => {
+            plan.org_units.forEach(orgUnit => {
+                if (!acc.includes(orgUnit.id)) {
+                    acc.push(orgUnit.id);
+                }
+            });
+            return acc;
+        }, [] as number[]).length;
+    }, [interventionPlans]);
 
     const selectedInterventionPlan: InterventionPlan | null = useMemo(() => {
         return (
@@ -75,6 +88,8 @@ export const InterventionsPlan: FC<Props> = ({
                             <InterventionPlanSummary
                                 setTabValue={setTabValue}
                                 tabValue={tabValue}
+                                assignedOrgUnits={assignedOrgUnitCount}
+                                totalOrgUnits={totalOrgUnitCount}
                             />
                         }
                     />

--- a/js/src/domains/planning/index.tsx
+++ b/js/src/domains/planning/index.tsx
@@ -44,7 +44,8 @@ export const Planning: FC = () => {
 
     const [metricFilters, setMetricFilters] = useState<MetricsFilters>();
     const [selectionOnMap, setSelectionOnMap] = useState<OrgUnit[]>([]);
-    const [expanded, setExpanded] = useState('interventionsList');
+    const [selectionOnInterventionList, setSelectionOnInterventionList] =
+        useState<OrgUnit[]>([]);
     const [selectedInterventions, setSelectedInterventions] = useState<{
         [categoryId: number]: Intervention;
     }>({});
@@ -129,10 +130,6 @@ export const Planning: FC = () => {
         );
     }, [formatMessage]);
 
-    const handleExpandAccordion = panel => (event, isExpanded) => {
-        setExpanded(isExpanded ? panel : null);
-    };
-
     return (
         <>
             {isLoadingOrgUnits && <LoadingSpinner />}
@@ -194,12 +191,7 @@ export const Planning: FC = () => {
                         <PaperContainer>
                             <InterventionsPlan
                                 scenarioId={scenario?.id}
-                                handleExpandAccordion={handleExpandAccordion}
-                                expanded={expanded}
-                                setSelectedInterventions={
-                                    setSelectedInterventions
-                                }
-                                selectedInterventions={selectedInterventions}
+                                totalOrgUnitCount={orgUnits?.length ?? 0}
                                 interventionPlans={interventionPlans ?? []}
                                 isLoadingPlans={isLoadingPlans}
                             />


### PR DESCRIPTION
Display run budget button and assigned org units count

Related JIRA tickets : SNT-121

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc


## Changes

Add Run budget button + translations. 
No action yet.

Calculate assigned org units to plan in a memo and show.

## How to test

Just go to a scenario, an empty one.
Count should be 0.
Add some org units to plan, verify that the count change.
Add some more, count updates.
If you assign one org unit to multiple interventions, it still count as 1.

When removing one or multiple org units, count is updated too.

## Print screen / video

<img width="732" height="104" alt="image" src="https://github.com/user-attachments/assets/e6305c0b-4674-4e33-960e-abde43587baf" />

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
