### PR TITLE
SNT-359: Handle unknown intervention when calculating budget

### DIFF
--- a/api/budget/views.py
+++ b/api/budget/views.py
@@ -85,6 +85,7 @@ class BudgetViewSet(viewsets.ModelViewSet):
             local_currency="NGN",
             budget_currency="USD",
             spatial_planning_unit="org_unit_id",
+            unknown_intervention_handling="handle",
         )
 
         for year in range(start_year, end_year + 1):


### PR DESCRIPTION
## What problem is this PR solving?

Handle unknown intervention when calculating budget

### Related JIRA tickets

SNT-359

## Changes

Change budget param to handle unknown intervention

## How to test

Go to SNT, setup an intervention with a custom code (you could use CM if you are lazy as we don't have a quantification function yet).
Make sure you have cost settings for at least a year: 
go to settings from left nav, find your intervention and add some cost. 
You can select whatever you want except for the unit which should be Other.

Go to a scenario that covers the year of your cost settings, add a rule that matches some org units for your intervention.
Go to the budget pan and run the budget.
You should have some result.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

This is related to budgeting PR, refer to the doc to use the version from the repo.
https://github.com/BLSQ/snt-malaria-budgeting/pull/42

Iaso update: 
[SNT-359-implement-the-default-budget-calculation-to-be-used-whenever-no-specific-calculation-exixts-for-a-given-intervtnion](https://github.com/BLSQ/iaso/pull/2905)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
