### PR TITLE
Fix SNT-410: org unit filtering for interventions

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -195,6 +195,6 @@ class ImpactOrgUnitMappingAdmin(admin.ModelAdmin):
 
 @admin.register(AccountSettings)
 class AccountSettingsAdmin(admin.ModelAdmin):
-    list_display = ("id", "account", "intervention_org_unit_type_id")
+    list_display = ("id", "account", "focus_org_unit_type_id", "intervention_org_unit_type_id")
     search_fields = ("account__name",)
     ordering = ("account__name",)

--- a/api/account_settings/serializers.py
+++ b/api/account_settings/serializers.py
@@ -9,6 +9,7 @@ class AccountSettingsSerializer(serializers.ModelSerializer):
         fields = [
             "id",
             "account",
+            "focus_org_unit_type_id",
             "intervention_org_unit_type_id",
         ]
         read_only_fields = [

--- a/api/scenario_rules/serializers.py
+++ b/api/scenario_rules/serializers.py
@@ -4,9 +4,9 @@ from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 
 from iaso.models import MetricType, OrgUnit
-from iaso.utils.org_units import get_valid_org_units_with_geography
 from iaso.utils.serializer.json_schema_field import JSONSchemaField
 from plugins.snt_malaria.models import Scenario, ScenarioRule
+from plugins.snt_malaria.models.account_settings import get_intervention_org_units
 from plugins.snt_malaria.models.scenario import (
     SCENARIO_RULE_MATCHING_CRITERIA_SCHEMA,
     ScenarioRuleInterventionProperties,
@@ -138,7 +138,7 @@ class ScenarioRuleWriteSerializerBase(serializers.ModelSerializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         user = self.context["request"].user
-        org_units = get_valid_org_units_with_geography(user.iaso_profile.account)
+        org_units = get_intervention_org_units(user.iaso_profile.account)
         self.fields["org_units_excluded"].child.queryset = org_units
         self.fields["org_units_included"].child.queryset = org_units
         self.fields["org_units_scope"].child.queryset = org_units

--- a/api/scenarios/serializers.py
+++ b/api/scenarios/serializers.py
@@ -4,12 +4,9 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 from iaso.api.common import UserSerializer
-from iaso.utils.org_units import get_valid_org_units_with_geography
-from plugins.snt_malaria.api.scenarios.utils import (
-    get_interventions,
-    get_missing_headers,
-)
+from plugins.snt_malaria.api.scenarios.utils import get_interventions, get_missing_headers
 from plugins.snt_malaria.models import Scenario, ScenarioRule
+from plugins.snt_malaria.models.account_settings import get_intervention_org_units
 
 
 class ScenarioSerializer(serializers.ModelSerializer):
@@ -94,7 +91,7 @@ class ImportScenarioSerializer(serializers.Serializer):
         header_errors = get_missing_headers(df, interventions)
 
         csv_org_unit_ids = set(df["org_unit_id"].dropna().astype(int).unique().tolist())
-        org_units = get_valid_org_units_with_geography(request.user.iaso_profile.account)
+        org_units = get_intervention_org_units(request.user.iaso_profile.account)
         available_org_unit_ids = set(org_units.values_list("id", flat=True))
         not_found_org_units = csv_org_unit_ids - available_org_unit_ids
         missing_org_units_from_file = available_org_unit_ids - csv_org_unit_ids

--- a/api/scenarios/views.py
+++ b/api/scenarios/views.py
@@ -14,7 +14,6 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from iaso.api.common import CONTENT_TYPE_CSV
-from iaso.utils.org_units import get_valid_org_units_with_geography
 from plugins.snt_malaria.api.scenarios.utils import (
     create_rules_from_import,
     duplicate_rules,
@@ -23,6 +22,7 @@ from plugins.snt_malaria.api.scenarios.utils import (
     get_scenario,
 )
 from plugins.snt_malaria.models import InterventionAssignment, Scenario, ScenarioRule
+from plugins.snt_malaria.models.account_settings import get_intervention_org_units
 from plugins.snt_malaria.models.intervention import Intervention
 
 from .permissions import ScenarioPermission
@@ -118,7 +118,7 @@ class ScenarioViewSet(viewsets.ModelViewSet):
             intervention_category__account=self.request.user.iaso_profile.account
         )
 
-        org_units = get_valid_org_units_with_geography(self.request.user.iaso_profile.account).order_by("name")
+        org_units = get_intervention_org_units(self.request.user.iaso_profile.account).order_by("name")
 
         assignments = (
             InterventionAssignment.objects.select_related("org_unit", "intervention").filter(scenario__id=scenario_id)

--- a/js/src/components/OrgUnitSelect.tsx
+++ b/js/src/components/OrgUnitSelect.tsx
@@ -30,7 +30,7 @@ export const OrgUnitSelect: FC<Props> = ({
     const { data: accountSettings } = useGetAccountSettings();
 
     const { data: orgUnitsByType, isLoading: isLoadingOrgUnits } =
-        useGetOrgUnitsByType(accountSettings?.intervention_org_unit_type_id);
+        useGetOrgUnitsByType(accountSettings?.focus_org_unit_type_id);
 
     const handleOrgUnitChange = (e: SelectChangeEvent<number>) => {
         const id = e.target.value as number;

--- a/js/src/domains/planning/types/accountSettings.ts
+++ b/js/src/domains/planning/types/accountSettings.ts
@@ -1,4 +1,5 @@
 export type AccountSettings = {
     id: number;
+    focus_org_unit_type_id?: number;
     intervention_org_unit_type_id?: number;
 };

--- a/migrations/0032_rename_and_add_org_unit_type_fields.py
+++ b/migrations/0032_rename_and_add_org_unit_type_fields.py
@@ -1,0 +1,55 @@
+import django.db.models.deletion
+
+from django.db import migrations, models
+
+
+def copy_to_focus_org_unit_type(apps, schema_editor):
+    AccountSettings = apps.get_model("snt_malaria", "AccountSettings")
+    for settings in AccountSettings.objects.filter(intervention_org_unit_type__isnull=False):
+        settings.focus_org_unit_type = settings.intervention_org_unit_type
+        settings.save(update_fields=["focus_org_unit_type"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("snt_malaria", "0031_allow_nullable_matching_criteria"),
+    ]
+
+    operations = [
+        # 1. Add the new focus field (starts NULL).
+        migrations.AddField(
+            model_name="accountsettings",
+            name="focus_org_unit_type",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Higher-level org unit type (e.g. regions) used to focus/zoom the map.",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="iaso.orgunittype",
+            ),
+        ),
+        # 2. Copy existing values: old intervention_org_unit_type -> focus_org_unit_type.
+        migrations.RunPython(copy_to_focus_org_unit_type, migrations.RunPython.noop),
+        # 3. Drop the old field (and its index) cleanly.
+        migrations.RemoveField(
+            model_name="accountsettings",
+            name="intervention_org_unit_type",
+        ),
+        # 4. Re-add intervention_org_unit_type with its new meaning (deployment level).
+        migrations.AddField(
+            model_name="accountsettings",
+            name="intervention_org_unit_type",
+            field=models.ForeignKey(
+                blank=True,
+                help_text=(
+                    "Org unit type where interventions are deployed (e.g. districts). "
+                    "Scopes rule matching, CSV export/import, and form dropdowns."
+                ),
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="iaso.orgunittype",
+            ),
+        ),
+    ]

--- a/models/account_settings.py
+++ b/models/account_settings.py
@@ -2,6 +2,25 @@ from django.db import models
 
 from iaso.models.base import Account
 from iaso.models.org_unit import OrgUnitType
+from iaso.utils.org_units import get_valid_org_units_with_geography
+
+
+def get_intervention_org_unit_type_id(account):
+    """Return the configured intervention org unit type ID, or None if not set."""
+    return getattr(
+        getattr(account, "snt_account_settings", None),
+        "intervention_org_unit_type_id",
+        None,
+    )
+
+
+def get_intervention_org_units(account):
+    """Return valid org units at the configured intervention level, or all valid geo org units as fallback."""
+    qs = get_valid_org_units_with_geography(account)
+    type_id = get_intervention_org_unit_type_id(account)
+    if type_id:
+        qs = qs.filter(org_unit_type_id=type_id)
+    return qs
 
 
 class AccountSettings(models.Model):
@@ -11,6 +30,22 @@ class AccountSettings(models.Model):
 
     account = models.OneToOneField(Account, on_delete=models.CASCADE, related_name="snt_account_settings")
 
-    # This is used to build the org unit dropdown which allows to focus on a specific branch of the org unit tree.
-    # It should be set to the org unit type id of the branch we want to focus on.
-    intervention_org_unit_type = models.ForeignKey(OrgUnitType, null=True, blank=True, on_delete=models.SET_NULL)
+    focus_org_unit_type = models.ForeignKey(
+        OrgUnitType,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="+",
+        help_text="Higher-level org unit type (e.g. regions) used to focus/zoom the map.",
+    )
+    intervention_org_unit_type = models.ForeignKey(
+        OrgUnitType,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="+",
+        help_text=(
+            "Org unit type where interventions are deployed (e.g. districts). "
+            "Scopes rule matching, CSV export/import, and form dropdowns."
+        ),
+    )

--- a/models/scenario.py
+++ b/models/scenario.py
@@ -14,6 +14,7 @@ from iaso.utils.models.soft_deletable import (
     SoftDeletableModel,
 )
 from iaso.utils.validators import JSONSchemaValidator
+from plugins.snt_malaria.models.account_settings import get_intervention_org_unit_type_id, get_intervention_org_units
 
 
 class Scenario(SoftDeletableModel):
@@ -177,12 +178,17 @@ class ScenarioRule(models.Model):
         """Evaluate matching_criteria and return the raw list of matched org unit IDs.
 
         This is the criteria-only result, before exclusion/inclusion overrides.
+        - match-all: returns all valid org units at the configured intervention level.
+        - criteria: evaluates against MetricValues, also scoped to the intervention level.
         """
         if matching_criteria is None:
             return []
-        metric_values = MetricValue.objects.filter(metric_type__account=account, org_unit_id__isnull=False)
         if isinstance(matching_criteria, dict) and matching_criteria.get("all"):
-            return list(metric_values.values_list("org_unit_id", flat=True).distinct())
+            return list(get_intervention_org_units(account).values_list("id", flat=True))
+        metric_values = MetricValue.objects.filter(metric_type__account=account, org_unit_id__isnull=False)
+        type_id = get_intervention_org_unit_type_id(account)
+        if type_id:
+            metric_values = metric_values.filter(org_unit__org_unit_type_id=type_id)
         q = jsonlogic_to_exists_q_clauses(matching_criteria, metric_values, "metric_type_id", "org_unit_id")
         return list(metric_values.filter(q).distinct().values_list("org_unit_id", flat=True))
 

--- a/tests/api/scenarios/test_views.py
+++ b/tests/api/scenarios/test_views.py
@@ -7,6 +7,7 @@ from iaso.models.data_source import DataSource, SourceVersion
 from iaso.models.project import Project
 from iaso.test import APITestCase
 from plugins.snt_malaria.models import (
+    AccountSettings,
     Intervention,
     InterventionAssignment,
     InterventionCategory,
@@ -1301,3 +1302,74 @@ class ScenarioAPITestCase(APITestCase):
         self.assertEqual(assignments_district_3.count(), 1)
         self.assertEqual(assignments_district_3.first().intervention, self.intervention_vaccination_rts)
         self.assertIsNotNone(assignments_district_3.first().rule)
+
+
+class CsvExportInterventionTypeScopeTestCase(APITestCase):
+    """Tests that CSV export respects AccountSettings.intervention_org_unit_type."""
+
+    BASE_URL = "/api/snt_malaria/scenarios/"
+
+    def setUp(self):
+        self.account = Account.objects.create(name="Test Account")
+        self.user, self.anon, self.user_no_perms = self.create_base_users(
+            self.account, [SNT_SCENARIO_FULL_WRITE_PERMISSION], "testuser"
+        )
+
+        project = Project.objects.create(name="Project", app_id="APP_ID", account=self.account)
+        sw_source = DataSource.objects.create(name="data_source")
+        sw_source.projects.add(project)
+        sw_version = SourceVersion.objects.create(data_source=sw_source, number=1)
+        self.account.default_version = sw_version
+        self.account.save()
+
+        self.region_type = OrgUnitType.objects.create(name="Region")
+        self.district_type = OrgUnitType.objects.create(name="District")
+        mock_multipolygon = MultiPolygon(Polygon([[-1.3, 2.5], [-1.7, 2.8], [-1.1, 4.1], [-1.3, 2.5]]))
+
+        self.region = OrgUnit.objects.create(
+            org_unit_type=self.region_type,
+            name="Region A",
+            validation_status=OrgUnit.VALIDATION_VALID,
+            version=sw_version,
+            location=Point(x=4, y=50, z=100),
+            geom=mock_multipolygon,
+        )
+        self.district1 = OrgUnit.objects.create(
+            org_unit_type=self.district_type,
+            name="District 1",
+            validation_status=OrgUnit.VALIDATION_VALID,
+            version=sw_version,
+            location=Point(x=4, y=51, z=100),
+            geom=mock_multipolygon,
+        )
+        self.district2 = OrgUnit.objects.create(
+            org_unit_type=self.district_type,
+            name="District 2",
+            validation_status=OrgUnit.VALIDATION_VALID,
+            version=sw_version,
+            location=Point(x=4, y=52, z=100),
+            geom=mock_multipolygon,
+        )
+
+        self.int_category = InterventionCategory.objects.create(
+            name="Vaccination", account=self.account, created_by=self.user
+        )
+        self.intervention = Intervention.objects.create(
+            name="RTS,S", created_by=self.user, intervention_category=self.int_category, code="rts_s"
+        )
+
+    def test_export_without_settings_includes_all_levels(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.BASE_URL}export_to_csv/")
+        csv_list = self.assertCsvFileResponse(response, return_as_lists=True)
+        org_unit_ids = {row[0] for row in csv_list[1:]}
+        self.assertEqual(org_unit_ids, {str(self.region.id), str(self.district1.id), str(self.district2.id)})
+
+    def test_export_with_intervention_type_excludes_regions(self):
+        AccountSettings.objects.create(account=self.account, intervention_org_unit_type=self.district_type)
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.BASE_URL}export_to_csv/")
+        csv_list = self.assertCsvFileResponse(response, return_as_lists=True)
+        org_unit_ids = {row[0] for row in csv_list[1:]}
+        self.assertEqual(org_unit_ids, {str(self.district1.id), str(self.district2.id)})
+        self.assertNotIn(str(self.region.id), org_unit_ids)

--- a/tests/models/test_scenario_rule.py
+++ b/tests/models/test_scenario_rule.py
@@ -4,10 +4,11 @@ from django.contrib.gis.geos import Point
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 
-from iaso.models import Account, DataSource, MetricType, MetricValue, OrgUnit, SourceVersion
+from iaso.models import Account, DataSource, MetricType, MetricValue, OrgUnit, OrgUnitType, SourceVersion
 from iaso.test import TestCase
 from iaso.utils.colors import DEFAULT_COLOR
 from plugins.snt_malaria.models import (
+    AccountSettings,
     Intervention,
     InterventionCategory,
     Scenario,
@@ -683,3 +684,65 @@ class ScenarioRuleInterventionPropertiesModelTestCase(TestCase):
                 coverage=Decimal("1.1"),
             )
             invalid_properties.full_clean()
+
+
+class ResolveMatchedOrgUnitsInterventionTypeScopeTestCase(TestCase):
+    """Tests that resolve_matched_org_units respects AccountSettings.intervention_org_unit_type."""
+
+    def setUp(self):
+        data_source = DataSource.objects.create(name="source")
+        source_version = SourceVersion.objects.create(data_source=data_source, number=1)
+        self.account = Account.objects.create(name="account", default_version=source_version)
+        self.user = self.create_user_with_profile(username="user", account=self.account)
+
+        self.region_type = OrgUnitType.objects.create(name="Region")
+        self.district_type = OrgUnitType.objects.create(name="District")
+
+        self.region = OrgUnit.objects.create(
+            name="Region A",
+            org_unit_type=self.region_type,
+            version=source_version,
+            validation_status=OrgUnit.VALIDATION_VALID,
+            location=Point(1.0, 2.0, 0.0),
+        )
+        self.district_1 = OrgUnit.objects.create(
+            name="District 1",
+            org_unit_type=self.district_type,
+            version=source_version,
+            validation_status=OrgUnit.VALIDATION_VALID,
+            location=Point(3.0, 4.0, 0.0),
+        )
+        self.district_2 = OrgUnit.objects.create(
+            name="District 2",
+            org_unit_type=self.district_type,
+            version=source_version,
+            validation_status=OrgUnit.VALIDATION_VALID,
+            location=Point(5.0, 6.0, 0.0),
+        )
+
+        metric_type = MetricType.objects.create(account=self.account, name="Population", code="POP", units="people")
+        MetricValue.objects.create(metric_type=metric_type, org_unit=self.region, value=50000, year=2025)
+        MetricValue.objects.create(metric_type=metric_type, org_unit=self.district_1, value=20000, year=2025)
+        MetricValue.objects.create(metric_type=metric_type, org_unit=self.district_2, value=30000, year=2025)
+
+    def test_match_all_without_settings_returns_all_levels(self):
+        result = ScenarioRule.resolve_matched_org_units(self.account, {"all": True})
+        self.assertCountEqual(result, [self.region.id, self.district_1.id, self.district_2.id])
+
+    def test_match_all_with_intervention_type_excludes_parent(self):
+        AccountSettings.objects.create(account=self.account, intervention_org_unit_type=self.district_type)
+        result = ScenarioRule.resolve_matched_org_units(self.account, {"all": True})
+        self.assertCountEqual(result, [self.district_1.id, self.district_2.id])
+        self.assertNotIn(self.region.id, result)
+
+    def test_criteria_with_intervention_type_excludes_parent(self):
+        metric_type = MetricType.objects.get(account=self.account, code="POP")
+        AccountSettings.objects.create(account=self.account, intervention_org_unit_type=self.district_type)
+        criteria = {"and": [{">=": [{"var": metric_type.id}, 1]}]}
+        result = ScenarioRule.resolve_matched_org_units(self.account, criteria)
+        self.assertCountEqual(result, [self.district_1.id, self.district_2.id])
+
+    def test_null_criteria_returns_empty(self):
+        AccountSettings.objects.create(account=self.account, intervention_org_unit_type=self.district_type)
+        result = ScenarioRule.resolve_matched_org_units(self.account, None)
+        self.assertEqual(result, [])


### PR DESCRIPTION
## What problem is this PR solving?

Scopes rule matching, CSV export/import, and form dropdowns to org units with configurable `intervention_org_unit_type`

### Related JIRA tickets

SNT-410

## Changes

The pre-existing field `intervention_org_unit_type` was used in a misleading way for filtering/zooming the map in the front-end. This PR repurposes this field for scoping org units to an org unit type that is relevant for intervention assignments so rules, imports/exports and form dropdowns contain only the relevant org units. The field is optional and the logic falls back to all org units when not provided.
For the purpose of filtering/zooming the map, a new field is introduced `focus_org_unit_type` which communicates the purpose more clearly. The migration moves existing configuration to the new field.

## How to test

* Create a match-all rule, go the the scenario comparison and look at the warnings, you should see warnings for unmatched org units on a higher level
* Configure the `intervention_org_unit_type` to the correct district level
* Repeat the first step and see that those org units are gone from the warning

Wrong org units included by a match-all appear in the impact warnings
<img width="444" height="235" alt="image" src="https://github.com/user-attachments/assets/5d83142c-fce4-4b93-9c8f-1e67bcd08b88" />


Example configuration for Cameroon
<img width="885" height="373" alt="image" src="https://github.com/user-attachments/assets/91065dc2-1797-40df-b57f-dd0051fcc417" />

