### PR TITLE
SNT-147: Validate name and show error

### DIFF
--- a/api/scenarios/serializers.py
+++ b/api/scenarios/serializers.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 from iaso.api.common import UserSerializer
@@ -23,6 +24,19 @@ class ScenarioSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
 
+    def validate_name(self, value):
+        if not value:
+            raise serializers.ValidationError(_("Name cannot be empty."))
+
+        existingScenarios = Scenario.objects.filter(
+            name=value, account=self.context["request"].user.iaso_profile.account
+        )
+
+        if existingScenarios.exists():
+            raise serializers.ValidationError(_("Scenario with this name already exists."))
+
+        return value
+
 
 class DuplicateScenarioSerializer(serializers.Serializer):
     id_to_duplicate = serializers.IntegerField()
@@ -32,6 +46,6 @@ class DuplicateScenarioSerializer(serializers.Serializer):
         account = request.user.iaso_profile.account
 
         if not Scenario.objects.filter(id=value, account=account).exists():
-            raise serializers.ValidationError("Scenario with this ID does not exist.")
+            raise serializers.ValidationError(_("Scenario with this ID does not exist."))
 
         return value

--- a/js/src/domains/planning/components/ScenarioTopBar.tsx
+++ b/js/src/domains/planning/components/ScenarioTopBar.tsx
@@ -83,7 +83,7 @@ export const ScenarioTopBar: FC<Props> = ({ scenario }) => {
     const [isEditing, setIsEditing] = useState(false);
     const [tempName, setTempName] = useState(scenario.name);
 
-    const { mutateAsync: updateScenario } = useUpdateScenario(scenario.id);
+    const { mutate: updateScenario } = useUpdateScenario(scenario.id);
     const { mutateAsync: deleteScenario } = useDeleteScenario(() => {
         navigate('/');
     });

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-22 13:02+0000\n"
+"POT-Creation-Date: 2025-09-23 12:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -42,3 +42,16 @@ msgstr "Support"
 #: plugins/snt_malaria/models/cost_breakdown.py
 msgid "Other"
 msgstr "Autre"
+
+#: plugins/snt_malaria/api/scenarios/serializers.py
+msgid "Name cannot be empty."
+msgstr "Le nom doit être défini"
+
+#: plugins/snt_malaria/api/scenarios/serializers.py
+msgid "Scenario with this name already exists."
+msgstr "Un scénario avec ce nom existe déjà"
+
+#: plugins/snt_malaria/api/scenarios/serializers.py
+msgid "Scenario with this ID does not exist."
+msgstr "Aucun scénario pour cet ID"
+

--- a/tests/api/test_scenarios.py
+++ b/tests/api/test_scenarios.py
@@ -19,6 +19,12 @@ class ScenarioAPITestCase(APITestCase):
             name="Test Scenario",
             description="A test scenario description.",
         )
+        cls.scenario2 = Scenario.objects.create(
+            account=cls.account,
+            created_by=cls.user,
+            name="Test Scenario 2",
+            description="A test scenario 2 description.",
+        )
 
         # Create intervention categories
         cls.int_category_vaccination = InterventionCategory.objects.create(
@@ -81,11 +87,15 @@ class ScenarioAPITestCase(APITestCase):
         url = reverse("scenarios-list")
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 1)
-        scenario = response.data[0]
+        self.assertEqual(len(response.data), 2)
+        scenario = next(item for item in response.data if item["id"] == self.scenario.id)
         self.assertEqual(scenario["name"], "Test Scenario")
         self.assertEqual(scenario["description"], "A test scenario description.")
         self.assertEqual(scenario["created_by"]["id"], self.user.id)
+        scenario2 = next(item for item in response.data if item["id"] == self.scenario2.id)
+        self.assertEqual(scenario2["name"], "Test Scenario 2")
+        self.assertEqual(scenario2["description"], "A test scenario 2 description.")
+        self.assertEqual(scenario2["created_by"]["id"], self.user.id)
 
     def test_scenario_retrieve(self):
         url = reverse("scenarios-detail", args=[self.scenario.id])
@@ -99,13 +109,13 @@ class ScenarioAPITestCase(APITestCase):
         url = reverse("scenarios-list")
         response = self.client.post(url, {"name": "New Scenario"}, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(Scenario.objects.count(), 2)
+        self.assertEqual(Scenario.objects.count(), 3)
         new_scenario = Scenario.objects.latest("id")
         self.assertEqual(new_scenario.name, "New Scenario")
         self.assertEqual(new_scenario.account, self.account)
         self.assertEqual(new_scenario.created_by, self.user)
 
-    def test_scenario_updat(self):
+    def test_scenario_update(self):
         url = reverse("scenarios-detail", args=[self.scenario.id])
         payload = {"id": self.scenario.id, "name": "Updated Scenario Name"}
         response = self.client.put(url, payload, format="json")
@@ -113,11 +123,19 @@ class ScenarioAPITestCase(APITestCase):
         self.scenario.refresh_from_db()
         self.assertEqual(self.scenario.name, "Updated Scenario Name")
 
+    def test_scenario_update_name_already_taken(self):
+        url = reverse("scenarios-detail", args=[self.scenario.id])
+        payload = {"id": self.scenario.id, "name": "Test Scenario 2"}
+        response = self.client.put(url, payload, format="json")
+        jsonResponse = self.assertJSONResponse(response, status.HTTP_400_BAD_REQUEST)
+        print(jsonResponse)
+        self.assertEqual(jsonResponse, {"name": ["Scenario with this name already exists."]})
+
     def test_scenario_duplicate_success(self):
         url = reverse("scenarios-duplicate")
         response = self.client.post(url, {"id_to_duplicate": self.scenario.id}, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(Scenario.objects.count(), 2)
+        self.assertEqual(Scenario.objects.count(), 3)
         duplicated_scenario = Scenario.objects.latest("id")
         self.assertIn(f"Copy of {self.scenario.name}", duplicated_scenario.name)
         self.assertEqual(duplicated_scenario.intervention_assignments.count(), 3)
@@ -127,7 +145,7 @@ class ScenarioAPITestCase(APITestCase):
         response = self.client.post(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(str(response.data["id_to_duplicate"][0]), "This field is required.")
-        self.assertEqual(Scenario.objects.count(), 1)
+        self.assertEqual(Scenario.objects.count(), 2)
 
     def test_scenario_duplicate_multiple_times_success(self):
         url = reverse("scenarios-duplicate")
@@ -135,7 +153,7 @@ class ScenarioAPITestCase(APITestCase):
         # First duplication
         response = self.client.post(url, {"id_to_duplicate": self.scenario.id}, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(Scenario.objects.count(), 2)
+        self.assertEqual(Scenario.objects.count(), 3)
         duplicated_scenario = Scenario.objects.latest("id")
 
         self.assertIn(f"Copy of {self.scenario.name}", duplicated_scenario.name)
@@ -144,7 +162,7 @@ class ScenarioAPITestCase(APITestCase):
         # Second duplication
         response = self.client.post(url, {"id_to_duplicate": self.scenario.id}, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(Scenario.objects.count(), 3)
+        self.assertEqual(Scenario.objects.count(), 4)
         duplicated_scenario = Scenario.objects.latest("id")
 
         self.assertIn(f"Copy of {self.scenario.name}", duplicated_scenario.name)


### PR DESCRIPTION
Validate name when updating scenario

Related JIRA tickets : SNT-147

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

We have currently a Sentry error when we try to use update the name of a scenario if it already exists.
Handling the error et showing a clean error message. 

## How to test

Create a scenario, then modify the name to  Scenario 1
Create a second scenario, rename it to be Scenario 2
Got to Scenario 1 and rename it to Scenario 2, a snack error should be shown.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
