### PR TITLE
feat: SNT-151 Empty selection when filter doesn't return anything

### DIFF
--- a/js/src/domains/planning/index.tsx
+++ b/js/src/domains/planning/index.tsx
@@ -107,7 +107,6 @@ export const Planning: FC = () => {
                 ),
             );
         } else {
-            setSelectionOnMap([]);
             openSnackBar({
                 messageKey: 'warning',
                 id: 'noOrgUnitsSelected',


### PR DESCRIPTION
When applying filter on map, if no org unit match with the filer, clear the selection

Related JIRA tickets : SNT-151

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

## Changes

When a filter was applied and no org unit matches it, we were keeping previous selections.
Changes that to set selected org unit to an empty array.

## How to test

Go to snt_malaria, open a scenario, on map, apply a filter that matches some org units and apply it.
It should work and select them.
Now add another filter that will return no value, such as a population filter > 1000000000. 
A warning message is shown and the selection is cleared.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
