### PR TITLE
SNT-136: Improve tooltip on main map when data is missing

### DIFF
--- a/js/src/domains/planning/components/map.tsx
+++ b/js/src/domains/planning/components/map.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback, useMemo, useState } from 'react';
-import { Box, Theme } from '@mui/material';
+import { Box, Theme, Typography } from '@mui/material';
 
 import L from 'leaflet';
 import {
@@ -81,7 +81,8 @@ export const Map: FC<Props> = ({
             const metricValue = displayedMetricValues?.find(
                 m => m.org_unit === orgUnitId,
             );
-            return metricValue?.value ?? metricValue?.string_value;
+            const value = metricValue?.value ?? metricValue?.string_value;
+            return value === 0 ? undefined : value;
         },
         [displayedMetricValues],
     );
@@ -161,6 +162,15 @@ export const Map: FC<Props> = ({
                                 }}
                             >
                                 <Tooltip>
+                                    <Typography
+                                        fontSize={12}
+                                        sx={{
+                                            fontWeight: 'bold',
+                                            marginBottom: 0,
+                                        }}
+                                    >
+                                        {orgUnit.name}
+                                    </Typography>
                                     {getSelectedMetricValue(orgUnit.id) ??
                                         'N/A'}
                                 </Tooltip>


### PR DESCRIPTION
Show org unit name in tooltip of map && fix null value to display N/A

Related JIRA tickets : SNT-136

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc



## Changes

Explain the changes that were made.



## How to test

With a Burkina Faso setup in SNT-Malaria. 
Open a scenario and on main map select "Proportion seeking care in the private sector".
On greyed out areas, hover them, you should see the name of the org unit and N/A.

## Print screen / video

<img width="981" height="436" alt="image" src="https://github.com/user-attachments/assets/19f64717-bc1d-4d3c-849f-af25e93edcef" />


## Notes

PR https://github.com/BLSQ/snt-malaria/pull/81 should be merged first

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
