### PR TITLE
SNT-134 Show intervention plan map by default

### DIFF
--- a/js/src/domains/planning/components/interventionPlan/InterventionplanSummary.tsx
+++ b/js/src/domains/planning/components/interventionPlan/InterventionplanSummary.tsx
@@ -2,16 +2,19 @@ import React, { FC } from 'react';
 import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
 import MapIcon from '@mui/icons-material/Map';
 import TableRowsIcon from '@mui/icons-material/TableRows';
-import { TabList } from '@mui/lab';
-import { Box, Grid, Stack, Tab, Typography } from '@mui/material';
+import { Box, Grid, Stack, Tab, Tabs, Typography } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
 import { MESSAGES } from '../../../messages';
 import { containerBoxStyles } from '../styles';
 
 type Props = {
-    setTabValue: (tabValue: string) => void;
+    setTabValue: (tabValue: 'map' | 'list') => void;
+    tabValue: 'map' | 'list';
 };
-export const InterventionPlanSummary: FC<Props> = ({ setTabValue }) => {
+export const InterventionPlanSummary: FC<Props> = ({
+    setTabValue,
+    tabValue,
+}) => {
     const { formatMessage } = useSafeIntl();
     return (
         <Grid
@@ -41,8 +44,9 @@ export const InterventionPlanSummary: FC<Props> = ({ setTabValue }) => {
                     alignItems="center"
                     sx={{ color: '#1F2B3D99' }}
                 >
-                    <TabList
+                    <Tabs
                         onChange={(_event, newValue) => setTabValue(newValue)}
+                        value={tabValue}
                         sx={{
                             '& .MuiTabs-indicator': {
                                 display: 'none',
@@ -51,7 +55,7 @@ export const InterventionPlanSummary: FC<Props> = ({ setTabValue }) => {
                     >
                         <Tab value="list" label={<TableRowsIcon />} />
                         <Tab value="map" label={<MapIcon />} />
-                    </TabList>
+                    </Tabs>
                 </Stack>
             </Grid>
         </Grid>

--- a/js/src/domains/planning/components/interventionPlan/InterventionplanSummary.tsx
+++ b/js/src/domains/planning/components/interventionPlan/InterventionplanSummary.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { Dispatch, FC, SetStateAction } from 'react';
 import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
 import MapIcon from '@mui/icons-material/Map';
 import TableRowsIcon from '@mui/icons-material/TableRows';
@@ -7,9 +7,10 @@ import { useSafeIntl } from 'bluesquare-components';
 import { MESSAGES } from '../../../messages';
 import { containerBoxStyles } from '../styles';
 
+export type TabValue = 'map' | 'list';
 type Props = {
-    setTabValue: (tabValue: 'map' | 'list') => void;
-    tabValue: 'map' | 'list';
+    setTabValue: Dispatch<SetStateAction<TabValue>>;
+    tabValue: TabValue;
 };
 export const InterventionPlanSummary: FC<Props> = ({
     setTabValue,
@@ -53,8 +54,8 @@ export const InterventionPlanSummary: FC<Props> = ({
                             },
                         }}
                     >
-                        <Tab value="list" label={<TableRowsIcon />} />
                         <Tab value="map" label={<MapIcon />} />
+                        <Tab value="list" label={<TableRowsIcon />} />
                     </Tabs>
                 </Stack>
             </Grid>

--- a/js/src/domains/planning/components/interventionPlan/InterventionsPlan.tsx
+++ b/js/src/domains/planning/components/interventionPlan/InterventionsPlan.tsx
@@ -19,7 +19,7 @@ export const InterventionsPlan: FC<Props> = ({
     interventionPlans,
     isLoadingPlans,
 }) => {
-    const [tabValue, setTabValue] = useState<string>('list');
+    const [tabValue, setTabValue] = useState<'map' | 'list'>('map');
 
     const [isRemovingOrgUnits, setIsRemovingOrgUnits] =
         useState<boolean>(false);
@@ -74,6 +74,7 @@ export const InterventionsPlan: FC<Props> = ({
                         title={
                             <InterventionPlanSummary
                                 setTabValue={setTabValue}
+                                tabValue={tabValue}
                             />
                         }
                     />

--- a/js/src/domains/planning/components/interventionPlan/InterventionsPlan.tsx
+++ b/js/src/domains/planning/components/interventionPlan/InterventionsPlan.tsx
@@ -4,7 +4,7 @@ import { Divider, Box, CardHeader, CardContent, Card } from '@mui/material';
 import { UseRemoveManyOrgUnitsFromInterventionPlan } from '../../hooks/UseRemoveOrgUnitFromInterventionPlan';
 import { InterventionPlan } from '../../types/interventions';
 import { InterventionPlanDetails } from './InterventionPlanDetails';
-import { InterventionPlanSummary } from './InterventionplanSummary';
+import { InterventionPlanSummary, TabValue } from './InterventionplanSummary';
 import { InterventionsPlanMap } from './InterventionsPlanMap';
 import { InterventionsPlanTable } from './InterventionsPlanTable';
 
@@ -19,7 +19,7 @@ export const InterventionsPlan: FC<Props> = ({
     interventionPlans,
     isLoadingPlans,
 }) => {
-    const [tabValue, setTabValue] = useState<'map' | 'list'>('map');
+    const [tabValue, setTabValue] = useState<TabValue>('map');
 
     const [isRemovingOrgUnits, setIsRemovingOrgUnits] =
         useState<boolean>(false);

--- a/js/src/domains/planning/components/interventionPlan/InterventionsPlanMap.tsx
+++ b/js/src/domains/planning/components/interventionPlan/InterventionsPlanMap.tsx
@@ -5,6 +5,7 @@ import React, {
     useState,
 } from 'react';
 import { Box, Theme } from '@mui/material';
+import { LoadingSpinner } from 'bluesquare-components';
 import L from 'leaflet';
 import { GeoJSON, MapContainer, Tooltip, ZoomControl } from 'react-leaflet';
 import { Tile } from 'Iaso/components/maps/tools/TilesSwitchControl';
@@ -114,7 +115,7 @@ const getInterventionsGroupLabel = (interventions: Intervention[]) => {
 export const InterventionsPlanMap: FunctionComponent<Props> = ({
     scenarioId,
 }) => {
-    const { data: orgUnits } = useGetOrgUnits();
+    const { data: orgUnits, isLoading: loadingOrgUnits } = useGetOrgUnits();
     const [currentTile] = useState<Tile>(tiles.osm);
 
     const boundsOptions: Record<string, any> = {
@@ -233,6 +234,13 @@ export const InterventionsPlanMap: FunctionComponent<Props> = ({
         });
         return { ...defaultLegendConfig, legend_config: { domain, range } };
     }, [interventionGroupColors]);
+
+    if (loadingOrgUnits)
+        return (
+            <Box height="390px" width="100%" sx={styles.mainBox}>
+                <LoadingSpinner absolute />;
+            </Box>
+        );
 
     return (
         <Box height="390px" width="100%" sx={styles.mainBox}>

--- a/js/src/domains/planning/components/interventionPlan/InterventionsPlanRowTable.tsx
+++ b/js/src/domains/planning/components/interventionPlan/InterventionsPlanRowTable.tsx
@@ -38,7 +38,11 @@ export const InterventionsPlanRowTable: FunctionComponent<Props> = ({
                 }}
             >
                 <Grid container sx={styles.tableCellStyle}>
-                    <Grid item xs={3}>
+                    <Grid
+                        item
+                        xs={3}
+                        sx={{ display: 'flex', alignItems: 'center' }}
+                    >
                         <Typography>{row?.intervention.name}</Typography>
                     </Grid>
                     <Grid item xs={3}>

--- a/js/src/domains/planning/components/map.tsx
+++ b/js/src/domains/planning/components/map.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback, useMemo, useState } from 'react';
-import { Box, Theme } from '@mui/material';
+import { Box, Theme, Typography } from '@mui/material';
 
 import L from 'leaflet';
 import {
@@ -81,7 +81,8 @@ export const Map: FC<Props> = ({
             const metricValue = displayedMetricValues?.find(
                 m => m.org_unit === orgUnitId,
             );
-            return metricValue?.value ?? metricValue?.string_value;
+            const value = metricValue?.value ?? metricValue?.string_value;
+            return value === 0 ? undefined : value;
         },
         [displayedMetricValues],
     );
@@ -161,6 +162,15 @@ export const Map: FC<Props> = ({
                                 }}
                             >
                                 <Tooltip>
+                                    <Typography
+                                        fontSize={12}
+                                        sx={{
+                                            fontWeight: 'bold',
+                                            marginBottom: 0,
+                                        }}
+                                    >
+                                        {orgUnit.name}
+                                    </Typography>
                                     {getSelectedMetricValue(orgUnit.id) ??
                                         'N/A'}
                                 </Tooltip>


### PR DESCRIPTION
On intervention plan, show map by default instead of list

Related JIRA tickets : SNT-134

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

On intervention plan, show map tab by default and make sure org units are loaded before rendering.

## How to test

Go to any scenario, check if in intervention plan section map is shown by default.

## Print screen / video

<img width="770" height="481" alt="image" src="https://github.com/user-attachments/assets/84140421-ff76-4191-a3dd-b070cee6097f" />

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
