### PR TITLE
SNT-125 setting page for costs

### DIFF
--- a/js/src/constants/menu.tsx
+++ b/js/src/constants/menu.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormatListBulletedOutlined } from '@mui/icons-material';
+import { FormatListBulletedOutlined, Settings } from '@mui/icons-material';
 
 export const menu = [
     {
@@ -7,5 +7,11 @@ export const menu = [
         key: 'snt_malaria/scenarios/list',
         permissions: [],
         icon: props => <FormatListBulletedOutlined {...props} />,
+    },
+    {
+        label: 'Settings',
+        key: 'snt_malaria/settings',
+        permissions: ['iaso_snt_malaria_admin'],
+        icon: props => <Settings {...props} />,
     },
 ];

--- a/js/src/constants/routes.tsx
+++ b/js/src/constants/routes.tsx
@@ -4,6 +4,7 @@ import { RoutePath } from 'Iaso/constants/routes';
 
 import { Planning } from '../domains/planning';
 import { Scenarios } from '../domains/scenarios';
+import { Settings } from '../domains/settings';
 import { baseUrls } from './urls';
 
 export const planningPath: RoutePath = {
@@ -20,4 +21,11 @@ export const scenariosPath: RoutePath = {
     permissions: [],
 };
 
-export const routes: RoutePath[] = [planningPath, scenariosPath];
+export const settingsPath: RoutePath = {
+    baseUrl: baseUrls.settings,
+    routerUrl: `${baseUrls.settings}/*`,
+    element: <Settings />,
+    permissions: ['iaso_snt_malaria_admin'],
+};
+
+export const routes: RoutePath[] = [planningPath, scenariosPath, settingsPath];

--- a/js/src/constants/translations/en.json
+++ b/js/src/constants/translations/en.json
@@ -36,5 +36,10 @@
     "iaso.snt_malaria.label.resolveConflictDesc": "Some districts already have an intervention from the same group.{br} Choose which one to apply, or decide to apply both.",
     "iaso.snt_malaria.label.selectAll": "Select All",
     "iaso.snt_malaria.label.unselectAll": "Unselect All",
-    "iaso.snt_malaria.label.clearOrgUnitSelection": "Clear selection"
+    "iaso.snt_malaria.label.clearOrgUnitSelection": "Clear selection",
+    "iaso.snt_malaria.settings.title": "Settings",
+    "iaso.snt_malaria.settings.intervention.title": "Intervention Settings",
+    "iaso.snt_malaria.settings.intervention.subtitle": "Set the default cost for each intervention. This cost will be used to calculate the total budget of your intervention plans.",
+    "iaso.snt_malaria.settings.intervention.editCost": "Edit cost"
+
 }

--- a/js/src/constants/translations/fr.json
+++ b/js/src/constants/translations/fr.json
@@ -36,5 +36,9 @@
     "iaso.snt_malaria.label.resolveConflictDesc": "Certains districts ont déjà une intervention du même groupe.{br} Choisissez celle à appliquer, ou décidez d'appliquer les deux.",
     "iaso.snt_malaria.label.selectAll": "Tout sélectionner",
     "iaso.snt_malaria.label.unselectAll": "Tout désélectionner",
-    "iaso.snt_malaria.label.clearOrgUnitSelection": "Effacer la sélection"
+    "iaso.snt_malaria.label.clearOrgUnitSelection": "Effacer la sélection",
+    "iaso.snt_malaria.settings.title": "Paramètres",
+    "iaso.snt_malaria.settings.intervention.title": "Paramètres d'intervention",
+    "iaso.snt_malaria.settings.intervention.subtitle": "Définir le coût par défaut pour chaque intervention. Ce coût sera utilisé pour calculer le budget total de vos plans d'intervention.",
+    "iaso.snt_malaria.settings.intervention.editCost": "Modifier le coût"
 }

--- a/js/src/constants/urls.ts
+++ b/js/src/constants/urls.ts
@@ -15,11 +15,16 @@ export const RouteConfigs: Record<string, RouteConfig> = {
         url: 'snt_malaria/scenarios/list',
         params: [...paginationPathParams],
     },
+    settings: {
+        url: 'snt_malaria/settings',
+        params: [],
+    },
 };
 
 export type BaseUrls = {
     planning: string;
     scenarios: string;
+    settings: string;
 };
 export const baseUrls = extractUrls(RouteConfigs) as BaseUrls;
 export const baseParams = extractParams(RouteConfigs);

--- a/js/src/domains/messages.ts
+++ b/js/src/domains/messages.ts
@@ -5,6 +5,10 @@ export const MESSAGES = defineMessages({
         id: 'iaso.snt_malaria.home.title',
         defaultMessage: 'SNT Malaria',
     },
+    settingsTitle: {
+        id: 'iaso.snt_malaria.settings.title',
+        defaultMessage: 'Settings',
+    },
     layers: {
         id: 'iaso.snt_malaria.label.layers',
         defaultMessage: 'Layers',

--- a/js/src/domains/settings/components/interventionSettings/InterventionSettings.tsx
+++ b/js/src/domains/settings/components/interventionSettings/InterventionSettings.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Box, Card, CardContent, CardHeader, Typography } from '@mui/material';
+import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
+import { useGetInterventionCategories } from '../../../planning/hooks/useGetInterventionCategories';
+import { MESSAGES } from '../../messages';
+
+export const InterventionSettings: React.FC = () => {
+    const { formatMessage } = useSafeIntl();
+
+    const {
+        data: interventionCategories = [],
+        isFetching: isLoadingCategories = true,
+    } = useGetInterventionCategories();
+
+    if (isLoadingCategories) return <LoadingSpinner />;
+
+    return (
+        <Card>
+            <CardHeader
+                title={formatMessage(MESSAGES.interventionsTitle)}
+                subheader={formatMessage(MESSAGES.interventionsSubtitle)}
+                titleTypographyProps={{ variant: 'h6' }}
+                subheaderTypographyProps={{ variant: 'subtitle1' }}
+            ></CardHeader>
+            <CardContent>
+                {interventionCategories.map(category => (
+                    <Box key={category.id} sx={{ marginBottom: 4 }}>
+                        <Typography
+                            variant="subtitle1"
+                            color="textPrimary"
+                            sx={{ marginBottom: 0.5, fontWeight: 'bold' }}
+                        >
+                            {category.name}
+                        </Typography>
+                        {category.interventions.map(intervention => (
+                            <Box
+                                key={intervention.id}
+                                sx={{
+                                    display: 'flex',
+                                    flexDirection: 'row',
+                                    justifyContent: 'space-between',
+                                }}
+                            >
+                                <Typography
+                                    variant="subtitle2"
+                                    color="textSecondary"
+                                >
+                                    {intervention.name}
+                                </Typography>
+                                <Typography
+                                    variant="subtitle2"
+                                    color="textSecondary"
+                                    sx={{ textAlign: 'right' }}
+                                >
+                                    $00.00
+                                </Typography>
+                            </Box>
+                        ))}
+                    </Box>
+                ))}
+            </CardContent>
+        </Card>
+    );
+};

--- a/js/src/domains/settings/components/interventionSettings/InterventionSettings.tsx
+++ b/js/src/domains/settings/components/interventionSettings/InterventionSettings.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import EditIcon from '@mui/icons-material/Edit';
 import { Box, Card, CardContent, CardHeader, Typography } from '@mui/material';
-import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
+import { IconButton, LoadingSpinner, useSafeIntl } from 'bluesquare-components';
 import { useGetInterventionCategories } from '../../../planning/hooks/useGetInterventionCategories';
+import { Intervention } from '../../../planning/types/interventions';
 import { MESSAGES } from '../../messages';
 
 export const InterventionSettings: React.FC = () => {
@@ -13,6 +15,11 @@ export const InterventionSettings: React.FC = () => {
     } = useGetInterventionCategories();
 
     if (isLoadingCategories) return <LoadingSpinner />;
+
+    function onEditInterventionCost(intervention: Intervention): void {
+        console.log('To edit intervention:', intervention.id);
+        throw new Error('Function not implemented.');
+    }
 
     return (
         <Card>
@@ -39,6 +46,7 @@ export const InterventionSettings: React.FC = () => {
                                     display: 'flex',
                                     flexDirection: 'row',
                                     justifyContent: 'space-between',
+                                    alignItems: 'center',
                                 }}
                             >
                                 <Typography
@@ -47,13 +55,32 @@ export const InterventionSettings: React.FC = () => {
                                 >
                                     {intervention.name}
                                 </Typography>
-                                <Typography
-                                    variant="subtitle2"
-                                    color="textSecondary"
-                                    sx={{ textAlign: 'right' }}
+                                <Box
+                                    sx={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                    }}
                                 >
-                                    $00.00
-                                </Typography>
+                                    <Typography
+                                        variant="subtitle2"
+                                        color="textPrimary"
+                                        sx={{
+                                            textAlign: 'right',
+                                            fontWeight: 'bold',
+                                            marginRight: 2,
+                                        }}
+                                    >
+                                        $00.00
+                                    </Typography>
+                                    <IconButton
+                                        onClick={() =>
+                                            onEditInterventionCost(intervention)
+                                        }
+                                        iconSize="small"
+                                        tooltipMessage={MESSAGES.editCost}
+                                        overrideIcon={EditIcon}
+                                    />
+                                </Box>
                             </Box>
                         ))}
                     </Box>

--- a/js/src/domains/settings/index.tsx
+++ b/js/src/domains/settings/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Card, CardContent, CardHeader } from '@mui/material';
+import { useSafeIntl } from 'bluesquare-components';
+import TopBar from 'Iaso/components/nav/TopBarComponent';
+import {
+    ContentsContainer,
+    PageContainer,
+} from '../../components/styledComponents';
+import { MESSAGES } from './messages';
+
+export const Settings: React.FC = () => {
+    const { formatMessage } = useSafeIntl();
+    return (
+        <>
+            <TopBar title={formatMessage(MESSAGES.title)} />
+            <PageContainer>
+                <ContentsContainer>
+                    <Card>
+                        <CardHeader
+                            title={formatMessage(MESSAGES.interventionsTitle)}
+                            subheader={formatMessage(
+                                MESSAGES.interventionsSubtitle,
+                            )}
+                            titleTypographyProps={{ variant: 'h6' }}
+                            subheaderTypographyProps={{ variant: 'subtitle1' }}
+                        ></CardHeader>
+                        <CardContent>
+                            <p>Settings content goes here.</p>
+                        </CardContent>
+                    </Card>
+                </ContentsContainer>
+            </PageContainer>
+        </>
+    );
+};

--- a/js/src/domains/settings/index.tsx
+++ b/js/src/domains/settings/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Card, CardContent, CardHeader } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
 import TopBar from 'Iaso/components/nav/TopBarComponent';
 import {
     ContentsContainer,
     PageContainer,
 } from '../../components/styledComponents';
+import { InterventionSettings } from './components/interventionSettings/InterventionSettings';
 import { MESSAGES } from './messages';
 
 export const Settings: React.FC = () => {
@@ -15,19 +15,7 @@ export const Settings: React.FC = () => {
             <TopBar title={formatMessage(MESSAGES.title)} />
             <PageContainer>
                 <ContentsContainer>
-                    <Card>
-                        <CardHeader
-                            title={formatMessage(MESSAGES.interventionsTitle)}
-                            subheader={formatMessage(
-                                MESSAGES.interventionsSubtitle,
-                            )}
-                            titleTypographyProps={{ variant: 'h6' }}
-                            subheaderTypographyProps={{ variant: 'subtitle1' }}
-                        ></CardHeader>
-                        <CardContent>
-                            <p>Settings content goes here.</p>
-                        </CardContent>
-                    </Card>
+                    <InterventionSettings />
                 </ContentsContainer>
             </PageContainer>
         </>

--- a/js/src/domains/settings/messages.ts
+++ b/js/src/domains/settings/messages.ts
@@ -13,4 +13,8 @@ export const MESSAGES = defineMessages({
         id: 'iaso.snt_malaria.settings.intervention.subtitle',
         defaultMessage: 'Customise and group interventions',
     },
+    editCost: {
+        id: 'iaso.snt_malaria.settings.intervention.editCost',
+        defaultMessage: 'Edit cost',
+    },
 });

--- a/js/src/domains/settings/messages.ts
+++ b/js/src/domains/settings/messages.ts
@@ -1,0 +1,16 @@
+import { defineMessages } from 'react-intl';
+
+export const MESSAGES = defineMessages({
+    title: {
+        id: 'iaso.snt_malaria.settings.title',
+        defaultMessage: 'Settings',
+    },
+    interventionsTitle: {
+        id: 'iaso.snt_malaria.label.interventionTitle',
+        defaultMessage: 'Interventions',
+    },
+    interventionsSubtitle: {
+        id: 'iaso.snt_malaria.settings.intervention.subtitle',
+        defaultMessage: 'Customise and group interventions',
+    },
+});

--- a/js/src/domains/settings/messages.ts
+++ b/js/src/domains/settings/messages.ts
@@ -6,7 +6,7 @@ export const MESSAGES = defineMessages({
         defaultMessage: 'Settings',
     },
     interventionsTitle: {
-        id: 'iaso.snt_malaria.label.interventionTitle',
+        id: 'iaso.snt_malaria.settings.intervention.title',
         defaultMessage: 'Interventions',
     },
     interventionsSubtitle: {


### PR DESCRIPTION
Show interventions settings page

Related JIRA tickets : SNT-125

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Add a settings page for snt_malaria only accessible by admin users.
Settings page list all interventions, display a default cost of 0 and allow to edit the cost.
Edition of cost is not yet implemented and will be in another task.

## How to test

You need an admin account to see nav item.
Open the navigation, check that there is a "settings" entry.
Click it, you should be redirected to a settings page with all interventions grouped per category.
A price for each intervention (which is 0 for now) and an edit icon (which throw a not implemented error).
Translation should be applied as well.

## Print screen / video

<img width="1504" height="778" alt="image" src="https://github.com/user-attachments/assets/f2e07ca4-8550-49c4-9668-fd5431457a1d" />

<img width="1504" height="778" alt="image" src="https://github.com/user-attachments/assets/26da634f-411a-4672-b0f5-739f3a3199fa" />

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
