### PR TITLE
SNT-150: Allow query less or equal

### DIFF
--- a/js/src/domains/planning/components/maps/FilterQueryBuilder.tsx
+++ b/js/src/domains/planning/components/maps/FilterQueryBuilder.tsx
@@ -55,7 +55,7 @@ export const FilterQueryBuilder: FC<Props> = ({
         return {
             label,
             type: 'number',
-            operators: ['greater_or_equal'],
+            operators: ['less_or_equal', 'greater_or_equal'],
             defaultOperator: 'greater_or_equal',
             valueSources: ['value'],
         };


### PR DESCRIPTION
Allow to filter with operator less_or_equal

Related JIRA tickets : SNT-150

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Add less_or_equal operator support when filtering districts.
Back was already able to handle this condition.

## How to test

Go to snt_malaria, a scenario for RDC (République du Congo).
On the filter in the main map, select population total field.
Use less or equal operator and enter 200000 for example.
Selected district should match.

You can play with different combinations if you want.

## Print screen / video

<img width="1459" height="525" alt="image" src="https://github.com/user-attachments/assets/d77d7ae6-5004-42f8-850c-db5d3f49fdb3" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
