### PR TITLE
SNT-142: re-fetch scenario on title change

### DIFF
--- a/js/src/domains/planning/components/ScenarioTopBar.tsx
+++ b/js/src/domains/planning/components/ScenarioTopBar.tsx
@@ -83,7 +83,7 @@ export const ScenarioTopBar: FC<Props> = ({ scenario }) => {
     const [isEditing, setIsEditing] = useState(false);
     const [tempName, setTempName] = useState(scenario.name);
 
-    const { mutateAsync: updateScenario } = useUpdateScenario();
+    const { mutateAsync: updateScenario } = useUpdateScenario(scenario.id);
     const { mutateAsync: deleteScenario } = useDeleteScenario(() => {
         navigate('/');
     });
@@ -125,10 +125,9 @@ export const ScenarioTopBar: FC<Props> = ({ scenario }) => {
     const handleSubmit = () => {
         if (tempName.trim() !== '') {
             updateScenario({ ...scenario, name: tempName });
-            setIsEditing(false);
-        } else {
-            setIsEditing(false);
         }
+
+        setIsEditing(false);
     };
 
     if (scenario) {

--- a/js/src/domains/scenarios/hooks/useGetScenarios.tsx
+++ b/js/src/domains/scenarios/hooks/useGetScenarios.tsx
@@ -61,11 +61,11 @@ export const useCreateScenario = (): UseMutationResult => {
     });
 };
 
-export const useUpdateScenario = (): UseMutationResult =>
+export const useUpdateScenario = (scenarioId): UseMutationResult =>
     useSnackMutation({
         mutationFn: (body: Scenario) =>
-            putRequest(`/api/snt_malaria/scenarios/${body.id}/`, body),
-        invalidateQueryKey: ['scenarios'],
+            putRequest(`/api/snt_malaria/scenarios/${scenarioId}/`, body),
+        invalidateQueryKey: ['scenarios', 'scenario', scenarioId],
     });
 
 export const useDuplicateScenario = (


### PR DESCRIPTION
When updating scenario name, name is not refreshed in the view.

Related JIRA tickets : SNT-142

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc


## Changes

Invalidate scenario key when scenario name is update to trigger a re-fetch

## How to test

Go to a scenario, edit the name, new value should be shown

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
