### PR TITLE
SNT-396: Added an isScenarioEditable which check on lock and user perms

### DIFF
--- a/api/scenario_rules/permissions.py
+++ b/api/scenario_rules/permissions.py
@@ -22,6 +22,9 @@ class ScenarioRulePermission(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:  # = GET for retrieve
             return True
 
+        if obj.scenario.is_locked:
+            return False
+
         user = request.user
         if user.has_perm(SNT_SCENARIO_FULL_WRITE_PERMISSION.full_name()):  # PATCH & DELETE
             return True

--- a/api/scenario_rules/serializers.py
+++ b/api/scenario_rules/serializers.py
@@ -202,6 +202,10 @@ class ScenarioRuleCreateSerializer(ScenarioRuleWriteSerializerBase):
 
     def validate_scenario(self, scenario):
         user = self.context["request"].user
+
+        if scenario.is_locked:
+            raise serializers.ValidationError("Cannot add rules to a locked scenario")
+
         if scenario.created_by != user and not user.has_perm(SNT_SCENARIO_FULL_WRITE_PERMISSION.full_name()):
             raise PermissionDenied("You don't have permission to edit this scenario")
         return scenario

--- a/api/scenarios/permissions.py
+++ b/api/scenarios/permissions.py
@@ -24,6 +24,9 @@ class ScenarioPermission(permissions.BasePermission):
         ):  # = GET for retrieve & POST for duplicate
             return True
 
+        if obj.is_locked and request.method in ["DELETE"]:
+            return False
+
         user = request.user
         if user.has_perm(SNT_SCENARIO_FULL_WRITE_PERMISSION.full_name()):  # PUT, DELETE & reorder
             return True

--- a/api/scenarios/serializers.py
+++ b/api/scenarios/serializers.py
@@ -44,7 +44,15 @@ class ScenarioWriteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Scenario
         fields = ["id", "name", "description", "start_year", "end_year", "is_locked"]
-        read_ony_fields = ["id"]
+        read_only_fields = ["id"]
+
+    def validate(self, data):
+        if self.instance and self.instance.is_locked:
+            # Only allow changing is_locked if scenario is locked
+            changed_fields = {key for key in data if getattr(self.instance, key, None) != data[key]}
+            if not changed_fields.issubset({"is_locked"}):
+                raise serializers.ValidationError(_("Cannot modify a locked scenario."))
+        return data
 
     def validate_start_year(self, value):
         if value < ScenarioWriteSerializer.SCENARIO_MIN_YEAR or value > ScenarioWriteSerializer.SCENARIO_MAX_YEAR:
@@ -117,6 +125,10 @@ class ScenarioRulesReorderSerializer(serializers.Serializer):
 
     def validate_new_order(self, new_order):
         scenario = self.context["scenario"]
+
+        if scenario.is_locked:
+            raise serializers.ValidationError("Cannot reorder rules for a locked scenario.")
+
         received_ids = set(rule.id for rule in new_order)
         scenario_rules_ids = set(scenario.rules.order_by("id").values_list("id", flat=True))
 

--- a/js/src/domains/planning/components/interventionPlan/BudgetAssumptionsForm.tsx
+++ b/js/src/domains/planning/components/interventionPlan/BudgetAssumptionsForm.tsx
@@ -43,7 +43,7 @@ export const BudgetAssumptionsForm: FC<Props> = ({
 }) => {
     const percentageNumberOptions = { suffix: '%', decimalScale: 0 };
     const { formatMessage } = useSafeIntl();
-    const { canEditScenario } = usePlanningContext();
+    const { isScenarioEditable } = usePlanningContext();
     const {
         mutateAsync: saveBudgetAssumptions,
         isLoading: isSavingBudgetAssumptions,
@@ -198,7 +198,7 @@ export const BudgetAssumptionsForm: FC<Props> = ({
                                 label={MESSAGES.budgetAssumptionsPopProp3_11}
                                 numberInputOptions={percentageNumberOptions}
                                 wrapperSx={styles.inputWrapper}
-                                disabled={!canEditScenario}
+                                disabled={!isScenarioEditable}
                             />
                         )}
                         {validationSchema.fields.pop_prop_12_59 && (
@@ -212,7 +212,7 @@ export const BudgetAssumptionsForm: FC<Props> = ({
                                 label={MESSAGES.budgetAssumptionsPopProp12_59}
                                 numberInputOptions={percentageNumberOptions}
                                 wrapperSx={styles.inputWrapper}
-                                disabled={!canEditScenario}
+                                disabled={!isScenarioEditable}
                             />
                         )}
                         <InputComponent
@@ -225,7 +225,7 @@ export const BudgetAssumptionsForm: FC<Props> = ({
                             label={MESSAGES.budgetAssumptionsCoverage}
                             numberInputOptions={percentageNumberOptions}
                             wrapperSx={styles.inputWrapper}
-                            disabled={!canEditScenario}
+                            disabled={!isScenarioEditable}
                         />
                         {validationSchema.fields.divisor && (
                             <InputComponent
@@ -238,7 +238,7 @@ export const BudgetAssumptionsForm: FC<Props> = ({
                                 label={MESSAGES.budgetAssumptionsPPN}
                                 numberInputOptions={{ decimalScale: 1 }}
                                 wrapperSx={styles.inputWrapper}
-                                disabled={!canEditScenario}
+                                disabled={!isScenarioEditable}
                             />
                         )}
                         {validationSchema.fields.touchpoints && (
@@ -252,7 +252,7 @@ export const BudgetAssumptionsForm: FC<Props> = ({
                                 label={MESSAGES.budgetAssumptionsTouchpoints}
                                 numberInputOptions={{ decimalScale: 0 }}
                                 wrapperSx={styles.inputWrapper}
-                                disabled={!canEditScenario}
+                                disabled={!isScenarioEditable}
                             />
                         )}
                         {validationSchema.fields.monthly_rounds && (
@@ -266,7 +266,7 @@ export const BudgetAssumptionsForm: FC<Props> = ({
                                 label={MESSAGES.budgetAssumptionsMonthlyRound}
                                 numberInputOptions={{ decimalScale: 0 }}
                                 wrapperSx={styles.inputWrapper}
-                                disabled={!canEditScenario}
+                                disabled={!isScenarioEditable}
                             />
                         )}
                         {validationSchema.fields.bale_size && (
@@ -280,7 +280,7 @@ export const BudgetAssumptionsForm: FC<Props> = ({
                                 label={MESSAGES.budgetAssumptionsBaleSize}
                                 numberInputOptions={{ decimalScale: 0 }}
                                 wrapperSx={styles.inputWrapper}
-                                disabled={!canEditScenario}
+                                disabled={!isScenarioEditable}
                             />
                         )}
                         {validationSchema.fields.doses_per_pw && (
@@ -294,7 +294,7 @@ export const BudgetAssumptionsForm: FC<Props> = ({
                                 label={MESSAGES.budgetAssumptionsDosesPerPW}
                                 numberInputOptions={{ decimalScale: 0 }}
                                 wrapperSx={styles.inputWrapper}
-                                disabled={!canEditScenario}
+                                disabled={!isScenarioEditable}
                             />
                         )}
                         {validationSchema.fields.doses_per_child && (
@@ -308,7 +308,7 @@ export const BudgetAssumptionsForm: FC<Props> = ({
                                 label={MESSAGES.budgetAssumptionsDosesPerChild}
                                 numberInputOptions={{ decimalScale: 0 }}
                                 wrapperSx={styles.inputWrapper}
-                                disabled={!canEditScenario}
+                                disabled={!isScenarioEditable}
                             />
                         )}
                         {validationSchema.fields.tablet_factor && (
@@ -322,7 +322,7 @@ export const BudgetAssumptionsForm: FC<Props> = ({
                                 label={MESSAGES.budgetAssumptionsTabletFactor}
                                 numberInputOptions={percentageNumberOptions}
                                 wrapperSx={styles.inputWrapper}
-                                disabled={!canEditScenario}
+                                disabled={!isScenarioEditable}
                             />
                         )}
 
@@ -336,7 +336,7 @@ export const BudgetAssumptionsForm: FC<Props> = ({
                             label={MESSAGES.budgetAssumptionsBuffer}
                             numberInputOptions={percentageNumberOptions}
                             wrapperSx={styles.inputWrapper}
-                            disabled={!canEditScenario}
+                            disabled={!isScenarioEditable}
                         />
                     </Box>
                     <Box>
@@ -357,7 +357,7 @@ export const BudgetAssumptionsForm: FC<Props> = ({
                         </Typography>
                     </Box>
                 </Box>
-                {canEditScenario && (
+                {isScenarioEditable && (
                     <Button
                         onClick={() => handleSubmit()}
                         variant="contained"

--- a/js/src/domains/planning/components/interventionPlan/InterventionPlanHeader.tsx
+++ b/js/src/domains/planning/components/interventionPlan/InterventionPlanHeader.tsx
@@ -50,7 +50,8 @@ export const InterventionPlanHeader: FC<Props> = ({
     onDeleteScenario,
     onToggleLockScenario,
 }) => {
-    const { scenarioId, scenario, canEditScenario } = usePlanningContext();
+    const { scenarioId, scenario, canEditScenario, isScenarioEditable } =
+        usePlanningContext();
     const csvUrl = `${exportScenarioAPIPath}?id=${scenarioId}`;
 
     const { formatMessage } = useSafeIntl();
@@ -151,7 +152,7 @@ export const InterventionPlanHeader: FC<Props> = ({
                         />
                     </DisplayIfUserHasPerm>
 
-                    {canEditScenario && !scenario?.is_locked && (
+                    {isScenarioEditable && (
                         <>
                             <UpdateScenarioModal
                                 onClose={noOp}

--- a/js/src/domains/planning/components/scenarioRule/scenarioRuleList/ScenarioRuleLine.tsx
+++ b/js/src/domains/planning/components/scenarioRule/scenarioRuleList/ScenarioRuleLine.tsx
@@ -39,7 +39,7 @@ export const ScenarioRuleLine: FC<Props> = ({ scenarioId, rule, onEdit }) => {
     const { mutateAsync: deleteScenarioRule } =
         useDeleteScenarioRule(scenarioId);
 
-    const { metricTypeCategories, canEditScenario } = usePlanningContext();
+    const { metricTypeCategories, isScenarioEditable } = usePlanningContext();
 
     const metricTypes = useMemo(
         () => metricTypeCategories.flatMap(category => category.items),
@@ -88,7 +88,7 @@ export const ScenarioRuleLine: FC<Props> = ({ scenarioId, rule, onEdit }) => {
                 >
                     {rule.name}
                 </Typography>
-                {canEditScenario && (
+                {isScenarioEditable && (
                     <>
                         <EditIconButton
                             onClick={() => onEdit(rule)}

--- a/js/src/domains/planning/components/scenarioRule/scenarioRuleList/ScenarioRulesContainer.tsx
+++ b/js/src/domains/planning/components/scenarioRule/scenarioRuleList/ScenarioRulesContainer.tsx
@@ -6,6 +6,7 @@ import { useReorderScenarioRules } from '../../../hooks/useReorderScenarioRules'
 import { ScenarioRule } from '../../../types/scenarioRule';
 import { ScenarioRuleLine } from './ScenarioRuleLine';
 import { ScenarioRulesHeader } from './ScenarioRulesHeader';
+import { usePlanningContext } from '../../../contexts/PlanningContext';
 
 const styles: SxStyles = {
     rulesContainer: {
@@ -52,6 +53,7 @@ export const ScenarioRulesContainer: FC<Props> = ({
 }) => {
     const { mutate: reorderScenarioRules } =
         useReorderScenarioRules(scenarioId);
+    const { isScenarioEditable } = usePlanningContext();
 
     const handleReorder = useCallback(
         ({ resume, abort, items }: ReorderScenarioRulesParams) => {
@@ -74,6 +76,7 @@ export const ScenarioRulesContainer: FC<Props> = ({
                 onDragEnd={handleReorder}
                 listSx={styles.rulesContainer}
                 itemSx={styles.ruleBox}
+                disabled={!isScenarioEditable}
                 RenderItem={({ item }) => (
                     <ScenarioRuleLine
                         scenarioId={scenarioId}

--- a/js/src/domains/planning/components/scenarioRule/scenarioRuleList/ScenarioRulesHeader.tsx
+++ b/js/src/domains/planning/components/scenarioRule/scenarioRuleList/ScenarioRulesHeader.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export const ScenarioRulesHeader: FC<Props> = ({ onCreateRule }) => {
     const { formatMessage } = useSafeIntl();
-    const { canEditScenario } = usePlanningContext();
+    const { isScenarioEditable } = usePlanningContext();
 
     return (
         <Stack
@@ -28,7 +28,7 @@ export const ScenarioRulesHeader: FC<Props> = ({ onCreateRule }) => {
                     {formatMessage(MESSAGES.interventionTitle)}
                 </Typography>
             </Stack>
-            {canEditScenario && (
+            {isScenarioEditable && (
                 <Button onClick={() => onCreateRule()}>
                     {formatMessage(MESSAGES.createScenarioRule)}
                 </Button>

--- a/js/src/domains/planning/contexts/PlanningContext.tsx
+++ b/js/src/domains/planning/contexts/PlanningContext.tsx
@@ -19,7 +19,8 @@ type PlanningContextType = {
     scenarioId: number;
     scenario?: Scenario;
     displayOrgUnitId?: number;
-    canEditScenario: boolean;
+    canEditScenario: boolean; // This is oriented user, does he have the necessary permissions to edit the scenario
+    isScenarioEditable: boolean; // This is oriented scenario, is it locked or not, if it's locked it can't be edited even if the user has permissions
     isEditing: boolean;
     orgUnits: OrgUnit[];
     metricTypeCategories: MetricTypeCategory[];
@@ -34,6 +35,7 @@ const PlanningContext = createContext<PlanningContextType>({
     scenario: undefined,
     displayOrgUnitId: undefined,
     canEditScenario: false,
+    isScenarioEditable: false,
     isEditing: false,
     orgUnits: [],
     metricTypeCategories: [],
@@ -69,6 +71,10 @@ export const PlanningProvider = ({
     const [interventionPlans, setInterventionPlans] = useState<
         InterventionPlan[]
     >([]);
+    const isScenarioEditable = scenario
+        ? !scenario.is_locked && canEditScenario
+        : canEditScenario;
+
     useEffect(() => {
         const plans = new Map<number, InterventionPlan>();
         interventionAssignments.forEach(assignment => {
@@ -102,6 +108,7 @@ export const PlanningProvider = ({
                 scenario,
                 displayOrgUnitId,
                 canEditScenario,
+                isScenarioEditable,
                 orgUnits,
                 metricTypeCategories,
                 interventionCategories,

--- a/tests/api/scenario_rules/common_base.py
+++ b/tests/api/scenario_rules/common_base.py
@@ -272,3 +272,7 @@ class ScenarioRulesTestBase(APITestCase):
             intervention=self.other_intervention,
             coverage=0.90,
         )
+
+    def lock_scenario(self, scenario):
+        scenario.is_locked = True
+        scenario.save()

--- a/tests/api/scenario_rules/test_serializers.py
+++ b/tests/api/scenario_rules/test_serializers.py
@@ -489,6 +489,25 @@ class ScenarioRuleCreateSerializerTestCase(ScenarioRulesTestBase):
         self.assertIn("scenario", serializer.errors)
         self.assertIn(f'Invalid pk "{unknown_scenario_id}"', serializer.errors["scenario"][0])
 
+    def test_invalid_scenario_locked(self):
+        self.lock_scenario(self.scenario)
+        data = {
+            "scenario": self.scenario.id,
+            "name": "New Rule",
+            "color": "#0000FF",
+            "matching_criteria": {"and": [{"==": [{"var": self.metric_type_population.id}, 1000]}]},
+            "intervention_properties": [
+                {
+                    "intervention": self.intervention_chemo_iptp.id,
+                    "coverage": 0.75,
+                },
+            ],
+        }
+        serializer = ScenarioRuleCreateSerializer(data=data, context=self.context)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("scenario", serializer.errors)
+        self.assertIn("Cannot add rules to a locked scenario", serializer.errors["scenario"][0])
+
     def test_invalid_scenario_wrong_account(self):
         data = {
             "scenario": self.other_scenario.id,  # other_scenario belongs to another account

--- a/tests/api/scenario_rules/test_views.py
+++ b/tests/api/scenario_rules/test_views.py
@@ -42,6 +42,15 @@ class ScenarioRuleAPITestCase(ScenarioRulesTestBase):
         response = self.client.get(self.BASE_URL, {"scenario": self.scenario.id})
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+    def test_list_locked_scenario_rules(self):
+        self.scenario.is_locked = True
+        self.scenario.save()
+
+        self.client.force_authenticate(user=self.user_with_full_perm)
+        response = self.client.get(self.BASE_URL, {"scenario": self.scenario.id})
+        result = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(len(result), 2)
+
     def test_list_scenario_rules_without_scenario_param(self):
         self.client.force_authenticate(user=self.user_with_full_perm)
         response = self.client.get(self.BASE_URL)  # missing scenario param
@@ -64,6 +73,15 @@ class ScenarioRuleAPITestCase(ScenarioRulesTestBase):
         self.assertEqual(result["id"], self.scenario_rule_1.id)
 
         self.client.force_authenticate(user=self.user_no_perm)
+        response = self.client.get(f"{self.BASE_URL}{self.scenario_rule_1.id}/")
+        result = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(result["id"], self.scenario_rule_1.id)
+
+    def test_retrieve_scenario_rule_locked_scenario(self):
+        self.scenario.is_locked = True
+        self.scenario.save()
+
+        self.client.force_authenticate(user=self.user_with_full_perm)
         response = self.client.get(f"{self.BASE_URL}{self.scenario_rule_1.id}/")
         result = self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertEqual(result["id"], self.scenario_rule_1.id)
@@ -113,6 +131,29 @@ class ScenarioRuleAPITestCase(ScenarioRulesTestBase):
         self.assertEqual(new_rule.org_units_scope, [])
         self.assertEqual(new_rule.created_by, self.user_with_full_perm)
         self.assertIsNone(new_rule.updated_by)
+
+    def test_post_scenario_rule_for_locked_scenario(self):
+        self.scenario.is_locked = True
+        self.scenario.save()
+
+        payload = {
+            "name": "New Rule",
+            "scenario": self.scenario.id,
+            "matching_criteria": {
+                "and": [{">=": [{"var": self.metric_type_population.id}, 1]}]
+            },  # all districts with population >= 1
+            "intervention_properties": [
+                {
+                    "intervention": self.intervention_chemo_iptp.id,
+                    "coverage": 0.5,
+                }
+            ],
+        }
+        self.client.force_authenticate(user=self.user_with_full_perm)
+        response = self.client.post(self.BASE_URL, payload)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("scenario", response.data)
+        self.assertIn("Cannot add rules to a locked scenario", response.data["scenario"][0])
 
     def test_post_scenario_rule_with_full_perm_other_scenario(self):
         new_scenario = Scenario.objects.create(
@@ -336,6 +377,18 @@ class ScenarioRuleAPITestCase(ScenarioRulesTestBase):
         self.assertEqual(self.scenario_rule_1.scenario, self.scenario)
         self.assertEqual(self.scenario_rule_1.priority, 1)
 
+    def test_patch_scenario_rule_for_locked_scenario(self):
+        self.scenario.is_locked = True
+        self.scenario.save()
+
+        payload = {
+            "name": "Updated Rule",
+        }
+        self.client.force_authenticate(user=self.user_with_full_perm)
+        response = self.client.patch(f"{self.BASE_URL}{self.scenario_rule_1.id}/", payload)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("You do not have permission to perform this action.", response.data["detail"])
+
     def test_patch_scenario_rule_with_full_perm_other_scenario(self):
         new_scenario = Scenario.objects.create(
             account=self.account,
@@ -507,6 +560,17 @@ class ScenarioRuleAPITestCase(ScenarioRulesTestBase):
         self.assertEqual(self.scenario.rules.count(), 1)
         with self.assertRaises(ScenarioRule.DoesNotExist):
             ScenarioRule.objects.get(id=self.scenario_rule_1.id)
+
+    def test_delete_scenario_rule_for_locked_scenario(self):
+        self.scenario.is_locked = True
+        self.scenario.save()
+
+        self.client.force_authenticate(user=self.user_with_full_perm)
+        response = self.client.delete(f"{self.BASE_URL}{self.scenario_rule_1.id}/")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("You do not have permission to perform this action.", response.data["detail"])
+        self.assertEqual(self.scenario.rules.count(), 2)  # rule should not be deleted
+        self.assertIsNotNone(ScenarioRule.objects.get(id=self.scenario_rule_1.id))  # rule should still exist
 
     def test_delete_scenario_rule_with_full_perm_other_scenario(self):
         new_scenario = Scenario.objects.create(

--- a/tests/api/scenario_rules/test_views.py
+++ b/tests/api/scenario_rules/test_views.py
@@ -43,8 +43,7 @@ class ScenarioRuleAPITestCase(ScenarioRulesTestBase):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_list_locked_scenario_rules(self):
-        self.scenario.is_locked = True
-        self.scenario.save()
+        self.lock_scenario(self.scenario)
 
         self.client.force_authenticate(user=self.user_with_full_perm)
         response = self.client.get(self.BASE_URL, {"scenario": self.scenario.id})
@@ -78,8 +77,7 @@ class ScenarioRuleAPITestCase(ScenarioRulesTestBase):
         self.assertEqual(result["id"], self.scenario_rule_1.id)
 
     def test_retrieve_scenario_rule_locked_scenario(self):
-        self.scenario.is_locked = True
-        self.scenario.save()
+        self.lock_scenario(self.scenario)
 
         self.client.force_authenticate(user=self.user_with_full_perm)
         response = self.client.get(f"{self.BASE_URL}{self.scenario_rule_1.id}/")
@@ -133,8 +131,7 @@ class ScenarioRuleAPITestCase(ScenarioRulesTestBase):
         self.assertIsNone(new_rule.updated_by)
 
     def test_post_scenario_rule_for_locked_scenario(self):
-        self.scenario.is_locked = True
-        self.scenario.save()
+        self.lock_scenario(self.scenario)
 
         payload = {
             "name": "New Rule",
@@ -378,8 +375,7 @@ class ScenarioRuleAPITestCase(ScenarioRulesTestBase):
         self.assertEqual(self.scenario_rule_1.priority, 1)
 
     def test_patch_scenario_rule_for_locked_scenario(self):
-        self.scenario.is_locked = True
-        self.scenario.save()
+        self.lock_scenario(self.scenario)
 
         payload = {
             "name": "Updated Rule",
@@ -562,8 +558,7 @@ class ScenarioRuleAPITestCase(ScenarioRulesTestBase):
             ScenarioRule.objects.get(id=self.scenario_rule_1.id)
 
     def test_delete_scenario_rule_for_locked_scenario(self):
-        self.scenario.is_locked = True
-        self.scenario.save()
+        self.lock_scenario(self.scenario)
 
         self.client.force_authenticate(user=self.user_with_full_perm)
         response = self.client.delete(f"{self.BASE_URL}{self.scenario_rule_1.id}/")

--- a/tests/api/scenarios/test_serializers.py
+++ b/tests/api/scenarios/test_serializers.py
@@ -88,6 +88,86 @@ class ScenarioWriteSerializerTestCase(BaseSerializerTestCase):
         self.assertIn("name", serializer.errors)
         self.assertIn("A scenario with this name already exists for your account.", serializer.errors["name"])
 
+    def test_update_if_is_locked(self):
+        self.scenario.is_locked = True
+        self.scenario.save()
+
+        payload = {
+            "name": "Updated Name",
+            "description": "Updated description.",
+            "start_year": 2025,
+            "end_year": 2026,
+            "is_locked": False,
+        }
+        serializer = ScenarioWriteSerializer(instance=self.scenario, data=payload, context=self.context)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("non_field_errors", serializer.errors)
+        self.assertIn("Cannot modify a locked scenario.", serializer.errors["non_field_errors"])
+
+    def test_update_is_locked_field(self):
+        self.scenario.is_locked = True
+        self.scenario.save()
+
+        payload = {
+            "is_locked": False,
+        }
+        serializer = ScenarioWriteSerializer(instance=self.scenario, data=payload, context=self.context, partial=True)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated_scenario = serializer.save()
+        self.assertFalse(updated_scenario.is_locked)
+
+
+class ScenarioReorderRulesSerializerTestCase(BaseSerializerTestCase):
+    def setUp(self):
+        super().setUp()
+        self.rule_1 = ScenarioRule.objects.create(
+            scenario=self.scenario,
+            name="Test Rule",
+            color="#FF0000",
+            matching_criteria={"and": [{"==": [{"var": 1}, 1]}]},
+            priority=1,
+            created_by=self.user_with_basic_perm,
+        )
+        self.rule_2 = ScenarioRule.objects.create(
+            scenario=self.scenario,
+            name="Test Rule 2",
+            color="#00FF00",
+            matching_criteria={"and": [{"==": [{"var": 1}, 1]}]},
+            priority=2,
+            created_by=self.user_with_basic_perm,
+        )
+        self.context["scenario"] = self.scenario
+
+    def test_reorder_on_locked_scenario(self):
+        self.scenario.is_locked = True
+        self.scenario.save()
+
+        payload = {
+            "new_order": [self.rule_2.id, self.rule_1.id],
+        }
+        serializer = ScenarioRulesReorderSerializer(data=payload, context=self.context)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("new_order", serializer.errors)
+        self.assertIn("Cannot reorder rules for a locked scenario.", serializer.errors["new_order"])
+
+    def test_reorder_with_valid_data(self):
+        payload = {
+            "new_order": [self.rule_2.id, self.rule_1.id],
+        }
+        serializer = ScenarioRulesReorderSerializer(data=payload, context=self.context)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_reorder_with_missing_rule(self):
+        payload = {
+            "new_order": [self.rule_2.id],
+        }
+        serializer = ScenarioRulesReorderSerializer(data=payload, context=self.context)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("new_order", serializer.errors)
+        self.assertIn(
+            f"Missing rule IDs that belong to the scenario - {{{self.rule_1.id}}}", serializer.errors["new_order"]
+        )
+
 
 class ScenarioRulesSerializerTestCase(BaseSerializerTestCase):
     def setUp(self):

--- a/tests/api/scenarios/test_views.py
+++ b/tests/api/scenarios/test_views.py
@@ -966,6 +966,15 @@ class ScenarioAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(Scenario.objects.count(), 2)  # both the one from setup and the other account scenario remain
 
+    def test_delete_scenario_locked(self):
+        self.scenario.is_locked = True
+        self.scenario.save()
+
+        self.client.force_authenticate(self.user_with_full_perm)
+        response = self.client.delete(f"{self.BASE_URL}{self.scenario.id}/")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(Scenario.objects.count(), 1)
+
     def test_reorder_rules_with_full_perm_own_scenario(self):
         """
         This test will also check the result of reordering with conflicts


### PR DESCRIPTION
## What problem is this PR solving?

Don't allow rule reordering and edition if a scenario is locked

### Related JIRA tickets

SNT-396

## Changes

Added a calculated field on the contextto know if the scenario is locked and if user has auth: isScenarioEditable.
Which lives aside of canEditScenario (which only let us know if a user has access).
This is because we want to hide the lock / unlock only if user does not have access. If the scenario is locked, we still want to see this action.

Replaced canEditScenario with isScenarioIsEditable everywhere except for the lock button display.


## How to test

Go to SNT, open a scenario and lock it.
You should not be able to edit a rule or to drag and drop.
You should be able to unlock it.

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
