### PR TITLE
feat: SNT-149 refine map zoom step size

### DIFF
--- a/js/src/domains/planning/components/interventionPlan/InterventionsPlanMap.tsx
+++ b/js/src/domains/planning/components/interventionPlan/InterventionsPlanMap.tsx
@@ -16,7 +16,12 @@ import { Bounds } from 'Iaso/utils/map/mapUtils';
 import { mapTheme } from '../../../../constants/map-theme';
 import { useGetInterventionAssignments } from '../../hooks/UseGetInterventionAssignments';
 import { useGetOrgUnits } from '../../hooks/useGetOrgUnits';
-import { defaultLegend, getColorRange } from '../../libs/map-utils';
+import {
+    defaultLegend,
+    defaultZoomDelta,
+    defaultZoomSnap,
+    getColorRange,
+} from '../../libs/map-utils';
 import { Intervention, InterventionPlan } from '../../types/interventions';
 import { MapLegend } from '../MapLegend';
 import { InterventionSelect } from './InterventionSelect';
@@ -259,6 +264,8 @@ export const InterventionsPlanMap: FunctionComponent<Props> = ({
                 zoomControl={false}
                 boundsOptions={boundsOptions}
                 bounds={bounds}
+                zoomSnap={defaultZoomSnap}
+                zoomDelta={defaultZoomDelta}
             >
                 <ZoomControl
                     position="bottomright"

--- a/js/src/domains/planning/components/map.tsx
+++ b/js/src/domains/planning/components/map.tsx
@@ -135,6 +135,8 @@ export const Map: FC<Props> = ({
                         bounds={bounds}
                         boundsOptions={boundsOptions}
                         zoomControl={false}
+                        zoomSnap={0.25}
+                        zoomDelta={0.5}
                     >
                         <ZoomControl position="bottomright" />
                         <TileLayer url="" attribution="" />

--- a/js/src/domains/planning/components/map.tsx
+++ b/js/src/domains/planning/components/map.tsx
@@ -16,7 +16,12 @@ import { OrgUnit } from 'Iaso/domains/orgUnits/types/orgUnit';
 import { SxStyles } from 'Iaso/types/general';
 import { Bounds } from 'Iaso/utils/map/mapUtils';
 import { mapTheme } from '../../../constants/map-theme';
-import { getStyleForShape, useGetOrgUnitMetric } from '../libs/map-utils';
+import {
+    defaultZoomDelta,
+    defaultZoomSnap,
+    getStyleForShape,
+    useGetOrgUnitMetric,
+} from '../libs/map-utils';
 import { MetricsFilters, MetricType, MetricValue } from '../types/metrics';
 import { MapLegend } from './MapLegend';
 import { MapOrgUnitDetails } from './MapOrgUnitDetails';
@@ -135,8 +140,8 @@ export const Map: FC<Props> = ({
                         bounds={bounds}
                         boundsOptions={boundsOptions}
                         zoomControl={false}
-                        zoomSnap={0.25}
-                        zoomDelta={0.5}
+                        zoomSnap={defaultZoomSnap}
+                        zoomDelta={defaultZoomDelta}
                     >
                         <ZoomControl position="bottomright" />
                         <TileLayer url="" attribution="" />

--- a/js/src/domains/planning/components/maps/SideMap.tsx
+++ b/js/src/domains/planning/components/maps/SideMap.tsx
@@ -18,7 +18,12 @@ import { Bounds } from 'Iaso/utils/map/mapUtils';
 
 import { mapTheme } from '../../../../constants/map-theme';
 import { useGetMetricValues } from '../../hooks/useGetMetrics';
-import { getStyleForShape, useGetOrgUnitMetric } from '../../libs/map-utils';
+import {
+    defaultZoomDelta,
+    defaultZoomSnap,
+    getStyleForShape,
+    useGetOrgUnitMetric,
+} from '../../libs/map-utils';
 import { MetricType } from '../../types/metrics';
 import { MapLegend } from '../MapLegend';
 import { LayerSelect } from './LayerSelect';
@@ -102,6 +107,8 @@ export const SideMap: FC<Props> = ({ orgUnits, initialDisplayedMetric }) => {
                 bounds={bounds}
                 boundsOptions={boundsOptions}
                 zoomControl={false}
+                zoomSnap={defaultZoomSnap}
+                zoomDelta={defaultZoomDelta}
             >
                 <ZoomControl position="bottomright" />
                 <TileLayer url="" attribution="" />

--- a/js/src/domains/planning/libs/map-utils.tsx
+++ b/js/src/domains/planning/libs/map-utils.tsx
@@ -9,6 +9,8 @@ import { useCallback } from 'react';
 
 export const defaultLegend = '#999999';
 export const maxHue = 350;
+export const defaultZoomSnap = 0.25;
+export const defaultZoomDelta = 0.5;
 
 export const getColorRange = (count: number = 1) => {
     const colorStep = Math.round(maxHue / count);


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : SNT-149

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Zoom steps on map are smaller to give more control

## How to test

Go to snt malaria, zoom on maps and verify that zoom step is not too big

## Print screen / video

Before:


https://github.com/user-attachments/assets/0f02f38c-a9a7-44aa-a01a-e28a7fc3465e


Now:


https://github.com/user-attachments/assets/ec26505d-79e7-40a1-b85a-86168e4f9921



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
