### PR TITLE
Feature SNT-339: comparative averted cases

### DIFF
--- a/api/impact/serializers.py
+++ b/api/impact/serializers.py
@@ -42,10 +42,7 @@ class ImpactMetricsSerializer(serializers.Serializer):
     number_cases = MetricWithCISerializer()
     number_severe_cases = MetricWithCISerializer()
     prevalence_rate = MetricWithCISerializer()
-    averted_cases = MetricWithCISerializer()
     direct_deaths = MetricWithCISerializer()
-    cost = serializers.FloatField(allow_null=True)
-    cost_per_averted_case = MetricWithCISerializer()
 
 
 class OrgUnitMetricsSerializer(ImpactMetricsSerializer):

--- a/js/src/constants/translations/en.json
+++ b/js/src/constants/translations/en.json
@@ -200,6 +200,12 @@
     "iaso.snt_malaria.impact.deaths": "Deaths",
     "iaso.snt_malaria.compareCustomize.noImpactData": "No impact data available",
     "iaso.snt_malaria.compareCustomize.noBudgetData": "No budget data available",
+    "iaso.snt_malaria.compareCustomize.costPerAvertedCaseTooltip": "The additional cost (or savings) per malaria case prevented, compared to the baseline scenario.",
+    "iaso.snt_malaria.compareCustomize.costPerAvertedCaseLabel": "Cost per averted case",
+    "iaso.snt_malaria.compareCustomize.relativeCostLabel": "Relative cost",
+    "iaso.snt_malaria.compareCustomize.avertedCasesLabel": "Cases averted",
+    "iaso.snt_malaria.compareCustomize.costPerAvertedCaseSelectComparison": "Select at least two scenarios to compare cost per averted case",
+    "iaso.snt_malaria.compareCustomize.costPerAvertedCaseNoCasesAverted": "The compared scenarios do not avert cases relative to the selected baseline.",
     "iaso.snt_malaria.compareCustomize.scenarioLabelWithIndex": "Scenario {index}",
     "iaso.snt_malaria.label.mapView": "Map",
     "iaso.snt_malaria.label.listView": "List",
@@ -220,3 +226,4 @@
     "iaso.snt_malaria.label.costSettings": "Cost settings",
     "iaso.snt_malaria.label.targetPopulationLabel": "Target population"
 }
+

--- a/js/src/constants/translations/fr.json
+++ b/js/src/constants/translations/fr.json
@@ -200,6 +200,12 @@
     "iaso.snt_malaria.impact.deaths": "Décès",
     "iaso.snt_malaria.compareCustomize.noImpactData": "Aucune donnée d'impact disponible",
     "iaso.snt_malaria.compareCustomize.noBudgetData": "Aucune donnée de budget disponible",
+    "iaso.snt_malaria.compareCustomize.costPerAvertedCaseTooltip": "Le coût (ou économie) supplémentaire par cas de paludisme évité, par rapport au scénario de référence.",
+    "iaso.snt_malaria.compareCustomize.costPerAvertedCaseLabel": "Coût par cas évité",
+    "iaso.snt_malaria.compareCustomize.relativeCostLabel": "Coût relatif",
+    "iaso.snt_malaria.compareCustomize.avertedCasesLabel": "Cas évités",
+    "iaso.snt_malaria.compareCustomize.costPerAvertedCaseSelectComparison": "Sélectionnez au moins deux scénarios pour comparer le coût par cas évité",
+    "iaso.snt_malaria.compareCustomize.costPerAvertedCaseNoCasesAverted": "Les scénarios comparés n'évitent pas de cas par rapport au scénario de référence sélectionné.",
     "iaso.snt_malaria.compareCustomize.scenarioLabelWithIndex": "Scénario {index}",
     "iaso.snt_malaria.label.mapView": "Carte",
     "iaso.snt_malaria.label.listView": "Liste",
@@ -219,3 +225,4 @@
     "iaso.snt_malaria.label.save": "Enregistrer les modifications",
     "iaso.snt_malaria.label.targetPopulationLabel": "Population cible"
 }
+

--- a/js/src/domains/compareCustomize/components/Card.tsx
+++ b/js/src/domains/compareCustomize/components/Card.tsx
@@ -1,11 +1,13 @@
 import React, { FC, ReactNode } from 'react';
-import { Box, Typography } from '@mui/material';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import { Box, Tooltip, Typography } from '@mui/material';
 import { blueGrey } from '@mui/material/colors';
 import { LoadingSpinner } from 'bluesquare-components';
 import { SxStyles } from 'Iaso/types/general';
 
 type Props = {
     title: string;
+    tooltip?: string;
     icon?: React.ElementType;
     iconSx?: Record<string, unknown>;
     actions?: ReactNode;
@@ -71,6 +73,7 @@ const styles = {
 
 export const Card: FC<Props> = ({
     title,
+    tooltip,
     icon,
     iconSx,
     actions,
@@ -91,6 +94,19 @@ export const Card: FC<Props> = ({
                     </Box>
                 )}
                 <Typography sx={styles.title}>{title}</Typography>
+                {tooltip && (
+                    <Tooltip title={tooltip} arrow>
+                        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                            <HelpOutlineIcon
+                                sx={{
+                                    color: blueGrey[300],
+                                    fontSize: '1rem',
+                                    cursor: 'help',
+                                }}
+                            />
+                        </Box>
+                    </Tooltip>
+                )}
             </Box>
             {actions}
         </Box>

--- a/js/src/domains/compareCustomize/components/charts/BudgetByCategoryCard.tsx
+++ b/js/src/domains/compareCustomize/components/charts/BudgetByCategoryCard.tsx
@@ -19,6 +19,7 @@ import { useComparisonDataContext } from '../../ComparisonDataContext';
 import { getInterventionGroupShades } from '../../utils/colors';
 import { Card } from '../Card';
 import { ChartEmptyState } from './ChartEmptyState';
+import { ChartTooltip } from './ChartTooltip';
 
 type BudgetCategoryDatum = {
     name: string;
@@ -63,7 +64,10 @@ const getCategoryTotals = (
     budget.results.forEach(result => {
         result.interventions?.forEach(intervention => {
             intervention.cost_breakdown?.forEach(line => {
-                totals.set(line.category, (totals.get(line.category) ?? 0) + line.cost);
+                totals.set(
+                    line.category,
+                    (totals.get(line.category) ?? 0) + line.cost,
+                );
             });
         });
     });
@@ -72,6 +76,30 @@ const getCategoryTotals = (
         .map(([name, value]) => ({ name, value }))
         .filter(entry => entry.value > 0)
         .sort((a, b) => b.value - a.value);
+};
+
+type BudgetTooltipProps = {
+    active?: boolean;
+    payload?: { name: string; value: number; payload: { fill?: string } }[];
+    scenarioLabel: string;
+};
+
+const BudgetTooltip: FC<BudgetTooltipProps> = ({
+    active,
+    payload,
+    scenarioLabel,
+}) => {
+    if (!active || !payload?.length) return null;
+    return (
+        <ChartTooltip
+            title={scenarioLabel}
+            rows={payload.map(entry => ({
+                label: entry.name,
+                value: formatBigNumber(entry.value),
+                color: entry.payload?.fill,
+            }))}
+        />
+    );
 };
 
 export const BudgetByCategoryCard: FC = () => {
@@ -105,14 +133,20 @@ export const BudgetByCategoryCard: FC = () => {
                 {chartData.map(({ scenario, data, colors }) => (
                     <Box key={scenario.id} sx={styles.chartItem}>
                         {data.length === 0 ? (
-                            <ChartEmptyState message={formatMessage(MESSAGES.noBudgetData)} />
+                            <ChartEmptyState
+                                message={formatMessage(MESSAGES.noBudgetData)}
+                            />
                         ) : (
                             <Box sx={styles.chartBody}>
                                 <ResponsiveContainer width="100%" height="100%">
                                     <PieChart>
                                         <Tooltip
-                                            formatter={(value: number) =>
-                                                formatBigNumber(value)
+                                            content={
+                                                <BudgetTooltip
+                                                    scenarioLabel={
+                                                        scenario.label
+                                                    }
+                                                />
                                             }
                                         />
                                         <Pie
@@ -140,7 +174,10 @@ export const BudgetByCategoryCard: FC = () => {
                                                     renderValue={entry => (
                                                         <Typography
                                                             variant="body2"
-                                                            sx={{ fontSize: '0.75rem' }}
+                                                            sx={{
+                                                                fontSize:
+                                                                    '0.75rem',
+                                                            }}
                                                         >
                                                             {entry.value}
                                                         </Typography>

--- a/js/src/domains/compareCustomize/components/charts/ChartTooltip.tsx
+++ b/js/src/domains/compareCustomize/components/charts/ChartTooltip.tsx
@@ -1,0 +1,65 @@
+import React, { FC, ReactNode } from 'react';
+import { Box } from '@mui/material';
+import { SxStyles } from 'Iaso/types/general';
+
+export type ChartTooltipRow = {
+    label: string;
+    value: string;
+    color?: string;
+};
+
+type Props = {
+    title: ReactNode;
+    rows: ChartTooltipRow[];
+};
+
+const styles = {
+    root: {
+        backgroundColor: 'common.white',
+        border: '1px solid',
+        borderColor: 'grey.300',
+        borderRadius: 0.5,
+        boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
+        px: 1,
+        py: 0.75,
+        fontSize: '0.75rem',
+        lineHeight: 1.4,
+    },
+    title: {
+        fontSize: '0.75rem',
+        display: 'block',
+        mb: 0.5,
+    },
+    row: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.75,
+    },
+    dot: {
+        width: 8,
+        height: 8,
+        borderRadius: '50%',
+        flexShrink: 0,
+    },
+} satisfies SxStyles;
+
+export const ChartTooltip: FC<Props> = ({ title, rows }) => (
+    <Box sx={styles.root}>
+        <Box component="b" sx={styles.title}>
+            {title}
+        </Box>
+        {rows.map(row => (
+            <Box key={row.label} sx={styles.row}>
+                {row.color && (
+                    <Box sx={{ ...styles.dot, backgroundColor: row.color }} />
+                )}
+                <Box component="span" sx={{ color: 'text.secondary' }}>
+                    {row.label}:
+                </Box>
+                <Box component="span" sx={{ fontWeight: 700 }}>
+                    {row.value}
+                </Box>
+            </Box>
+        ))}
+    </Box>
+);

--- a/js/src/domains/compareCustomize/components/charts/ChartTooltip.tsx
+++ b/js/src/domains/compareCustomize/components/charts/ChartTooltip.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode } from 'react';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { SxStyles } from 'Iaso/types/general';
 
 export type ChartTooltipRow = {
@@ -27,6 +27,7 @@ const styles = {
     },
     title: {
         fontSize: '0.75rem',
+        fontWeight: 700,
         display: 'block',
         mb: 0.5,
     },
@@ -45,20 +46,24 @@ const styles = {
 
 export const ChartTooltip: FC<Props> = ({ title, rows }) => (
     <Box sx={styles.root}>
-        <Box component="b" sx={styles.title}>
-            {title}
-        </Box>
-        {rows.map(row => (
+        <Typography sx={styles.title}>{title}</Typography>
+        {rows.map((row) => (
             <Box key={row.label} sx={styles.row}>
                 {row.color && (
                     <Box sx={{ ...styles.dot, backgroundColor: row.color }} />
                 )}
-                <Box component="span" sx={{ color: 'text.secondary' }}>
+                <Typography
+                    component="span"
+                    sx={{ fontSize: 'inherit', color: 'text.secondary' }}
+                >
                     {row.label}:
-                </Box>
-                <Box component="span" sx={{ fontWeight: 700 }}>
+                </Typography>
+                <Typography
+                    component="span"
+                    sx={{ fontSize: 'inherit', fontWeight: 700 }}
+                >
                     {row.value}
-                </Box>
+                </Typography>
             </Box>
         ))}
     </Box>

--- a/js/src/domains/compareCustomize/components/charts/CostPerAvertedCaseCard.tsx
+++ b/js/src/domains/compareCustomize/components/charts/CostPerAvertedCaseCard.tsx
@@ -8,6 +8,7 @@ import {
     CartesianGrid,
     Cell,
     ErrorBar,
+    ReferenceLine,
     ResponsiveContainer,
     Tooltip,
     XAxis,
@@ -15,16 +16,65 @@ import {
 } from 'recharts';
 import { SxStyles } from 'Iaso/types/general';
 import { MESSAGES } from '../../../messages';
+import { formatBigNumber } from '../../../planning/libs/cost-utils';
 import { useComparisonDataContext } from '../../ComparisonDataContext';
-import { buildCostChartData } from '../../utils/chartData';
+import {
+    CostPerAvertedCaseDatum,
+    buildCostPerAvertedCaseChartData,
+} from '../../utils/chartData';
+import { SCENARIO_BASE_COLORS } from '../../utils/colors';
 import { Card } from '../Card';
 import { ChartEmptyState } from './ChartEmptyState';
+import { ChartTooltip } from './ChartTooltip';
 
 const formatCostValue = (value: number): string =>
     new Intl.NumberFormat(undefined, {
         minimumFractionDigits: 0,
         maximumFractionDigits: 2,
     }).format(value);
+
+/**
+ * D3-style "nice" step size for axis ticks (see d3-scale tickStep).
+ * Thresholds ≈ √50, √10, √2 are geometric means between 10, 5, 2, 1.
+ */
+const niceStep = (range: number, count: number): number => {
+    const raw = range / Math.max(1, count - 1);
+    const mag = 10 ** Math.floor(Math.log10(raw));
+    const r = raw / mag;
+    if (r >= 7.07) return 10 * mag;
+    if (r >= 3.16) return 5 * mag;
+    if (r >= 1.41) return 2 * mag;
+    return mag;
+};
+
+/**
+ * Axis domain + ticks with round labels, always including 0 (baseline).
+ * Recharts auto-scaling can't guarantee either, so we compute our own.
+ * Adds an extra step when data reaches within 10% of a domain edge.
+ */
+const computeNiceTicks = (
+    data: { value: number; errorLower: number; errorUpper: number }[],
+): { domain: [number, number]; ticks: number[] } => {
+    if (data.length === 0) return { domain: [0, 1], ticks: [0] };
+
+    const dataMin = Math.min(0, ...data.map(d => d.value - d.errorLower));
+    const dataMax = Math.max(0, ...data.map(d => d.value + d.errorUpper));
+    const step = niceStep(dataMax - dataMin || 1, 6);
+
+    let lo = Math.floor(dataMin / step) * step;
+    let hi = Math.ceil(dataMax / step) * step;
+
+    // If data fills over 90% of the outermost step, add one more
+    if (dataMin < 0 && dataMin - lo < step * 0.1) lo -= step;
+    if (dataMax > 0 && hi - dataMax < step * 0.1) hi += step;
+
+    const ticks = Array.from(
+        { length: Math.round((hi - lo) / step) + 1 },
+        (_, i) => lo + i * step,
+    );
+
+    return { domain: [lo, hi], ticks };
+};
 
 const styles = {
     chartBody: {
@@ -33,69 +83,173 @@ const styles = {
     },
 } satisfies SxStyles;
 
+type CostTooltipProps = {
+    active?: boolean;
+    payload?: { payload: CostPerAvertedCaseDatum }[];
+    labels: {
+        costPerAverted: string;
+        relativeCost: string;
+        avertedCases: string;
+    };
+};
+
+const CostTooltip: FC<CostTooltipProps> = ({ active, payload, labels }) => {
+    if (!active || !payload?.length) return null;
+    const d = payload[0].payload;
+    return (
+        <ChartTooltip
+            title={d.name}
+            rows={[
+                {
+                    label: labels.costPerAverted,
+                    value: formatCostValue(d.value),
+                },
+                {
+                    label: labels.relativeCost,
+                    value: formatBigNumber(d.relativeCost),
+                },
+                {
+                    label: labels.avertedCases,
+                    value: formatBigNumber(d.avertedCases),
+                },
+            ]}
+        />
+    );
+};
+
 export const CostPerAvertedCaseCard: FC = () => {
-    const { scenarios, impactsByScenarioId, isImpactLoading: isLoading } =
-        useComparisonDataContext();
+    const {
+        scenarios,
+        baselineScenarioId,
+        impactsByScenarioId,
+        budgetsByScenarioId,
+        isImpactLoading,
+        isBudgetLoading,
+    } = useComparisonDataContext();
     const { formatMessage } = useSafeIntl();
     const theme = useTheme();
     const axisColor = theme.palette.text.secondary;
+    const isLoading = isImpactLoading || isBudgetLoading;
+    const hasComparison = scenarios.length >= 2;
 
-    const chartData = useMemo(
-        () => buildCostChartData(scenarios, impactsByScenarioId),
-        [scenarios, impactsByScenarioId],
+    const { data: chartData, hasInsufficientAverted } = useMemo(
+        () =>
+            buildCostPerAvertedCaseChartData(
+                scenarios,
+                impactsByScenarioId,
+                budgetsByScenarioId,
+                baselineScenarioId,
+            ),
+        [
+            scenarios,
+            impactsByScenarioId,
+            budgetsByScenarioId,
+            baselineScenarioId,
+        ],
     );
+
+    const { domain, ticks } = useMemo(
+        () => computeNiceTicks(chartData),
+        [chartData],
+    );
+
+    let emptyMessage: string;
+    if (!hasComparison) {
+        emptyMessage = formatMessage(
+            MESSAGES.costPerAvertedCaseSelectComparison,
+        );
+    } else if (hasInsufficientAverted) {
+        emptyMessage = formatMessage(MESSAGES.costPerAvertedCaseNoCasesAverted);
+    } else {
+        emptyMessage = formatMessage(MESSAGES.noBudgetData);
+    }
 
     return (
         <Card
             title={formatMessage(MESSAGES.costPerAvertedCaseTitle)}
+            tooltip={formatMessage(MESSAGES.costPerAvertedCaseTooltip)}
             icon={BarChartOutlinedIcon}
             bodySx={{ minHeight: 220 }}
             isLoading={isLoading}
         >
             {chartData.length === 0 ? (
-                <ChartEmptyState message={formatMessage(MESSAGES.noImpactData)} />
+                <ChartEmptyState message={emptyMessage} />
             ) : (
                 <Box sx={styles.chartBody}>
                     <ResponsiveContainer width="100%" height="100%">
                         <BarChart
+                            layout="vertical"
                             data={chartData}
                             margin={{
                                 top: 5,
-                                right: 5,
-                                left: 0,
-                                bottom: -5,
+                                right: 20,
+                                left: 5,
+                                bottom: 5,
                             }}
                         >
-                            <CartesianGrid vertical={false} strokeDasharray="" stroke={theme.palette.divider} />
-                            <XAxis dataKey="name" tick={{ fill: axisColor, fontSize: '0.75rem' }} stroke={axisColor} tickMargin={4} />
+                            <CartesianGrid
+                                horizontal={false}
+                                strokeDasharray=""
+                                stroke={theme.palette.divider}
+                            />
                             <YAxis
+                                type="category"
+                                dataKey="name"
+                                tick={{ fill: axisColor, fontSize: '0.75rem' }}
+                                stroke={axisColor}
+                                width={80}
+                            />
+                            <XAxis
+                                type="number"
                                 tickFormatter={(v: number) =>
-                                    formatCostValue(v)
+                                    v === 0
+                                        ? formatMessage(MESSAGES.baselineLabel)
+                                        : formatCostValue(v)
                                 }
                                 tick={{ fill: axisColor, fontSize: '0.75rem' }}
                                 stroke={axisColor}
-                                width={50}
                                 tickMargin={2}
-                                allowDecimals
+                                domain={domain}
+                                ticks={ticks}
                             />
                             <Tooltip
-                                formatter={formatCostValue}
                                 cursor={false}
+                                content={
+                                    <CostTooltip
+                                        labels={{
+                                            costPerAverted: formatMessage(
+                                                MESSAGES.costPerAvertedCaseLabel,
+                                            ),
+                                            relativeCost: formatMessage(
+                                                MESSAGES.relativeCostLabel,
+                                            ),
+                                            avertedCases: formatMessage(
+                                                MESSAGES.avertedCasesLabel,
+                                            ),
+                                        }}
+                                    />
+                                }
                             />
-                            <Bar dataKey="value" maxBarSize={64} radius={[4, 4, 0, 0]}>
+                            <Bar
+                                dataKey="value"
+                                maxBarSize={64}
+                                radius={[0, 4, 4, 0]}
+                            >
                                 <ErrorBar
-                                    dataKey="error"
-                                    width={6}
+                                    dataKey="errorBounds"
+                                    width={8}
                                     strokeWidth={1.5}
-                                    stroke={theme.palette.text.disabled}
+                                    stroke={axisColor}
                                 />
                                 {chartData.map(entry => (
-                                    <Cell
-                                        key={entry.name}
-                                        fill={entry.color}
-                                    />
+                                    <Cell key={entry.name} fill={entry.color} />
                                 ))}
                             </Bar>
+                            <ReferenceLine
+                                x={0}
+                                stroke={SCENARIO_BASE_COLORS[0]}
+                                strokeWidth={3}
+                            />
                         </BarChart>
                     </ResponsiveContainer>
                 </Box>

--- a/js/src/domains/compareCustomize/components/charts/CostPerAvertedCaseCard.tsx
+++ b/js/src/domains/compareCustomize/components/charts/CostPerAvertedCaseCard.tsx
@@ -22,6 +22,7 @@ import {
     CostPerAvertedCaseDatum,
     buildCostPerAvertedCaseChartData,
 } from '../../utils/chartData';
+import { computeNiceTicks } from '../../utils/chartUtils';
 import { SCENARIO_BASE_COLORS } from '../../utils/colors';
 import { Card } from '../Card';
 import { ChartEmptyState } from './ChartEmptyState';
@@ -32,49 +33,6 @@ const formatCostValue = (value: number): string =>
         minimumFractionDigits: 0,
         maximumFractionDigits: 2,
     }).format(value);
-
-/**
- * D3-style "nice" step size for axis ticks (see d3-scale tickStep).
- * Thresholds ≈ √50, √10, √2 are geometric means between 10, 5, 2, 1.
- */
-const niceStep = (range: number, count: number): number => {
-    const raw = range / Math.max(1, count - 1);
-    const mag = 10 ** Math.floor(Math.log10(raw));
-    const r = raw / mag;
-    if (r >= 7.07) return 10 * mag;
-    if (r >= 3.16) return 5 * mag;
-    if (r >= 1.41) return 2 * mag;
-    return mag;
-};
-
-/**
- * Axis domain + ticks with round labels, always including 0 (baseline).
- * Recharts auto-scaling can't guarantee either, so we compute our own.
- * Adds an extra step when data reaches within 10% of a domain edge.
- */
-const computeNiceTicks = (
-    data: { value: number; errorLower: number; errorUpper: number }[],
-): { domain: [number, number]; ticks: number[] } => {
-    if (data.length === 0) return { domain: [0, 1], ticks: [0] };
-
-    const dataMin = Math.min(0, ...data.map(d => d.value - d.errorLower));
-    const dataMax = Math.max(0, ...data.map(d => d.value + d.errorUpper));
-    const step = niceStep(dataMax - dataMin || 1, 6);
-
-    let lo = Math.floor(dataMin / step) * step;
-    let hi = Math.ceil(dataMax / step) * step;
-
-    // If data fills over 90% of the outermost step, add one more
-    if (dataMin < 0 && dataMin - lo < step * 0.1) lo -= step;
-    if (dataMax > 0 && hi - dataMax < step * 0.1) hi += step;
-
-    const ticks = Array.from(
-        { length: Math.round((hi - lo) / step) + 1 },
-        (_, i) => lo + i * step,
-    );
-
-    return { domain: [lo, hi], ticks };
-};
 
 const styles = {
     chartBody: {
@@ -153,16 +111,19 @@ export const CostPerAvertedCaseCard: FC = () => {
         [chartData],
     );
 
-    let emptyMessage: string;
-    if (!hasComparison) {
-        emptyMessage = formatMessage(
-            MESSAGES.costPerAvertedCaseSelectComparison,
-        );
-    } else if (hasInsufficientAverted) {
-        emptyMessage = formatMessage(MESSAGES.costPerAvertedCaseNoCasesAverted);
-    } else {
-        emptyMessage = formatMessage(MESSAGES.noBudgetData);
-    }
+    const emptyMessage = useMemo(() => {
+        if (!hasComparison) {
+            return formatMessage(
+                MESSAGES.costPerAvertedCaseSelectComparison,
+            );
+        }
+        if (hasInsufficientAverted) {
+            return formatMessage(
+                MESSAGES.costPerAvertedCaseNoCasesAverted,
+            );
+        }
+        return formatMessage(MESSAGES.noBudgetData);
+    }, [hasComparison, hasInsufficientAverted, formatMessage]);
 
     return (
         <Card

--- a/js/src/domains/compareCustomize/components/charts/YearlyPrevalenceCard.tsx
+++ b/js/src/domains/compareCustomize/components/charts/YearlyPrevalenceCard.tsx
@@ -19,6 +19,7 @@ import { useComparisonDataContext } from '../../ComparisonDataContext';
 import { buildPrevalenceChartData } from '../../utils/chartData';
 import { Card } from '../Card';
 import { ChartEmptyState } from './ChartEmptyState';
+import { ChartTooltip } from './ChartTooltip';
 
 const styles = {
     chartBody: {
@@ -27,9 +28,36 @@ const styles = {
     },
 } satisfies SxStyles;
 
+type PrevalenceTooltipProps = {
+    active?: boolean;
+    label?: number;
+    payload?: { name: string; value: number; color: string }[];
+};
+
+const PrevalenceTooltip: FC<PrevalenceTooltipProps> = ({
+    active,
+    label,
+    payload,
+}) => {
+    if (!active || !payload?.length) return null;
+    return (
+        <ChartTooltip
+            title={label}
+            rows={payload.map(entry => ({
+                label: entry.name,
+                value: formatPercentValue(entry.value),
+                color: entry.color,
+            }))}
+        />
+    );
+};
+
 export const YearlyPrevalenceCard: FC = () => {
-    const { scenarios, impactsByScenarioId, isImpactLoading: isLoading } =
-        useComparisonDataContext();
+    const {
+        scenarios,
+        impactsByScenarioId,
+        isImpactLoading: isLoading,
+    } = useComparisonDataContext();
     const { formatMessage } = useSafeIntl();
     const theme = useTheme();
     const axisColor = theme.palette.text.secondary;
@@ -49,7 +77,9 @@ export const YearlyPrevalenceCard: FC = () => {
             isLoading={isLoading}
         >
             {!hasData ? (
-                <ChartEmptyState message={formatMessage(MESSAGES.noImpactData)} />
+                <ChartEmptyState
+                    message={formatMessage(MESSAGES.noImpactData)}
+                />
             ) : (
                 <Box sx={styles.chartBody}>
                     <ResponsiveContainer width="100%" height="100%">
@@ -62,8 +92,17 @@ export const YearlyPrevalenceCard: FC = () => {
                                 bottom: -5,
                             }}
                         >
-                            <CartesianGrid vertical={false} strokeDasharray="" stroke={theme.palette.divider} />
-                            <XAxis dataKey="year" tick={{ fill: axisColor, fontSize: '0.75rem' }} stroke={axisColor} tickMargin={4} />
+                            <CartesianGrid
+                                vertical={false}
+                                strokeDasharray=""
+                                stroke={theme.palette.divider}
+                            />
+                            <XAxis
+                                dataKey="year"
+                                tick={{ fill: axisColor, fontSize: '0.75rem' }}
+                                stroke={axisColor}
+                                tickMargin={4}
+                            />
                             <YAxis
                                 tickFormatter={formatPercentValue}
                                 tick={{ fill: axisColor, fontSize: '0.75rem' }}
@@ -71,9 +110,7 @@ export const YearlyPrevalenceCard: FC = () => {
                                 width={50}
                                 tickMargin={2}
                             />
-                            <Tooltip
-                                formatter={formatPercentValue}
-                            />
+                            <Tooltip content={<PrevalenceTooltip />} />
                             {scenarios.map(scenario => (
                                 <Line
                                     key={scenario.id}

--- a/js/src/domains/compareCustomize/types.ts
+++ b/js/src/domains/compareCustomize/types.ts
@@ -28,10 +28,7 @@ export type OrgUnitImpactMetrics = {
     number_cases: ImpactMetricWithConfidenceInterval;
     number_severe_cases: ImpactMetricWithConfidenceInterval;
     prevalence_rate: ImpactMetricWithConfidenceInterval;
-    averted_cases: ImpactMetricWithConfidenceInterval;
     direct_deaths: ImpactMetricWithConfidenceInterval;
-    cost?: number | null;
-    cost_per_averted_case: ImpactMetricWithConfidenceInterval;
 };
 
 export type YearImpactMetrics = {
@@ -39,10 +36,7 @@ export type YearImpactMetrics = {
     number_cases: ImpactMetricWithConfidenceInterval;
     number_severe_cases: ImpactMetricWithConfidenceInterval;
     prevalence_rate: ImpactMetricWithConfidenceInterval;
-    averted_cases: ImpactMetricWithConfidenceInterval;
     direct_deaths: ImpactMetricWithConfidenceInterval;
-    cost: number | null;
-    cost_per_averted_case: ImpactMetricWithConfidenceInterval;
     org_units: OrgUnitImpactMetrics[];
 };
 
@@ -51,10 +45,7 @@ export type ScenarioImpactMetrics = {
     number_cases: ImpactMetricWithConfidenceInterval;
     number_severe_cases: ImpactMetricWithConfidenceInterval;
     prevalence_rate: ImpactMetricWithConfidenceInterval;
-    averted_cases: ImpactMetricWithConfidenceInterval;
     direct_deaths: ImpactMetricWithConfidenceInterval;
-    cost: number | null;
-    cost_per_averted_case: ImpactMetricWithConfidenceInterval;
     by_year: YearImpactMetrics[];
     org_units: OrgUnitImpactMetrics[];
     org_units_not_found: OrgUnitRef[];

--- a/js/src/domains/compareCustomize/utils/chartData.ts
+++ b/js/src/domains/compareCustomize/utils/chartData.ts
@@ -16,11 +16,11 @@ export type PrevalenceDataPoint = {
  */
 export const buildPrevalenceChartData = (
     scenarios: ScenarioDisplay[],
-    impactsByScenarioId: Map<number, ScenarioImpactMetrics | undefined>,
+    impactMetricsByScenarioId: Map<number, ScenarioImpactMetrics | undefined>,
 ): PrevalenceDataPoint[] => {
     const yearSet = new Set<number>();
     scenarios.forEach(scenario => {
-        const impact = impactsByScenarioId.get(scenario.id);
+        const impact = impactMetricsByScenarioId.get(scenario.id);
         impact?.by_year?.forEach(yr => yearSet.add(yr.year));
     });
 
@@ -30,7 +30,7 @@ export const buildPrevalenceChartData = (
     return years.map(year => {
         const point: PrevalenceDataPoint = { year };
         scenarios.forEach(scenario => {
-            const impact = impactsByScenarioId.get(scenario.id);
+            const impact = impactMetricsByScenarioId.get(scenario.id);
             const yearData = impact?.by_year?.find(yr => yr.year === year);
             const metric = yearData?.prevalence_rate;
             point[scenario.label] = metric?.value ?? undefined;
@@ -63,17 +63,17 @@ export type CostPerAvertedCaseDatum = {
     color: string;
 };
 
-const computeCostPerAverted = (
+/** cost_per_averted = cost_diff / (baseline_cases − scenario_cases) */
+const costPerAverted = (
     costDiff: number,
-    baselineCases: number | null | undefined,
-    scenarioCases: number | null | undefined,
-): { value: number; averted: number } | undefined => {
-    if (baselineCases == null || scenarioCases == null) return undefined;
-    const averted = baselineCases - scenarioCases;
-    // Cases are absolute counts, so < 1 means no meaningful case was averted.
-    // This also prevents near-zero divisions producing huge values.
-    if (averted < 1) return undefined;
-    return { value: costDiff / averted, averted };
+    baselineCases: number,
+    scenarioCases: number,
+): { costPerAvertedCase: number; avertedCases: number } | undefined => {
+    const avertedCases = baselineCases - scenarioCases;
+    // Cases are absolute counts; < 1 means nothing meaningful was averted.
+    if (avertedCases < 1) return undefined;
+    const costPerAvertedCase = costDiff / avertedCases;
+    return { costPerAvertedCase, avertedCases };
 };
 
 export type CostPerAvertedCaseResult = {
@@ -86,19 +86,17 @@ export type CostPerAvertedCaseResult = {
 /**
  * Computes comparative cost-per-averted-case for each non-baseline scenario.
  *
- * averted_cases       = baseline.cases - scenario.cases
- * cost_per_averted    = (scenario.cost - baseline.cost) / averted_cases
+ *   averted_cases    = baseline.cases − scenario.cases
+ *   cost_per_averted = (scenario.cost − baseline.cost) / averted_cases
  *
- * Only scenarios that meaningfully avert cases (≥ 1) are included.
- *
- * Only uncomplicated cases (excluding severe) are used for averted cases.
- * Confidence intervals use the worst/best case averted bounds
- * (baseline.lower − scenario.upper and baseline.upper − scenario.lower).
- * The baseline itself is never shown (it has no comparison target).
+ * Only uncomplicated cases are used (severe cases excluded).
+ * A scenario must avert at least 1 case to be included; otherwise the
+ * metric is meaningless and `hasInsufficientAverted` is flagged.
+ * Confidence intervals repeat the formula with pessimistic/optimistic bounds.
  */
 export const buildCostPerAvertedCaseChartData = (
     scenarios: ScenarioDisplay[],
-    impactsByScenarioId: Map<number, ScenarioImpactMetrics | undefined>,
+    impactMetricsByScenarioId: Map<number, ScenarioImpactMetrics | undefined>,
     budgetsByScenarioId: Map<number, BudgetCalculationResponse | undefined>,
     baselineScenarioId: number | undefined,
 ): CostPerAvertedCaseResult => {
@@ -108,52 +106,46 @@ export const buildCostPerAvertedCaseChartData = (
     };
     if (baselineScenarioId === undefined) return empty;
 
-    const baselineImpact = impactsByScenarioId.get(baselineScenarioId);
-    const b = baselineImpact?.number_cases;
-    const baselineCost = getCumulativeCosts(
-        budgetsByScenarioId.get(baselineScenarioId),
-    );
-
-    if (b?.value == null || baselineCost == null) return empty;
+    const baselineCases = impactMetricsByScenarioId.get(baselineScenarioId)?.number_cases;
+    const baselineCost = getCumulativeCosts(budgetsByScenarioId.get(baselineScenarioId));
+    if (baselineCases?.value == null || baselineCost == null) return empty;
 
     let hasInsufficientAverted = false;
 
     const data = scenarios
-        .filter(s => s.id !== baselineScenarioId)
+        .filter((scenario) => scenario.id !== baselineScenarioId)
         .map((scenario): CostPerAvertedCaseDatum | null => {
-            const impact = impactsByScenarioId.get(scenario.id);
-            const s = impact?.number_cases;
-            const cost = getCumulativeCosts(
-                budgetsByScenarioId.get(scenario.id),
-            );
-            if (cost == null) return null;
 
-            const costDiff = cost - baselineCost;
-            const central = computeCostPerAverted(costDiff, b.value, s?.value);
+            const scenarioCases = impactMetricsByScenarioId.get(scenario.id)?.number_cases;
+            const scenarioCost = getCumulativeCosts(budgetsByScenarioId.get(scenario.id));
+            if (scenarioCost == null || scenarioCases?.value == null) return null;
+
+            const costDiff = scenarioCost - baselineCost;
+
+            const central = costPerAverted(costDiff, baselineCases.value!, scenarioCases.value);
             if (central === undefined) {
-                if (s?.value != null) {
-                    hasInsufficientAverted = true;
-                }
+                hasInsufficientAverted = true;
                 return null;
             }
 
-            const bound1 = computeCostPerAverted(costDiff, b.lower, s?.upper);
-            const bound2 = computeCostPerAverted(costDiff, b.upper, s?.lower);
+            // CI bounds: cross baseline.lower with scenario.upper (and vice-versa)
+            // to get the pessimistic/optimistic averted-cases denominators.
+            const lower = costPerAverted(costDiff, baselineCases.lower ?? 0, scenarioCases.upper ?? 0);
+            const upper = costPerAverted(costDiff, baselineCases.upper ?? 0, scenarioCases.lower ?? 0);
 
+            // Stored as offsets from the central value (Recharts ErrorBar expects deltas).
             let errorLower = 0;
             let errorUpper = 0;
-            if (bound1 !== undefined && bound2 !== undefined) {
-                const ciLower = Math.min(bound1.value, bound2.value);
-                const ciUpper = Math.max(bound1.value, bound2.value);
-                errorLower = central.value - ciLower;
-                errorUpper = ciUpper - central.value;
+            if (lower !== undefined && upper !== undefined) {
+                errorLower = central.costPerAvertedCase - Math.min(lower.costPerAvertedCase, upper.costPerAvertedCase);
+                errorUpper = Math.max(lower.costPerAvertedCase, upper.costPerAvertedCase) - central.costPerAvertedCase;
             }
 
             return {
                 name: scenario.label,
-                value: central.value,
+                value: central.costPerAvertedCase,
                 relativeCost: costDiff,
-                avertedCases: central.averted,
+                avertedCases: central.avertedCases,
                 errorLower,
                 errorUpper,
                 errorBounds: [errorLower, errorUpper],

--- a/js/src/domains/compareCustomize/utils/chartData.ts
+++ b/js/src/domains/compareCustomize/utils/chartData.ts
@@ -1,4 +1,6 @@
+import { BudgetCalculationResponse } from '../../planning/types/budget';
 import { ScenarioImpactMetrics, ScenarioDisplay } from '../types';
+import { getCumulativeCosts } from './impactCalculations';
 
 // --- Yearly prevalence chart ---
 
@@ -53,41 +55,112 @@ export const buildPrevalenceChartData = (
 export type CostPerAvertedCaseDatum = {
     name: string;
     value: number;
-    error?: [number, number];
+    relativeCost: number;
+    avertedCases: number;
+    errorLower: number;
+    errorUpper: number;
+    errorBounds: [number, number];
     color: string;
 };
 
+const computeCostPerAverted = (
+    costDiff: number,
+    baselineCases: number | null | undefined,
+    scenarioCases: number | null | undefined,
+): { value: number; averted: number } | undefined => {
+    if (baselineCases == null || scenarioCases == null) return undefined;
+    const averted = baselineCases - scenarioCases;
+    // Cases are absolute counts, so < 1 means no meaningful case was averted.
+    // This also prevents near-zero divisions producing huge values.
+    if (averted < 1) return undefined;
+    return { value: costDiff / averted, averted };
+};
+
+export type CostPerAvertedCaseResult = {
+    data: CostPerAvertedCaseDatum[];
+    /** True when at least one scenario was excluded because it does not
+     *  meaningfully avert cases compared to the baseline. */
+    hasInsufficientAverted: boolean;
+};
+
 /**
- * Extracts cost-per-averted-case bar chart data from impact results.
- * Scenarios with no data, zero, or negative cost are excluded.
+ * Computes comparative cost-per-averted-case for each non-baseline scenario.
+ *
+ * averted_cases       = baseline.cases - scenario.cases
+ * cost_per_averted    = (scenario.cost - baseline.cost) / averted_cases
+ *
+ * Only scenarios that meaningfully avert cases (≥ 1) are included.
+ *
+ * Only uncomplicated cases (excluding severe) are used for averted cases.
+ * Confidence intervals use the worst/best case averted bounds
+ * (baseline.lower − scenario.upper and baseline.upper − scenario.lower).
+ * The baseline itself is never shown (it has no comparison target).
  */
-export const buildCostChartData = (
+export const buildCostPerAvertedCaseChartData = (
     scenarios: ScenarioDisplay[],
     impactsByScenarioId: Map<number, ScenarioImpactMetrics | undefined>,
-): CostPerAvertedCaseDatum[] =>
-    scenarios
+    budgetsByScenarioId: Map<number, BudgetCalculationResponse | undefined>,
+    baselineScenarioId: number | undefined,
+): CostPerAvertedCaseResult => {
+    const empty: CostPerAvertedCaseResult = {
+        data: [],
+        hasInsufficientAverted: false,
+    };
+    if (baselineScenarioId === undefined) return empty;
+
+    const baselineImpact = impactsByScenarioId.get(baselineScenarioId);
+    const b = baselineImpact?.number_cases;
+    const baselineCost = getCumulativeCosts(
+        budgetsByScenarioId.get(baselineScenarioId),
+    );
+
+    if (b?.value == null || baselineCost == null) return empty;
+
+    let hasInsufficientAverted = false;
+
+    const data = scenarios
+        .filter(s => s.id !== baselineScenarioId)
         .map((scenario): CostPerAvertedCaseDatum | null => {
             const impact = impactsByScenarioId.get(scenario.id);
-            const metric = impact?.cost_per_averted_case;
-            const costValue = metric?.value;
+            const s = impact?.number_cases;
+            const cost = getCumulativeCosts(
+                budgetsByScenarioId.get(scenario.id),
+            );
+            if (cost == null) return null;
 
-            if (!costValue || costValue < 0) {
+            const costDiff = cost - baselineCost;
+            const central = computeCostPerAverted(costDiff, b.value, s?.value);
+            if (central === undefined) {
+                if (s?.value != null) {
+                    hasInsufficientAverted = true;
+                }
                 return null;
             }
 
-            const datum: CostPerAvertedCaseDatum = {
-                name: scenario.label,
-                value: costValue,
-                color: scenario.color,
-            };
+            const bound1 = computeCostPerAverted(costDiff, b.lower, s?.upper);
+            const bound2 = computeCostPerAverted(costDiff, b.upper, s?.lower);
 
-            if (metric.lower != null && metric.upper != null) {
-                datum.error = [
-                    costValue - metric.lower,
-                    metric.upper - costValue,
-                ];
+            let errorLower = 0;
+            let errorUpper = 0;
+            if (bound1 !== undefined && bound2 !== undefined) {
+                const ciLower = Math.min(bound1.value, bound2.value);
+                const ciUpper = Math.max(bound1.value, bound2.value);
+                errorLower = central.value - ciLower;
+                errorUpper = ciUpper - central.value;
             }
 
-            return datum;
+            return {
+                name: scenario.label,
+                value: central.value,
+                relativeCost: costDiff,
+                avertedCases: central.averted,
+                errorLower,
+                errorUpper,
+                errorBounds: [errorLower, errorUpper],
+                color: scenario.color,
+            };
         })
         .filter((d): d is CostPerAvertedCaseDatum => d !== null);
+
+    return { data, hasInsufficientAverted };
+};

--- a/js/src/domains/compareCustomize/utils/chartUtils.ts
+++ b/js/src/domains/compareCustomize/utils/chartUtils.ts
@@ -1,0 +1,47 @@
+/**
+ * D3-style "nice" step size for axis ticks (see d3-scale tickStep).
+ * Thresholds ≈ √50, √10, √2 are geometric means between 10, 5, 2, 1.
+ */
+const niceStep = (range: number, count: number): number => {
+    const raw = range / Math.max(1, count - 1);
+    const mag = 10 ** Math.floor(Math.log10(raw));
+    const r = raw / mag;
+    if (r >= 7.07) return 10 * mag;
+    if (r >= 3.16) return 5 * mag;
+    if (r >= 1.41) return 2 * mag;
+    return mag;
+};
+
+/**
+ * Axis domain + ticks with round labels, always including 0 (baseline).
+ * Recharts auto-scaling can't guarantee either, so we compute our own.
+ * Adds an extra step when data reaches within 10% of a domain edge.
+ */
+export const computeNiceTicks = (
+    data: { value: number; errorLower: number; errorUpper: number }[],
+): { domain: [number, number]; ticks: number[] } => {
+    if (data.length === 0) return { domain: [0, 1], ticks: [0] };
+
+    const dataMin = Math.min(
+        0,
+        ...data.map((d) => d.value - d.errorLower),
+    );
+    const dataMax = Math.max(
+        0,
+        ...data.map((d) => d.value + d.errorUpper),
+    );
+    const step = niceStep(dataMax - dataMin || 1, 6);
+
+    let lo = Math.floor(dataMin / step) * step;
+    let hi = Math.ceil(dataMax / step) * step;
+
+    if (dataMin < 0 && dataMin - lo < step * 0.1) lo -= step;
+    if (dataMax > 0 && hi - dataMax < step * 0.1) hi += step;
+
+    const ticks = Array.from(
+        { length: Math.round((hi - lo) / step) + 1 },
+        (_, i) => lo + i * step,
+    );
+
+    return { domain: [lo, hi], ticks };
+};

--- a/js/src/domains/messages.ts
+++ b/js/src/domains/messages.ts
@@ -237,6 +237,33 @@ export const MESSAGES = defineMessages({
         id: 'iaso.snt_malaria.label.costSettings',
         defaultMessage: 'Cost settings',
     },
+    costPerAvertedCaseTooltip: {
+        id: 'iaso.snt_malaria.compareCustomize.costPerAvertedCaseTooltip',
+        defaultMessage:
+            'The additional cost (or savings) per malaria case prevented, compared to the baseline scenario.',
+    },
+    costPerAvertedCaseLabel: {
+        id: 'iaso.snt_malaria.compareCustomize.costPerAvertedCaseLabel',
+        defaultMessage: 'Cost per averted case',
+    },
+    relativeCostLabel: {
+        id: 'iaso.snt_malaria.compareCustomize.relativeCostLabel',
+        defaultMessage: 'Relative cost',
+    },
+    avertedCasesLabel: {
+        id: 'iaso.snt_malaria.compareCustomize.avertedCasesLabel',
+        defaultMessage: 'Cases averted',
+    },
+    costPerAvertedCaseSelectComparison: {
+        id: 'iaso.snt_malaria.compareCustomize.costPerAvertedCaseSelectComparison',
+        defaultMessage:
+            'Select at least two scenarios to compare cost per averted case',
+    },
+    costPerAvertedCaseNoCasesAverted: {
+        id: 'iaso.snt_malaria.compareCustomize.costPerAvertedCaseNoCasesAverted',
+        defaultMessage:
+            'The compared scenarios do not avert cases relative to the selected baseline.',
+    },
     create: {
         defaultMessage: 'Create',
         id: 'iaso.label.create',

--- a/js/src/domains/planning/libs/cost-utils.tsx
+++ b/js/src/domains/planning/libs/cost-utils.tsx
@@ -40,14 +40,16 @@ export const formatPercentValue = (value: number) => {
 };
 
 export const formatBigNumber = (value: number) => {
-    if (value >= 1_000_000_000) {
-        return `${(value / 1_000_000_000).toFixed(2)}B`;
+    const abs = Math.abs(value);
+    const sign = value < 0 ? '-' : '';
+    if (abs >= 1_000_000_000) {
+        return `${sign}${(abs / 1_000_000_000).toFixed(2)}B`;
     }
-    if (value >= 1_000_000) {
-        return `${(value / 1_000_000).toFixed(2)}M`;
+    if (abs >= 1_000_000) {
+        return `${sign}${(abs / 1_000_000).toFixed(2)}M`;
     }
-    if (value >= 1_000) {
-        return `${(value / 1_000).toFixed(2)}K`;
+    if (abs >= 1_000) {
+        return `${sign}${(abs / 1_000).toFixed(2)}K`;
     }
-    return value.toString();
+    return value.toFixed(2);
 };

--- a/services/impact.py
+++ b/services/impact.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from iaso.models import OrgUnit
-from plugins.snt_malaria.models import Budget, Intervention, InterventionAssignment, Scenario
+from plugins.snt_malaria.models import Intervention, InterventionAssignment, Scenario
 from plugins.snt_malaria.providers.impact.base import (
     ImpactMetricWithConfidenceInterval,
     ImpactProvider,
@@ -20,12 +20,7 @@ class ImpactMetrics:
     number_cases: ImpactMetricWithConfidenceInterval = field(default_factory=ImpactMetricWithConfidenceInterval)
     number_severe_cases: ImpactMetricWithConfidenceInterval = field(default_factory=ImpactMetricWithConfidenceInterval)
     prevalence_rate: ImpactMetricWithConfidenceInterval = field(default_factory=ImpactMetricWithConfidenceInterval)
-    averted_cases: ImpactMetricWithConfidenceInterval = field(default_factory=ImpactMetricWithConfidenceInterval)
     direct_deaths: ImpactMetricWithConfidenceInterval = field(default_factory=ImpactMetricWithConfidenceInterval)
-    cost: Optional[float] = None
-    cost_per_averted_case: ImpactMetricWithConfidenceInterval = field(
-        default_factory=ImpactMetricWithConfidenceInterval
-    )
 
 
 @dataclass
@@ -40,19 +35,14 @@ class OrgUnitImpactMetrics(ImpactMetrics):
         cls,
         result: ImpactResult,
         org_unit: OrgUnit,
-        cost: Optional[float] = None,
     ) -> "OrgUnitImpactMetrics":
-        averted_cases = _compute_averted_cases(result.population, result.number_cases, result.number_severe_cases)
         return cls(
             org_unit_id=org_unit.id,
             org_unit_name=org_unit.name,
             number_cases=result.number_cases,
             number_severe_cases=result.number_severe_cases,
             prevalence_rate=result.prevalence_rate,
-            averted_cases=averted_cases,
             direct_deaths=result.direct_deaths,
-            cost=cost,
-            cost_per_averted_case=_compute_cost_per_averted(cost, averted_cases),
         )
 
 
@@ -75,79 +65,21 @@ class ScenarioImpactMetrics(ImpactMetrics):
     org_units_with_unmatched_interventions: list[OrgUnitRef] = field(default_factory=list)
 
 
-def _compute_averted_cases(
-    population: float,
-    number_cases: ImpactMetricWithConfidenceInterval,
-    number_severe_cases: ImpactMetricWithConfidenceInterval,
-) -> ImpactMetricWithConfidenceInterval:
-    """Compute averted cases = population - (cases + severe).
-
-    CI bounds invert: lower averted when cases are at their upper bound.
-    """
-
-    def _subtract(pop, cases_val, severe_val):
-        if cases_val is not None and severe_val is not None:
-            return pop - (cases_val + severe_val)
-        return None
-
-    return ImpactMetricWithConfidenceInterval(
-        value=_subtract(population, number_cases.value, number_severe_cases.value),
-        # CI bounds invert: fewer cases (lower bound) → more averted (upper bound)
-        lower=_subtract(population, number_cases.upper, number_severe_cases.upper),
-        upper=_subtract(population, number_cases.lower, number_severe_cases.lower),
-    )
-
-
-def _compute_cost_per_averted(
-    cost: Optional[float],
-    averted_cases: ImpactMetricWithConfidenceInterval,
-) -> ImpactMetricWithConfidenceInterval:
-    """Compute cost per averted case = cost / averted.
-
-    CI bounds invert: lower cost/averted when most averted (upper).
-    """
-    if cost is None:
-        return ImpactMetricWithConfidenceInterval()
-
-    def _divide(c, averted):
-        if averted is not None and averted > 0:
-            return c / averted
-        return None
-
-    return ImpactMetricWithConfidenceInterval(
-        value=_divide(cost, averted_cases.value),
-        # CI bounds invert: more averted (upper) → lower cost per averted
-        lower=_divide(cost, averted_cases.upper),
-        upper=_divide(cost, averted_cases.lower),
-    )
-
-
 def _aggregate_metrics(metrics: list[ImpactMetrics]) -> ImpactMetrics:
     """Aggregate a list of ImpactMetrics.
 
-    Sums cases, severe cases, averted cases, direct deaths, and cost.
-    Averages prevalence. Derives cost_per_averted_case from summed cost
-    and summed averted cases (only counting entries that have cost data).
+    Sums cases, severe cases, and direct deaths. Averages prevalence.
     """
     sum_cases = ImpactMetricWithConfidenceInterval()
     sum_severe = ImpactMetricWithConfidenceInterval()
-    sum_averted = ImpactMetricWithConfidenceInterval()
     sum_deaths = ImpactMetricWithConfidenceInterval()
-    sum_cost = 0.0
-    has_cost = False
-    sum_costed_averted = ImpactMetricWithConfidenceInterval()
     sum_prevalence = ImpactMetricWithConfidenceInterval()
     prevalence_count = 0
 
     for m in metrics:
         sum_cases = sum_cases + m.number_cases
         sum_severe = sum_severe + m.number_severe_cases
-        sum_averted = sum_averted + m.averted_cases
         sum_deaths = sum_deaths + m.direct_deaths
-        if m.cost is not None:
-            sum_cost += m.cost
-            has_cost = True
-            sum_costed_averted = sum_costed_averted + m.averted_cases
         if m.prevalence_rate.value is not None:
             sum_prevalence = sum_prevalence + m.prevalence_rate
             prevalence_count += 1
@@ -158,20 +90,15 @@ def _aggregate_metrics(metrics: list[ImpactMetrics]) -> ImpactMetrics:
         number_cases=sum_cases,
         number_severe_cases=sum_severe,
         prevalence_rate=avg_prevalence,
-        averted_cases=sum_averted,
         direct_deaths=sum_deaths,
-        cost=sum_cost if has_cost else None,
-        cost_per_averted_case=_compute_cost_per_averted(sum_cost if has_cost else None, sum_costed_averted),
     )
 
 
 class ImpactService:
     """Orchestrates impact analysis for a scenario.
 
-    Combines epidemiological data from an ImpactProvider (cases, prevalence,
-    deaths) with budget cost data for the given scenario to produce enriched
-    metrics such as averted cases and cost per averted case. Results are
-    aggregated per org unit, per year, and overall.
+    Fetches epidemiological data from an ImpactProvider (cases, prevalence,
+    deaths) and aggregates results per org unit, per year, and overall.
     """
 
     def __init__(self, provider: ImpactProvider):
@@ -186,8 +113,7 @@ class ImpactService:
     ) -> ScenarioImpactMetrics:
         """Return the full impact result for a scenario."""
         org_unit_interventions = self._get_org_unit_interventions(scenario)
-        cost_map = self._build_cost_map(scenario)
-        year_data, warnings = self._collect_metrics(org_unit_interventions, cost_map, age_group, year_from, year_to)
+        year_data, warnings = self._collect_metrics(org_unit_interventions, age_group, year_from, year_to)
         return self._build_response(scenario, year_data, warnings)
 
     @staticmethod
@@ -203,29 +129,9 @@ class ImpactService:
             result[assignment.org_unit].append(assignment.intervention)
         return dict(result)
 
-    @staticmethod
-    def _build_cost_map(scenario: Scenario) -> dict[int, dict[int, float]]:
-        latest_budget = Budget.objects.filter(scenario=scenario).order_by("-created_at").first()
-        if not latest_budget or not latest_budget.results:
-            return {}
-
-        cost_map: dict[int, dict[int, float]] = {}
-        for year_result in latest_budget.results:
-            budget_year = year_result.get("year")
-            if budget_year is None:
-                continue
-            for org_unit_cost in year_result.get("org_units_costs", []):
-                ou_id = org_unit_cost.get("org_unit_id")
-                cost = org_unit_cost.get("total_cost", 0)
-                if ou_id is not None:
-                    cost_map.setdefault(budget_year, {})[ou_id] = cost
-
-        return cost_map
-
     def _collect_metrics(
         self,
         org_unit_interventions: dict[OrgUnit, list[Intervention]],
-        cost_map: dict[int, dict[int, float]],
         age_group: str,
         year_from: Optional[str],
         year_to: Optional[str],
@@ -235,13 +141,9 @@ class ImpactService:
         warnings = MatchWarnings()
 
         if self._provider.supports_bulk:
-            self._collect_bulk(
-                org_unit_interventions, age_group, year_from, year_to, ou_by_id, cost_map, year_data, warnings
-            )
+            self._collect_bulk(org_unit_interventions, age_group, year_from, year_to, ou_by_id, year_data, warnings)
         else:
-            self._collect_individual(
-                org_unit_interventions, age_group, year_from, year_to, cost_map, year_data, warnings
-            )
+            self._collect_individual(org_unit_interventions, age_group, year_from, year_to, year_data, warnings)
 
         return dict(year_data), warnings
 
@@ -252,7 +154,6 @@ class ImpactService:
         year_from: Optional[str],
         year_to: Optional[str],
         ou_by_id: dict[int, OrgUnit],
-        cost_map: dict[int, dict[int, float]],
         year_data: dict[int, list[OrgUnitImpactMetrics]],
         warnings: MatchWarnings,
     ) -> None:
@@ -279,8 +180,7 @@ class ImpactService:
             for ou_id, impact_results in bulk.results.items():
                 org_unit = ou_by_id[ou_id]
                 for result in impact_results:
-                    ou_cost = cost_map.get(result.year, {}).get(ou_id)
-                    metrics = OrgUnitImpactMetrics.from_impact_result(result, org_unit, cost=ou_cost)
+                    metrics = OrgUnitImpactMetrics.from_impact_result(result, org_unit)
                     year_data[result.year].append(metrics)
 
     def _collect_individual(
@@ -289,7 +189,6 @@ class ImpactService:
         age_group: str,
         year_from: Optional[str],
         year_to: Optional[str],
-        cost_map: dict[int, dict[int, float]],
         year_data: dict[int, list[OrgUnitImpactMetrics]],
         warnings: MatchWarnings,
     ) -> None:
@@ -309,8 +208,7 @@ class ImpactService:
             )
 
             for result in match.results:
-                ou_cost = cost_map.get(result.year, {}).get(org_unit.id)
-                metrics = OrgUnitImpactMetrics.from_impact_result(result, org_unit, cost=ou_cost)
+                metrics = OrgUnitImpactMetrics.from_impact_result(result, org_unit)
                 year_data[result.year].append(metrics)
 
     def _aggregate_org_units(

--- a/tests/api/impact/test_serializers.py
+++ b/tests/api/impact/test_serializers.py
@@ -115,26 +115,20 @@ class ImpactQuerySerializerTestCase(TestCase):
 
 class ScenarioImpactSerializerTestCase(TestCase):
     def test_full_response_structure(self):
-        """All fields including CI bounds, averted_cases, cost, and cost_per_averted_case are serialized."""
+        """All fields including CI bounds are serialized."""
         metrics = ScenarioImpactMetrics(
             scenario_id=42,
             number_cases=_metric(100.0, 90.0, 110.0),
             number_severe_cases=_metric(10.0, 8.0, 12.0),
             prevalence_rate=_metric(0.05, 0.04, 0.06),
-            averted_cases=_metric(20.0, 15.0, 25.0),
             direct_deaths=_metric(2.0, 1.5, 2.5),
-            cost=5000.0,
-            cost_per_averted_case=_metric(250.0, 200.0, 333.3),
             by_year=[
                 YearImpactMetrics(
                     year=2025,
                     number_cases=_metric(50.0, 45.0, 55.0),
                     number_severe_cases=_metric(5.0, 4.0, 6.0),
                     prevalence_rate=_metric(0.06, 0.05, 0.07),
-                    averted_cases=_metric(10.0, 7.0, 13.0),
                     direct_deaths=_metric(1.0, 0.8, 1.2),
-                    cost=2500.0,
-                    cost_per_averted_case=_metric(250.0, 192.3, 357.1),
                     org_units=[
                         OrgUnitImpactMetrics(
                             org_unit_id=1,
@@ -142,10 +136,7 @@ class ScenarioImpactSerializerTestCase(TestCase):
                             number_cases=_metric(50.0, 45.0, 55.0),
                             number_severe_cases=_metric(5.0, 4.0, 6.0),
                             prevalence_rate=_metric(0.06, 0.05, 0.07),
-                            averted_cases=_metric(10.0, 7.0, 13.0),
                             direct_deaths=_metric(1.0, 0.8, 1.2),
-                            cost=2500.0,
-                            cost_per_averted_case=_metric(250.0, 192.3, 357.1),
                         ),
                     ],
                 ),
@@ -157,31 +148,23 @@ class ScenarioImpactSerializerTestCase(TestCase):
                     number_cases=_metric(100.0, 90.0, 110.0),
                     number_severe_cases=_metric(10.0, 8.0, 12.0),
                     prevalence_rate=_metric(0.05, 0.04, 0.06),
-                    averted_cases=_metric(20.0, 15.0, 25.0),
                     direct_deaths=_metric(2.0, 1.5, 2.5),
-                    cost=5000.0,
-                    cost_per_averted_case=_metric(250.0, 200.0, 333.3),
                 ),
             ],
         )
         data = ScenarioImpactSerializer(metrics).data
 
         self.assertEqual(data["scenario_id"], 42)
-        self.assertEqual(data["cost"], 5000.0)
 
         self._assert_metric(data["number_cases"], 100.0, 90.0, 110.0)
         self._assert_metric(data["number_severe_cases"], 10.0, 8.0, 12.0)
         self._assert_metric(data["prevalence_rate"], 0.05, 0.04, 0.06)
-        self._assert_metric(data["averted_cases"], 20.0, 15.0, 25.0)
         self._assert_metric(data["direct_deaths"], 2.0, 1.5, 2.5)
-        self._assert_metric(data["cost_per_averted_case"], 250.0, 200.0, 333.3)
 
         self.assertEqual(len(data["by_year"]), 1)
         year = data["by_year"][0]
         self.assertEqual(year["year"], 2025)
-        self.assertEqual(year["cost"], 2500.0)
         self._assert_metric(year["number_cases"], 50.0, 45.0, 55.0)
-        self._assert_metric(year["averted_cases"], 10.0, 7.0, 13.0)
 
         self.assertEqual(len(year["org_units"]), 1)
         ou_year = year["org_units"][0]
@@ -194,7 +177,6 @@ class ScenarioImpactSerializerTestCase(TestCase):
         self.assertEqual(ou["org_unit_id"], 1)
         self.assertEqual(ou["org_unit_name"], "OU1")
         self._assert_metric(ou["number_cases"], 100.0, 90.0, 110.0)
-        self._assert_metric(ou["averted_cases"], 20.0, 15.0, 25.0)
 
     def test_empty_results(self):
         """No impact data matched: empty lists and all-None metrics are serialized cleanly."""
@@ -202,12 +184,9 @@ class ScenarioImpactSerializerTestCase(TestCase):
         data = ScenarioImpactSerializer(metrics).data
 
         self.assertEqual(data["scenario_id"], 1)
-        self.assertIsNone(data["cost"])
         self.assertIsNone(data["number_cases"]["value"])
         self.assertIsNone(data["number_cases"]["lower"])
         self.assertIsNone(data["number_cases"]["upper"])
-        self.assertIsNone(data["averted_cases"]["value"])
-        self.assertIsNone(data["cost_per_averted_case"]["value"])
         self.assertEqual(data["by_year"], [])
         self.assertEqual(data["org_units"], [])
 

--- a/tests/services/test_impact.py
+++ b/tests/services/test_impact.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 from iaso.models import OrgUnit, OrgUnitType
 from iaso.test import TestCase
-from plugins.snt_malaria.models import Budget, Intervention, InterventionAssignment, InterventionCategory, Scenario
+from plugins.snt_malaria.models import Intervention, InterventionAssignment, InterventionCategory, Scenario
 from plugins.snt_malaria.providers.impact.base import (
     BulkMatchResult,
     ImpactMetricWithConfidenceInterval,
@@ -26,7 +26,7 @@ def _metric(value=None, lower=None, upper=None):
 class AggregateMetricsTestCase(TestCase):
     """Tests for _aggregate_metrics module-level function."""
 
-    def test_sums_number_cases_number_severe_cases_direct_deaths_and_cost(self):
+    def test_sums_number_cases_number_severe_cases_and_direct_deaths(self):
         metrics = [
             OrgUnitImpactMetrics(
                 org_unit_id=1,
@@ -34,7 +34,6 @@ class AggregateMetricsTestCase(TestCase):
                 number_cases=_metric(100.0),
                 number_severe_cases=_metric(10.0),
                 direct_deaths=_metric(2.0),
-                cost=5000.0,
             ),
             OrgUnitImpactMetrics(
                 org_unit_id=2,
@@ -42,14 +41,12 @@ class AggregateMetricsTestCase(TestCase):
                 number_cases=_metric(50.0),
                 number_severe_cases=_metric(5.0),
                 direct_deaths=_metric(1.0),
-                cost=3000.0,
             ),
         ]
         result = _aggregate_metrics(metrics)
         self.assertEqual(result.number_cases.value, 150.0)
         self.assertEqual(result.number_severe_cases.value, 15.0)
         self.assertEqual(result.direct_deaths.value, 3.0)
-        self.assertEqual(result.cost, 8000.0)
 
     def test_averages_prevalence_rate(self):
         metrics = [
@@ -73,7 +70,6 @@ class AggregateMetricsTestCase(TestCase):
         self.assertIsNone(result.number_severe_cases.value)
         self.assertIsNone(result.direct_deaths.value)
         self.assertIsNone(result.prevalence_rate.value)
-        self.assertIsNone(result.cost)
 
     def test_single_entry_with_none_prevalence_returns_default_prevalence(self):
         metrics = [
@@ -87,23 +83,6 @@ class AggregateMetricsTestCase(TestCase):
         result = _aggregate_metrics(metrics)
         self.assertEqual(result.number_cases.value, 100.0)
         self.assertIsNone(result.prevalence_rate.value)
-
-    def test_cost_none_when_no_metrics_have_cost(self):
-        metrics = [
-            OrgUnitImpactMetrics(org_unit_id=1, org_unit_name="OU1", cost=None),
-            OrgUnitImpactMetrics(org_unit_id=2, org_unit_name="OU2", cost=None),
-        ]
-        result = _aggregate_metrics(metrics)
-        self.assertIsNone(result.cost)
-
-    def test_cost_sums_only_non_none(self):
-        metrics = [
-            OrgUnitImpactMetrics(org_unit_id=1, org_unit_name="OU1", cost=5000.0),
-            OrgUnitImpactMetrics(org_unit_id=2, org_unit_name="OU2", cost=None),
-            OrgUnitImpactMetrics(org_unit_id=3, org_unit_name="OU3", cost=2000.0),
-        ]
-        result = _aggregate_metrics(metrics)
-        self.assertEqual(result.cost, 7000.0)
 
 
 class ImpactServiceGetScenarioImpactTestCase(TestCase):
@@ -189,33 +168,6 @@ class ImpactServiceGetScenarioImpactTestCase(TestCase):
             created_by=self.user,
         )
 
-        Budget.objects.create(
-            scenario=self.scenario,
-            name="Test Budget",
-            created_by=self.user,
-            cost_input={},
-            population_input={},
-            assumptions={},
-            results=[
-                {
-                    "year": 2025,
-                    "org_units_costs": [
-                        {"org_unit_id": self.district1.id, "total_cost": 5000.0},
-                        {"org_unit_id": self.district2.id, "total_cost": 3000.0},
-                        {"org_unit_id": self.district3.id, "total_cost": 7000.0},
-                    ],
-                },
-                {
-                    "year": 2026,
-                    "org_units_costs": [
-                        {"org_unit_id": self.district1.id, "total_cost": 5500.0},
-                        {"org_unit_id": self.district2.id, "total_cost": 3500.0},
-                        {"org_unit_id": self.district3.id, "total_cost": 7500.0},
-                    ],
-                },
-            ],
-        )
-
     def _make_impact_results(self):
         """Return a dict of org_unit_id -> [ImpactResult] with distinct values per district and year."""
         return {
@@ -294,18 +246,16 @@ class ImpactServiceGetScenarioImpactTestCase(TestCase):
         return mock_provider
 
     def _assert_scenario_impact(self, result):
-        """Shared assertions on a ScenarioImpactMetrics produced from _make_impact_results + Budget fixture."""
+        """Shared assertions on a ScenarioImpactMetrics produced from _make_impact_results."""
         self.assertEqual(result.scenario_id, self.scenario.id)
 
         # -- Top-level aggregation (3 districts x 2 years = 6 entries) --
         # cases: 600 + 630 = 1230, severe: 60 + 63 = 123, deaths: 12 + 15 = 27
         # prevalence: avg(0.04,0.06,0.08,0.05,0.07,0.09) = 0.065
-        # cost: 15000 + 16500 = 31500
         self.assertEqual(result.number_cases.value, 1230.0)
         self.assertEqual(result.number_severe_cases.value, 123.0)
         self.assertAlmostEqual(result.prevalence_rate.value, 0.065)
         self.assertEqual(result.direct_deaths.value, 27.0)
-        self.assertEqual(result.cost, 31500.0)
 
         # -- by_year breakdown --
         self.assertEqual(len(result.by_year), 2)
@@ -316,16 +266,12 @@ class ImpactServiceGetScenarioImpactTestCase(TestCase):
         self.assertEqual(year_2025.number_severe_cases.value, 60.0)
         self.assertAlmostEqual(year_2025.prevalence_rate.value, 0.06)
         self.assertEqual(year_2025.direct_deaths.value, 12.0)
-        self.assertEqual(year_2025.cost, 15000.0)
 
         self.assertEqual(len(year_2025.org_units), 3)
         ou_2025 = {ou.org_unit_id: ou for ou in year_2025.org_units}
         self.assertEqual(ou_2025[self.district1.id].number_cases.value, 100.0)
-        self.assertEqual(ou_2025[self.district1.id].cost, 5000.0)
         self.assertEqual(ou_2025[self.district2.id].number_cases.value, 200.0)
-        self.assertEqual(ou_2025[self.district2.id].cost, 3000.0)
         self.assertEqual(ou_2025[self.district3.id].number_cases.value, 300.0)
-        self.assertEqual(ou_2025[self.district3.id].cost, 7000.0)
 
         year_2026 = result.by_year[1]
         self.assertEqual(year_2026.year, 2026)
@@ -333,41 +279,34 @@ class ImpactServiceGetScenarioImpactTestCase(TestCase):
         self.assertEqual(year_2026.number_severe_cases.value, 63.0)
         self.assertAlmostEqual(year_2026.prevalence_rate.value, 0.07)
         self.assertEqual(year_2026.direct_deaths.value, 15.0)
-        self.assertEqual(year_2026.cost, 16500.0)
 
         self.assertEqual(len(year_2026.org_units), 3)
         ou_2026 = {ou.org_unit_id: ou for ou in year_2026.org_units}
         self.assertEqual(ou_2026[self.district1.id].number_cases.value, 110.0)
-        self.assertEqual(ou_2026[self.district1.id].cost, 5500.0)
         self.assertEqual(ou_2026[self.district2.id].number_cases.value, 210.0)
-        self.assertEqual(ou_2026[self.district2.id].cost, 3500.0)
         self.assertEqual(ou_2026[self.district3.id].number_cases.value, 310.0)
-        self.assertEqual(ou_2026[self.district3.id].cost, 7500.0)
 
         # -- org_units across years --
         self.assertEqual(len(result.org_units), 3)
         agg = {ou.org_unit_id: ou for ou in result.org_units}
 
-        # District 1: cases 100+110=210, prevalence avg(0.04,0.05)=0.045, cost 5000+5500=10500
+        # District 1: cases 100+110=210, prevalence avg(0.04,0.05)=0.045
         self.assertEqual(agg[self.district1.id].number_cases.value, 210.0)
         self.assertEqual(agg[self.district1.id].number_severe_cases.value, 21.0)
         self.assertAlmostEqual(agg[self.district1.id].prevalence_rate.value, 0.045)
         self.assertEqual(agg[self.district1.id].direct_deaths.value, 5.0)
-        self.assertEqual(agg[self.district1.id].cost, 10500.0)
 
-        # District 2: cases 200+210=410, prevalence avg(0.06,0.07)=0.065, cost 3000+3500=6500
+        # District 2: cases 200+210=410, prevalence avg(0.06,0.07)=0.065
         self.assertEqual(agg[self.district2.id].number_cases.value, 410.0)
         self.assertEqual(agg[self.district2.id].number_severe_cases.value, 41.0)
         self.assertAlmostEqual(agg[self.district2.id].prevalence_rate.value, 0.065)
         self.assertEqual(agg[self.district2.id].direct_deaths.value, 9.0)
-        self.assertEqual(agg[self.district2.id].cost, 6500.0)
 
-        # District 3: cases 300+310=610, prevalence avg(0.08,0.09)=0.085, cost 7000+7500=14500
+        # District 3: cases 300+310=610, prevalence avg(0.08,0.09)=0.085
         self.assertEqual(agg[self.district3.id].number_cases.value, 610.0)
         self.assertEqual(agg[self.district3.id].number_severe_cases.value, 61.0)
         self.assertAlmostEqual(agg[self.district3.id].prevalence_rate.value, 0.085)
         self.assertEqual(agg[self.district3.id].direct_deaths.value, 13.0)
-        self.assertEqual(agg[self.district3.id].cost, 14500.0)
 
         # -- warnings should be empty in the happy path --
         self.assertEqual(result.org_units_not_found, [])


### PR DESCRIPTION
## What problem is this PR solving?

Remove averted cases from backend/API, calculate comparative averted cases in frontend

### Related JIRA tickets

SNT-339

## Changes

The "Cost per averted case" widget in Compare & Customize now calculates the metric comparatively against the selected baseline scenario, rather than calculating averted cases against the population within a scenario in the backend.

### Changes
#### Backend

* Removed `averted_cases`, `cost`, and `cost_per_averted_case` from the impact API response (service, serializers, and tests). These are no longer computed server-side.

#### Cost per averted case chart

* Calculates cost per averted case on the frontend by comparing each scenario's budget and uncomplicated cases against the baseline: `(scenario.cost - baseline.cost) / (baseline.cases - scenario.cases)`
* Switched from vertical to horizontal bar chart with a yellow baseline reference line at zero, labelled "Baseline"
* Confidence intervals shown as error bars
* Scenarios that don't meaningfully avert cases (< 1) are filtered out with a dedicated info message
* New tooltip shows cost per averted case, relative cost, and cases averted
* New ChartTooltip component with compact, consistent styling (matching map tooltips) used across all three chart widgets
* Added optional help icon tooltip to Card component, used for explaining cost per averted case
* Fixed formatBigNumber to correctly handle negative values and apply .toFixed(2) consistently

At least two scenarios need to be selected
<img width="628" height="316" alt="image" src="https://github.com/user-attachments/assets/c2c5ca2b-48c9-40c2-b17b-55bc03f264ce" />

No cases are averted
<img width="628" height="316" alt="image" src="https://github.com/user-attachments/assets/763f3e58-6514-4321-bb8f-52652caa8cb5" />

Different positive/negative bar constellations
<img width="628" height="316" alt="image" src="https://github.com/user-attachments/assets/8e62702f-e818-4120-bc33-397461c9882d" />
<img width="628" height="316" alt="image" src="https://github.com/user-attachments/assets/84828991-698c-4cb6-b74c-e0aa2a85577d" />
<img width="628" height="316" alt="image" src="https://github.com/user-attachments/assets/578e1281-657b-452c-bd76-ae86bfe2c654" />



## How to test
* Prepare three scenarios with valid interventions that match impact data and generate budgets for them. Ideally they yield significantly differetnt cases and costs
* Prepare one scenario without cost
* Go to Compare and Customize, you should see "select at least two scenarios" message in the widget
* Select two scenarios, one of which has no budget data, you should see the "no budget data" message
* Select two scenarios with budget data, select one with **less or equal** cases as your baseline. You shoud see a "no cases averted" message in the widget
* Select two scenarios with budget data, select the one with the highest cases as your baseline. You should see averted cases bars
* Select three scenarios with budget data, you should see two bars
