### PR TITLE
Snt 141 fix ordinal string legend map color

### DIFF
--- a/js/src/constants/translations/en.json
+++ b/js/src/constants/translations/en.json
@@ -36,5 +36,7 @@
     "iaso.snt_malaria.label.resolveConflictDesc": "Some districts already have an intervention from the same group.{br} Choose which one to apply, or decide to apply both.",
     "iaso.snt_malaria.label.selectAll": "Select All",
     "iaso.snt_malaria.label.unselectAll": "Unselect All",
-    "iaso.snt_malaria.label.clearOrgUnitSelection": "Clear selection"
+    "iaso.snt_malaria.label.clearOrgUnitSelection": "Clear selection",
+    "iaso.snt_malaria.metrics.seasonal": "Seasonal",
+    "iaso.snt_malaria.metrics.not-seasonal": "Not seasonal"
 }

--- a/js/src/constants/translations/fr.json
+++ b/js/src/constants/translations/fr.json
@@ -36,5 +36,7 @@
     "iaso.snt_malaria.label.resolveConflictDesc": "Certains districts ont déjà une intervention du même groupe.{br} Choisissez celle à appliquer, ou décidez d'appliquer les deux.",
     "iaso.snt_malaria.label.selectAll": "Tout sélectionner",
     "iaso.snt_malaria.label.unselectAll": "Tout désélectionner",
-    "iaso.snt_malaria.label.clearOrgUnitSelection": "Effacer la sélection"
+    "iaso.snt_malaria.label.clearOrgUnitSelection": "Effacer la sélection",
+    "iaso.snt_malaria.metrics.seasonal": "Saisonnier",
+    "iaso.snt_malaria.metrics.not-seasonal": "Pas Saisonnier"
 }

--- a/js/src/domains/messages.ts
+++ b/js/src/domains/messages.ts
@@ -162,4 +162,12 @@ export const MESSAGES = defineMessages({
         id: 'iaso.snt_malaria.label.unselectAll',
         defaultMessage: 'Unselect All',
     },
+    seasonal: {
+        id: 'iaso_snt_malaria.metrics.seasonal',
+        defaultMessage: 'Seasonal',
+    },
+    'not-seasonal': {
+        id: 'iaso_snt_malaria.metrics.not-seasonal',
+        defaultMessage: 'Not Seasonal',
+    },
 });

--- a/js/src/domains/messages.ts
+++ b/js/src/domains/messages.ts
@@ -163,11 +163,11 @@ export const MESSAGES = defineMessages({
         defaultMessage: 'Unselect All',
     },
     seasonal: {
-        id: 'iaso_snt_malaria.metrics.seasonal',
+        id: 'iaso.snt_malaria.metrics.seasonal',
         defaultMessage: 'Seasonal',
     },
     'not-seasonal': {
-        id: 'iaso_snt_malaria.metrics.not-seasonal',
+        id: 'iaso.snt_malaria.metrics.not-seasonal',
         defaultMessage: 'Not Seasonal',
     },
 });

--- a/js/src/domains/planning/components/map.tsx
+++ b/js/src/domains/planning/components/map.tsx
@@ -16,7 +16,7 @@ import { OrgUnit } from 'Iaso/domains/orgUnits/types/orgUnit';
 import { SxStyles } from 'Iaso/types/general';
 import { Bounds } from 'Iaso/utils/map/mapUtils';
 import { mapTheme } from '../../../constants/map-theme';
-import { getStyleForShape } from '../libs/map-utils';
+import { getStyleForShape, useGetOrgUnitMetric } from '../libs/map-utils';
 import { MetricsFilters, MetricType, MetricValue } from '../types/metrics';
 import { MapLegend } from './MapLegend';
 import { MapOrgUnitDetails } from './MapOrgUnitDetails';
@@ -76,16 +76,7 @@ export const Map: FC<Props> = ({
     }, [orgUnits]);
 
     // Displaying metrics on the map
-    const getSelectedMetricValue = useCallback(
-        (orgUnitId: number) => {
-            const metricValue = displayedMetricValues?.find(
-                m => m.org_unit === orgUnitId,
-            );
-            const value = metricValue?.value ?? metricValue?.string_value;
-            return value === 0 ? undefined : value;
-        },
-        [displayedMetricValues],
-    );
+    const getSelectedMetric = useGetOrgUnitMetric(displayedMetricValues);
 
     // Selecting an org unit on the map
     const [clickedOrgUnit, setClickedOrgUnit] = useState<OrgUnit | null>(null);
@@ -108,21 +99,16 @@ export const Map: FC<Props> = ({
 
     const getMapStyleForOrgUnit = useCallback(
         (orgUnitId: number) => {
-            const selectedMetricValue = getSelectedMetricValue(orgUnitId);
+            const selectedMetric = getSelectedMetric(orgUnitId);
             return getStyleForShape(
-                selectedMetricValue,
+                selectedMetric?.value,
                 displayedMetric?.legend_type,
                 displayedMetric?.legend_config,
                 orgUnitId === clickedOrgUnit?.id,
                 orgUnitIdsOnMap.includes(orgUnitId),
             );
         },
-        [
-            getSelectedMetricValue,
-            displayedMetric,
-            clickedOrgUnit,
-            orgUnitIdsOnMap,
-        ],
+        [getSelectedMetric, displayedMetric, clickedOrgUnit, orgUnitIdsOnMap],
     );
 
     return (
@@ -171,7 +157,7 @@ export const Map: FC<Props> = ({
                                     >
                                         {orgUnit.name}
                                     </Typography>
-                                    {getSelectedMetricValue(orgUnit.id) ??
+                                    {getSelectedMetric(orgUnit.id)?.label ??
                                         'N/A'}
                                 </Tooltip>
                             </GeoJSON>

--- a/js/src/domains/planning/components/maps/SideMap.tsx
+++ b/js/src/domains/planning/components/maps/SideMap.tsx
@@ -18,7 +18,7 @@ import { Bounds } from 'Iaso/utils/map/mapUtils';
 
 import { mapTheme } from '../../../../constants/map-theme';
 import { useGetMetricValues } from '../../hooks/useGetMetrics';
-import { getStyleForShape } from '../../libs/map-utils';
+import { getStyleForShape, useGetOrgUnitMetric } from '../../libs/map-utils';
 import { MetricType } from '../../types/metrics';
 import { MapLegend } from '../MapLegend';
 import { LayerSelect } from './LayerSelect';
@@ -70,28 +70,20 @@ export const SideMap: FC<Props> = ({ orgUnits, initialDisplayedMetric }) => {
     const { data: displayedMetricValues } = useGetMetricValues({
         metricTypeId: displayedMetric?.id || null,
     });
-    const getSelectedMetricValue = useCallback(
-        (orgUnitId: number) => {
-            const metricValue = displayedMetricValues?.find(
-                m => m.org_unit === orgUnitId,
-            );
-            return metricValue?.value;
-        },
-        [displayedMetricValues],
-    );
+    const getSelectedMetric = useGetOrgUnitMetric(displayedMetricValues);
 
     // Selecting an org unit on the map
 
     const getMapStyleForOrgUnit = useCallback(
         (orgUnitId: number) => {
-            const selectedMetricValue = getSelectedMetricValue(orgUnitId);
+            const selectedMetric = getSelectedMetric(orgUnitId);
             return getStyleForShape(
-                selectedMetricValue,
+                selectedMetric?.value,
                 displayedMetric?.legend_type,
                 displayedMetric?.legend_config,
             );
         },
-        [getSelectedMetricValue, displayedMetric],
+        [getSelectedMetric, displayedMetric],
     );
 
     return (
@@ -119,7 +111,9 @@ export const SideMap: FC<Props> = ({ orgUnits, initialDisplayedMetric }) => {
                         style={getMapStyleForOrgUnit(orgUnit.id)}
                         data={orgUnit.geo_json as unknown as GeoJson}
                     >
-                        <Tooltip>{getSelectedMetricValue(orgUnit.id)}</Tooltip>
+                        <Tooltip>
+                            {getSelectedMetric(orgUnit.id)?.label}
+                        </Tooltip>
                     </GeoJSON>
                 ))}
                 {displayedMetric && (

--- a/js/src/domains/planning/libs/map-utils.tsx
+++ b/js/src/domains/planning/libs/map-utils.tsx
@@ -2,7 +2,10 @@ import { hslToRgb } from '@mui/material';
 import { scaleThreshold } from '@visx/scale';
 import * as d3 from 'd3-scale';
 import { mapTheme } from '../../../constants/map-theme';
-import { ScaleDomainRange } from '../types/metrics';
+import { MESSAGES } from '../../messages';
+import { MetricValue, ScaleDomainRange } from '../types/metrics';
+import { useSafeIntl } from 'bluesquare-components';
+import { useCallback } from 'react';
 
 export const defaultLegend = '#999999';
 export const maxHue = 350;
@@ -123,4 +126,41 @@ export const getStyleForShape = (
             getColorForShape(value, legend_type, legend_config),
         fillOpacity: 1,
     };
+};
+
+export const useGetOrgUnitMetric = (
+    displayedMetricValues: MetricValue[] | undefined,
+) => {
+    const { formatMessage } = useSafeIntl();
+
+    return useCallback(
+        (orgUnitId: number) => {
+            if (!displayedMetricValues) {
+                return undefined;
+            }
+
+            const metricValue = displayedMetricValues.find(
+                m => m.org_unit === orgUnitId,
+            );
+
+            if (!metricValue) {
+                return undefined;
+            }
+
+            if (metricValue.value) {
+                return { label: metricValue.value, value: metricValue.value };
+            }
+
+            if (!metricValue.string_value) {
+                return undefined;
+            }
+
+            const metricLabel = MESSAGES[metricValue.string_value]
+                ? formatMessage(MESSAGES[metricValue.string_value])
+                : metricValue.string_value;
+
+            return { value: metricValue.string_value, label: metricLabel };
+        },
+        [formatMessage, displayedMetricValues],
+    );
 };

--- a/js/src/domains/planning/libs/map-utils.tsx
+++ b/js/src/domains/planning/libs/map-utils.tsx
@@ -61,7 +61,10 @@ const getColorForShape = (
     }
 
     if (legend_type === 'ordinal') {
-        const index = legend_config.domain.indexOf(value as never);
+        const index = legend_config.domain.findIndex(
+            (d: string | number) => d.toString() === value.toString(),
+        );
+
         return legend_config.range[index] ?? defaultLegend;
     }
 


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : SNT-141

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- String comparison on metric values and metric scales
- Translate labels if string_value

## How to test

### Seasonal and Not seasonal fix

On snt_malaria with a DRC account, get latest version from OH: 
Go here, http://localhost:8081/snt_malaria/import_openhexa_metrics/
Use drc-snt-data-pre-processing as workspace slug
And snt-results as dataset slug.
Select your DRC account.

Once done, go here: http://localhost:8081/dashboard/snt_malaria/scenarios/list/accountId/1/
Select or create a scenario for that account and on main map and side maps, select Saisonalité des précipitations.
On the map, over a org unit with a seasonal value and not-seasonal value.
Tooltip should show a label "Seasonal" or "Not Seasonal".
And if you change language, it should be translated.

### Ordinal numeric value fix

Got to a scenario, select on main map: Durée de la période saisonnière de transmission
It should apply colors properly on main map and side maps.


## Print screen / video

### Seasonal and Not Seasonal
<img width="1496" height="518" alt="image" src="https://github.com/user-attachments/assets/e147e43b-68ed-48e2-b584-b4b84ec3089f" />

<img width="1496" height="518" alt="image" src="https://github.com/user-attachments/assets/64f5f402-7c8a-4b90-977f-a349df77984d" />

### Durée de la période saisonnière de transmission

<img width="1496" height="518" alt="image" src="https://github.com/user-attachments/assets/897060ab-9dcb-41a4-ba8d-3a4c09dc943a" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
