### PR TITLE
SNT-417: Fix TopBar index on data layer view

### DIFF
--- a/js/src/domains/dataLayers/index.tsx
+++ b/js/src/domains/dataLayers/index.tsx
@@ -78,6 +78,7 @@ export const DataLayers: FC = () => {
             <TopBar
                 title={formatMessage(MESSAGES.dataLayersTitle)}
                 disableShadow
+                sx={{ zIndex: 401 }}
             />
             <PageContainer>
                 <SidebarLayout>


### PR DESCRIPTION
## What problem is this PR solving?

Fix top bar index from data layer page

### Related JIRA tickets

SNT-417

## Changes

Move TopBar zindex above map.

## How to test

Go to SNT Malaria with a multi account user (you'll need at least 4)
Go to Layers and open the account selector, it should be displayed above the map.

## Print screen / video

Before:

<img width="394" height="313" alt="image" src="https://github.com/user-attachments/assets/20a34a0c-882e-4a93-8628-2779ab59824f" />


After:

<img width="1647" height="306" alt="image" src="https://github.com/user-attachments/assets/1d5e054d-9e4f-41f2-be7d-eec5c367b801" />


## Notes

N/A

## Doc

N/A
