### PR TITLE
fix SNT-416: fetch all org units for dropdowns when zoomed

### DIFF
--- a/js/src/components/OrgUnitSelect.tsx
+++ b/js/src/components/OrgUnitSelect.tsx
@@ -29,10 +29,12 @@ export const OrgUnitSelect: FC<Props> = ({
 
     const { data: accountSettings } = useGetAccountSettings();
 
+    const focusTypeId = accountSettings?.focus_org_unit_type_id;
     const { data: orgUnitsByType, isLoading: isLoadingOrgUnits } =
         useGetOrgUnits({
-            orgUnitTypeId: accountSettings?.focus_org_unit_type_id,
+            orgUnitTypeId: focusTypeId,
             withGeometry: false,
+            enabled: !!focusTypeId,
         });
 
     const handleOrgUnitChange = (e: SelectChangeEvent<number>) => {

--- a/js/src/components/OrgUnitSelect.tsx
+++ b/js/src/components/OrgUnitSelect.tsx
@@ -3,7 +3,7 @@ import { MenuItem, Select, SelectChangeEvent } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
 import { SxStyles } from 'Iaso/types/general';
 import { MESSAGES } from '../domains/messages';
-import { useGetOrgUnitsByType } from '../domains/planning/hooks/useGetOrgUnits';
+import { useGetOrgUnits } from '../domains/planning/hooks/useGetOrgUnits';
 import { useGetAccountSettings } from '../domains/planning/hooks/useGetAccountSettings';
 
 const styles = {
@@ -30,7 +30,10 @@ export const OrgUnitSelect: FC<Props> = ({
     const { data: accountSettings } = useGetAccountSettings();
 
     const { data: orgUnitsByType, isLoading: isLoadingOrgUnits } =
-        useGetOrgUnitsByType(accountSettings?.focus_org_unit_type_id);
+        useGetOrgUnits({
+            orgUnitTypeId: accountSettings?.focus_org_unit_type_id,
+            withGeometry: false,
+        });
 
     const handleOrgUnitChange = (e: SelectChangeEvent<number>) => {
         const id = e.target.value as number;

--- a/js/src/domains/compareCustomize/components/maps/InterventionPlanMap.tsx
+++ b/js/src/domains/compareCustomize/components/maps/InterventionPlanMap.tsx
@@ -2,6 +2,7 @@ import React, { FC, useCallback, useMemo } from 'react';
 import { Box } from '@mui/material';
 import { SxStyles } from 'Iaso/types/general';
 import { Map as SNTMap } from '../../../../components/Map';
+import { useGetAccountSettings } from '../../../planning/hooks/useGetAccountSettings';
 import { useGetInterventionPlans } from '../../../planning/hooks/useGetInterventionAssignments';
 import { useGetOrgUnits } from '../../../planning/hooks/useGetOrgUnits';
 import { Intervention } from '../../../planning/types/interventions';
@@ -62,7 +63,13 @@ export const InterventionPlanMap: FC<Props> = ({
     titleDotColor,
     titleText,
 }) => {
-    const { data: orgUnits } = useGetOrgUnits();
+    const { data: accountSettings } = useGetAccountSettings();
+    const interventionTypeId =
+        accountSettings?.intervention_org_unit_type_id;
+    const { data: orgUnits } = useGetOrgUnits({
+        orgUnitTypeId: interventionTypeId,
+        enabled: !!interventionTypeId,
+    });
     const {
         data: interventionAssignments,
         isLoading: isLoadingInterventionAssignments,

--- a/js/src/domains/planning/components/scenarioRule/scenarioRuleForm/ScenarioRuleForm.tsx
+++ b/js/src/domains/planning/components/scenarioRule/scenarioRuleForm/ScenarioRuleForm.tsx
@@ -13,6 +13,8 @@ import { SxStyles } from 'Iaso/types/general';
 import { useGetExtendedFormikContext } from '../../../../../hooks/useGetExtendedFormikContext';
 import { MESSAGES } from '../../../../messages';
 import { usePlanningContext } from '../../../contexts/PlanningContext';
+import { useGetAccountSettings } from '../../../hooks/useGetAccountSettings';
+import { useGetOrgUnits } from '../../../hooks/useGetOrgUnits';
 import { ScenarioRuleFormValues } from '../../../hooks/useScenarioRuleFormState';
 import { InterventionPropertiesForm } from './InterventionPropertiesForm';
 import { MatchingCriteriaForm } from './MatchingCriteriaForm';
@@ -40,11 +42,17 @@ const ScenarioRuleHeading: FC<{ label: string }> = ({ label }) => {
 
 export const ScenarioRuleForm: FC = () => {
     const { formatMessage } = useSafeIntl();
-    const {
-        metricTypeCategories,
-        interventionCategories,
-        orgUnits: allOrgUnits,
-    } = usePlanningContext();
+    const { metricTypeCategories, interventionCategories } =
+        usePlanningContext();
+
+    const { data: accountSettings } = useGetAccountSettings();
+    // Fetch all intervention-level org units including geometry. The map makes
+    // the same request (same query key), so when the page was loaded without a
+    // region filter this is an instant cache hit instead of a costly extra call.
+    const { data: allOrgUnits, isLoading: isLoadingOrgUnits } =
+        useGetOrgUnits({
+            orgUnitTypeId: accountSettings?.intervention_org_unit_type_id,
+        });
 
     const {
         values,
@@ -65,7 +73,7 @@ export const ScenarioRuleForm: FC = () => {
 
     const allOrgUnitOptions = useMemo(
         () =>
-            allOrgUnits.map(orgUnit => ({
+            (allOrgUnits ?? []).map(orgUnit => ({
                 value: orgUnit.id,
                 label: orgUnit.name,
             })),
@@ -161,6 +169,7 @@ export const ScenarioRuleForm: FC = () => {
                         type="select"
                         value={values.org_units_excluded || []}
                         multi={true}
+                        loading={isLoadingOrgUnits}
                         options={exclusionOrgUnitOptions}
                         onChange={setFieldValueAndState}
                         errors={getErrors('org_units_excluded')}
@@ -173,6 +182,7 @@ export const ScenarioRuleForm: FC = () => {
                         type="select"
                         value={values.org_units_included || []}
                         multi={true}
+                        loading={isLoadingOrgUnits}
                         disabled={values.is_match_all}
                         options={inclusionOrgUnitOptions}
                         onChange={setFieldValueAndState}

--- a/js/src/domains/planning/components/scenarioRule/scenarioRuleForm/ScenarioRuleForm.tsx
+++ b/js/src/domains/planning/components/scenarioRule/scenarioRuleForm/ScenarioRuleForm.tsx
@@ -49,9 +49,12 @@ export const ScenarioRuleForm: FC = () => {
     // Fetch all intervention-level org units including geometry. The map makes
     // the same request (same query key), so when the page was loaded without a
     // region filter this is an instant cache hit instead of a costly extra call.
+    const interventionTypeId =
+        accountSettings?.intervention_org_unit_type_id;
     const { data: allOrgUnits, isLoading: isLoadingOrgUnits } =
         useGetOrgUnits({
-            orgUnitTypeId: accountSettings?.intervention_org_unit_type_id,
+            orgUnitTypeId: interventionTypeId,
+            enabled: !!interventionTypeId,
         });
 
     const {

--- a/js/src/domains/planning/hooks/useGetOrgUnits.tsx
+++ b/js/src/domains/planning/hooks/useGetOrgUnits.tsx
@@ -4,53 +4,48 @@ import { getRequest } from 'Iaso/libs/Api';
 import { useSnackQuery } from 'Iaso/libs/apiHooks';
 import { makeUrlWithParams } from 'Iaso/libs/utils';
 
-export const useGetOrgUnits = (
-    orgUnitParentId?: number | null,
-): UseQueryResult<OrgUnit[], Error> => {
+type UseGetOrgUnitsOptions = {
+    orgUnitParentId?: number | null;
+    orgUnitTypeId?: number;
+    withGeometry?: boolean;
+};
+
+export const useGetOrgUnits = ({
+    orgUnitParentId,
+    orgUnitTypeId,
+    withGeometry = true,
+}: UseGetOrgUnitsOptions = {}): UseQueryResult<OrgUnit[], Error> => {
     const params: Record<string, any> = {
         validation_status: 'VALID',
         defaultVersion: true,
-        asLocation: true,
         limit: 8000,
     };
+    if (withGeometry) {
+        params.asLocation = true;
+    } else {
+        params.smallSearch = true;
+        params.order = 'name';
+    }
     if (orgUnitParentId) {
         params.orgUnitParentId = orgUnitParentId;
+    }
+    if (orgUnitTypeId) {
+        params.orgUnitTypeId = orgUnitTypeId;
     }
     const url = makeUrlWithParams('/api/orgunits/', params);
     return useSnackQuery({
         queryKey: ['orgUnits', params],
         queryFn: () => getRequest(url),
         options: {
-            cacheTime: Infinity, // disable auto fetch on cache expiration
-        },
-    });
-};
-
-type OrgUnitsResponse = {
-    orgunits: OrgUnit[];
-};
-
-export const useGetOrgUnitsByType = (
-    orgUnitTypeId?: number,
-): UseQueryResult<OrgUnit[], Error> => {
-    const params: Record<string, any> = {
-        validation_status: 'VALID',
-        defaultVersion: true,
-        limit: 8000,
-        smallSearch: true,
-        order: 'name',
-    };
-    if (orgUnitTypeId) {
-        params.orgUnitTypeId = orgUnitTypeId;
-    }
-    const url = makeUrlWithParams('/api/orgunits/', params);
-    return useSnackQuery({
-        queryKey: ['orgUnitsByType', params],
-        queryFn: () => getRequest(url) as Promise<OrgUnitsResponse>,
-        options: {
             enabled: !!orgUnitTypeId,
             cacheTime: Infinity,
-            select: (data: OrgUnitsResponse) => data.orgunits ?? [],
+            staleTime: Infinity,
+            // asLocation returns OrgUnit[] directly; smallSearch returns
+            // { orgunits: OrgUnit[], ... } so we need to unwrap it.
+            ...(!withGeometry && {
+                select: (data: { orgunits: OrgUnit[] }) =>
+                    data.orgunits ?? [],
+            }),
         },
     });
 };

--- a/js/src/domains/planning/hooks/useGetOrgUnits.tsx
+++ b/js/src/domains/planning/hooks/useGetOrgUnits.tsx
@@ -8,12 +8,14 @@ type UseGetOrgUnitsOptions = {
     orgUnitParentId?: number | null;
     orgUnitTypeId?: number;
     withGeometry?: boolean;
+    enabled?: boolean;
 };
 
 export const useGetOrgUnits = ({
     orgUnitParentId,
     orgUnitTypeId,
     withGeometry = true,
+    enabled = true,
 }: UseGetOrgUnitsOptions = {}): UseQueryResult<OrgUnit[], Error> => {
     const params: Record<string, any> = {
         validation_status: 'VALID',
@@ -37,7 +39,7 @@ export const useGetOrgUnits = ({
         queryKey: ['orgUnits', params],
         queryFn: () => getRequest(url),
         options: {
-            enabled: !!orgUnitTypeId,
+            enabled,
             cacheTime: Infinity,
             staleTime: Infinity,
             // asLocation returns OrgUnit[] directly; smallSearch returns

--- a/js/src/domains/planning/index.tsx
+++ b/js/src/domains/planning/index.tsx
@@ -36,6 +36,7 @@ import { useGetInterventionAssignments } from './hooks/useGetInterventionAssignm
 import { useGetInterventionCategories } from './hooks/useGetInterventionCategories';
 import { useGetLatestCalculatedBudget } from './hooks/useGetLatestCalculatedBudget';
 import { useGetMetricCategories } from './hooks/useGetMetrics';
+import { useGetAccountSettings } from './hooks/useGetAccountSettings';
 import { useGetOrgUnits } from './hooks/useGetOrgUnits';
 import { useGetScenarioRules } from './hooks/useGetScenarioRules';
 import { usePreviewScenarioRule } from './hooks/usePreviewScenarioRule';
@@ -75,8 +76,14 @@ export const Planning: FC = () => {
 
     const { data: metricTypeCategories } = useGetMetricCategories();
     const { data: interventionCategories } = useGetInterventionCategories();
+    const { data: accountSettings } = useGetAccountSettings();
+    const interventionTypeId =
+        accountSettings?.intervention_org_unit_type_id;
     const { data: orgUnits, isLoading: isLoadingOrgUnits } =
-        useGetOrgUnits(displayOrgUnitId);
+        useGetOrgUnits({
+            orgUnitParentId: displayOrgUnitId,
+            orgUnitTypeId: interventionTypeId,
+        });
 
     const { data: scenarioRules, isFetching: isFetchingRules } =
         useGetScenarioRules(scenarioId);

--- a/js/src/domains/planning/index.tsx
+++ b/js/src/domains/planning/index.tsx
@@ -83,6 +83,7 @@ export const Planning: FC = () => {
         useGetOrgUnits({
             orgUnitParentId: displayOrgUnitId,
             orgUnitTypeId: interventionTypeId,
+            enabled: !!interventionTypeId,
         });
 
     const { data: scenarioRules, isFetching: isFetchingRules } =


### PR DESCRIPTION
## What problem is this PR solving?

Fix rule drop downs showing error when selected org unit is not in current zoomed region

### Related JIRA tickets

SNT-416

## Changes

Before: The rule form dropdowns shared the map's org units request. Filtering by region also reduced the dropdown options, breaking selections from other regions.

Now: The dropdowns fetch the full unfiltered list independently. This uses the same query key as the map's "All" request, so react query's cache is shared - no extra network call when the page starts unfiltered. When the page starts filtered, a brief loading state appears on the dropdowns while they fetch.

Fetching org units with geometry in the dropdown request seems overkill but it allows to share the query key with the map's, enabling cache sharing.

Also refactored `useGetOrgUnitsByType` into `useGetOrgUnits` with an options object (`orgUnitParentId`, `orgUnitTypeId`, `withGeometry`), and added `orgUnitTypeId` filtering to the map request to reduce response size.

Update:
Also the Compare & Customize page uses the same request now so it also uses the same cache and doesn't re-fetch.

## How to test

Prepare a scenario with a rule that has a few org units in the included dropdown

Scenario 1, start unfiltered:
* Load rule builder from scratch (unfiltered), observe the org unit requests (one for the region dropdown, one for all intervention org units)
* Edit the rule, no additional requets should appear
* Change region filter to different regions, one request per selection. The existing dropdown selections stay stable, no error

Scenario 2, start filtered:
* Load rule builder with a region filter (by using deep link) observe the org unit requests (one for the region dropdown, one for the filtered intervention org units)
* Edit the rule, you should see spinners in the dropdowns and an additional request of all org units, selections eventuall appear
* Change region filter to different regions, one request per selection. The existing dropdown selections stay stable, no error


Initial state is all, drop downs share query key with the initial org unit fetch, no further fetch

https://github.com/user-attachments/assets/e5bd2e2f-4be1-4d07-8c2b-19046e170afc

Initial state is zoomed, only partial org units are fetched, drop downs trigger full fetch

https://github.com/user-attachments/assets/f6567cdf-1c6b-4ce5-b20c-ebc89a48d98e