### PR TITLE
chore: Improve the run-name of the GitHub deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,5 @@
 name: Deploy SNT Malaria Web App
+run-name: Deploy SNT ${{ inputs.branch }} (IASO ${{ inputs.iaso_ref }}) to ${{ inputs.environment }} by @${{ github.actor }}
 
 on:
     workflow_dispatch:


### PR DESCRIPTION
See docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#run-name

This will hopefully make the actions list more useful than:
<img width="2619" height="1857" alt="image" src="https://github.com/user-attachments/assets/b291bf99-3071-452f-8ec4-1ded6884d048" />
