### PR TITLE
SNT-431: Add rules to the demo account

### DIFF
--- a/management/commands/recreate_demo_account.py
+++ b/management/commands/recreate_demo_account.py
@@ -37,6 +37,30 @@ DEMO_ACCOUNT_NAME = "Burkina Faso (demo)"
 DEMO_USER_USERNAME = "demo"
 DEMO_USER_PASSWORD = "demo"
 
+intervention_impact_refs = {
+    "CM": "impact_1",
+    "CM Subsidy": "impact_1",
+    "iCCM": "impact_1",
+    "IPTp": "impact_1",
+    "Dual AI (Campaign)": "impact_5",
+    "PBO (Campaign)": "impact_3",
+    "PYR (Campaign)": "impact_1",
+    "Dual AI (Routine)": "impact_5",
+    "PBO (Routine)": "impact_3",
+    "PYR (Routine)": "impact_1",
+    "Dual AI (School)": "impact_5",
+    "PBO (School)": "impact_3",
+    "PYR (School)": "impact_1",
+    "PMC": "impact_5",
+    "SMC": "impact_2",
+    "SMC3": "impact_2",
+    "SMC4": "impact_2",
+    "SMC5": "impact_2",
+    "R21": "impact_3",
+    "RTS,S": "impact_3",
+    "LSM": "impact_3",
+}
+
 
 class Command(BaseCommand):
     help = "Set up the 'Burkina Faso Demo' account. If the account already exists, it will be deleted and re-created."
@@ -156,7 +180,6 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.ERROR(f"Failed to import GPKG file: {e}"))
                 raise
 
-            # Create account settings
             focus_org_unit_type = OrgUnitType.objects.get(projects=project, name="Region")
             intervention_org_unit_type = OrgUnitType.objects.get(projects=project, name="District")
             AccountSettings.objects.create(
@@ -184,7 +207,9 @@ class Command(BaseCommand):
             # Randomly assign impact ref to interventions
             interventions = Intervention.objects_include_deleted.filter(intervention_category__account=account)
             for intervention in interventions:
-                intervention.impact_ref = f"impact_{random.randint(1, 5)}"
+                intervention.impact_ref = intervention_impact_refs.get(
+                    intervention.short_name, random.choice(list(intervention_impact_refs.values()))
+                )
                 intervention.save()
 
             # Create demo scenario with intervention assignments

--- a/management/commands/recreate_demo_account.py
+++ b/management/commands/recreate_demo_account.py
@@ -220,7 +220,7 @@ class Command(BaseCommand):
             ImpactProviderConfig.objects.create(
                 account=account,
                 provider_key="fake",
-                config={},
+                config={"population_metric_code": "POPULATION"},
             )
 
             self.stdout.write(self.style.SUCCESS("Setup completed successfully:"))

--- a/management/commands/recreate_demo_account.py
+++ b/management/commands/recreate_demo_account.py
@@ -1,4 +1,5 @@
 import os
+import random
 
 from django.contrib.auth.models import Permission, User
 from django.core.management.base import BaseCommand
@@ -7,9 +8,12 @@ from django.db import transaction
 from iaso.gpkg.import_gpkg import import_gpkg_file2
 from iaso.models import Account, DataSource, MetricType, MetricValue, Profile, Project, Report, SourceVersion, Team
 from iaso.models.data_store import JsonDataStore
+from iaso.models.org_unit import OrgUnitType
 from iaso.permissions.core_permissions import CORE_DATASTORE_READ_PERMISSION
 from plugins.snt_malaria.models import (
+    AccountSettings,
     Budget,
+    ImpactProviderConfig,
     Intervention,
     InterventionAssignment,
     InterventionCategory,
@@ -49,6 +53,8 @@ class Command(BaseCommand):
         categories = InterventionCategory.objects_include_deleted.filter(account=demo_account)
         interventions = Intervention.objects_include_deleted.filter(intervention_category__in=categories)
         metric_types = MetricType.objects.filter(account=demo_account)
+        account_settings = AccountSettings.objects.filter(account=demo_account)
+        impact_provider_configs = ImpactProviderConfig.objects.filter(account=demo_account)
 
         # Delete in order to avoid PROTECT foreign key constraints
         InterventionAssignment.objects.filter(scenario__in=scenarios).delete()
@@ -69,7 +75,9 @@ class Command(BaseCommand):
         data_sources.delete()
         projects.delete()
         User.objects.filter(username=DEMO_USER_USERNAME).delete()
+        account_settings.delete()
         demo_account.delete()
+        impact_provider_configs.delete()
 
         self.stdout.write(self.style.SUCCESS(f"Deleted existing demo account: {DEMO_ACCOUNT_NAME}"))
 
@@ -145,6 +153,15 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.ERROR(f"Failed to import GPKG file: {e}"))
                 raise
 
+            # Create account settings
+            focus_org_unit_type = OrgUnitType.objects.get(projects=project, name="Region")
+            intervention_org_unit_type = OrgUnitType.objects.get(projects=project, name="District")
+            AccountSettings.objects.create(
+                account=account,
+                focus_org_unit_type=focus_org_unit_type,
+                intervention_org_unit_type=intervention_org_unit_type,
+            )
+
             # Import data layers (metrics)
             metadata_file_path = os.path.join(os.path.dirname(__file__), "fixtures", "BFA_dummy_metadata.csv")
             dataset_file_path = os.path.join(os.path.dirname(__file__), "fixtures", "BFA_dummy_results_dataset.csv")
@@ -161,8 +178,22 @@ class Command(BaseCommand):
             # Seed interventions and intervention costs
             InterventionSeeder(account, self.stdout.write).create_interventions()
 
+            # Randomly assign impact ref to interventions
+            interventions = Intervention.objects_include_deleted.filter(intervention_category__account=account)
+            for intervention in interventions:
+                intervention.impact_ref = f"impact_{random.randint(1, 5)}"
+                intervention.save()
+
             # Create demo scenario with intervention assignments
             DemoScenarioSeeder(account, project, self.stdout.write).create_scenario()
+
+            self.stdout.write("Create Impact Provider Config for demo account.")
+            # Create Impact provider config
+            ImpactProviderConfig.objects.create(
+                account=account,
+                provider_key="fake",
+                config={},
+            )
 
             self.stdout.write(self.style.SUCCESS("Setup completed successfully:"))
             self.stdout.write(

--- a/management/commands/recreate_demo_account.py
+++ b/management/commands/recreate_demo_account.py
@@ -9,6 +9,7 @@ from iaso.gpkg.import_gpkg import import_gpkg_file2
 from iaso.models import Account, DataSource, MetricType, MetricValue, Profile, Project, Report, SourceVersion, Team
 from iaso.models.data_store import JsonDataStore
 from iaso.models.org_unit import OrgUnitType
+from iaso.modules import MODULE_DEFAULT, MODULE_SNT_MALARIA
 from iaso.permissions.core_permissions import CORE_DATASTORE_READ_PERMISSION
 from plugins.snt_malaria.models import (
     AccountSettings,
@@ -113,7 +114,9 @@ class Command(BaseCommand):
             self.stdout.write(f"Created new admin user: {DEMO_USER_USERNAME} / {DEMO_USER_PASSWORD}")
 
             # Demo account
-            account = Account.objects.create(name=DEMO_ACCOUNT_NAME)
+            modules = [MODULE_DEFAULT, MODULE_SNT_MALARIA]
+            account = Account.objects.create(name=DEMO_ACCOUNT_NAME, modules=[module.codename for module in modules])
+
             self.stdout.write(f"Created Account: {account.name}")
 
             profile = Profile.objects.create(user=demo_user, account=account)

--- a/management/commands/support/demo_scenario_seeder.py
+++ b/management/commands/support/demo_scenario_seeder.py
@@ -2,23 +2,21 @@
 Create a demo scenario with intervention assignments for Burkina Faso
 """
 
-import random
-
 from datetime import date
 
 from snt_malaria_budgeting import DEFAULT_COST_ASSUMPTIONS, BudgetCalculator
 
 from iaso.models import OrgUnitType, User
 from iaso.models.data_store import JsonDataStore
-from iaso.models.metric import MetricValue
+from iaso.models.metric import MetricType
 from plugins.snt_malaria.api.budget.utils import (
     build_cost_dataframe,
     build_interventions_input,
     build_population_dataframe,
 )
 from plugins.snt_malaria.models.budget import Budget
-from plugins.snt_malaria.models.intervention import Intervention, InterventionAssignment
-from plugins.snt_malaria.models.scenario import Scenario
+from plugins.snt_malaria.models.intervention import Intervention
+from plugins.snt_malaria.models.scenario import Scenario, ScenarioRule, ScenarioRuleInterventionProperties
 
 
 class DemoScenarioSeeder:
@@ -34,7 +32,7 @@ class DemoScenarioSeeder:
         # Check if a demo scenario already exists
         if Scenario.objects.filter(account=self.account, name__icontains="Demo").exists():
             self.stdout_write(f"Skipping scenario creation for {self.account.name}, demo scenario already exists")
-            return None
+            return
 
         self.stdout_write(f"Creating demo scenario for account {self.account.name}:")
 
@@ -42,23 +40,7 @@ class DemoScenarioSeeder:
         created_by = User.objects.filter(iaso_profile__account=self.account).first()
         if not created_by:
             self.stdout_write("ERROR: No user found for this account")
-            return None
-
-        # Create the demo scenario
-        current_year = date.today().year
-        scenario = Scenario.objects.create(
-            account=self.account,
-            created_by=created_by,
-            name=f"Demo Scenario {current_year}-{current_year + 5}",
-            description=(
-                "This is a demonstration scenario for Burkina Faso showing various malaria "
-                "intervention strategies across different districts. The scenario includes "
-                "a mix of preventive measures (ITNs, SMC, IPTp), case management, and vaccination interventions."
-            ),
-            start_year=current_year,
-            end_year=current_year + 5,
-        )
-        self.stdout_write(f"Created scenario: {scenario.name}")
+            return
 
         # Get all interventions for this account
         interventions = Intervention.objects.filter(intervention_category__account=self.account).select_related(
@@ -67,92 +49,25 @@ class DemoScenarioSeeder:
 
         if not interventions.exists():
             self.stdout_write("WARNING: No interventions found for this account. Run intervention_seeder first.")
-            return None
+            return
 
-        metrics = MetricValue.objects.filter(
-            metric_type__code__in=["PF_PR_RATE", "PF_INCIDENCE_RATE"],
-            metric_type__account=self.account,
-        ).select_related("org_unit")
-
-        all_org_units = metrics.values_list("org_unit", flat=True).distinct()
-        incidence_250_ou = (
-            metrics.filter(value__gte=250, metric_type__code="PF_INCIDENCE_RATE")
-            .values_list("org_unit", flat=True)
-            .distinct()
+        metric_types = MetricType.objects.filter(
+            account=self.account, code__in=["PF_PR_RATE", "SEASONALITY_PRECIPITATION"]
         )
-        prevalence_55_ou = (
-            metrics.filter(value__gte=55, metric_type__code="PF_PR_RATE").values_list("org_unit", flat=True).distinct()
+        pf_rate_metric_type = metric_types.filter(code="PF_PR_RATE").first()
+        seasonality_precipitation_metric_type = metric_types.filter(code="SEASONALITY_PRECIPITATION").first()
+
+        scenario_1 = self._create_scenarion_(
+            "NSP 1", created_by, interventions, seasonality_precipitation_metric_type, pf_rate_metric_type, rate=60
         )
-        prevalence_75_ou = (
-            metrics.filter(value__gte=75, metric_type__code="PF_PR_RATE").values_list("org_unit", flat=True).distinct()
+        scenario_2 = self._create_scenarion_(
+            "NSP 2", created_by, interventions, seasonality_precipitation_metric_type, pf_rate_metric_type, rate=80
         )
-
-        incidence_250_prevalence_55_ou = [ou for ou in prevalence_55_ou if ou in incidence_250_ou]
-        incidence_250_prevalence_75_ou = [ou for ou in incidence_250_ou if ou in prevalence_75_ou]
-        intervention_to_assign = {
-            "cm_public": "all",
-            "itn_routine": "all",
-            "itn_campaign": "all",
-            "iptp": "prevalence_55",
-            "vacc": "prevalence_75",
-        }
-        all_assignments = []
-
-        for intervention_code, prevalence_group in intervention_to_assign.items():
-            # Get interventions for this code
-            if intervention_code in ["itn_routine", "itn_campaign"]:
-                code_interventions = interventions.filter(code=intervention_code, name="Dual AI")
-            else:
-                code_interventions = interventions.filter(code=intervention_code)
-
-            if not code_interventions.exists():
-                self.stdout_write(f"WARNING: No interventions found for code '{intervention_code}', skipping...")
-                continue
-
-            # Convert to list for random selection
-            code_interventions_list = list(code_interventions)
-            self.stdout_write(
-                f"Found {len(code_interventions_list)} '{intervention_code}' interventions: "
-                f"{[i.name for i in code_interventions_list]}"
-            )
-
-            # Filter org units by prevalence group if needed
-            filtered_org_units = []
-            if prevalence_group != "all":
-                if prevalence_group == "prevalence_55":
-                    filtered_org_units = incidence_250_prevalence_55_ou
-                elif prevalence_group == "prevalence_75":
-                    filtered_org_units = incidence_250_prevalence_75_ou
-                self.stdout_write(
-                    f"Assigning '{intervention_code}' to {len(filtered_org_units)} org units in prevalence group '{prevalence_group}'"
-                )
-            else:
-                filtered_org_units = all_org_units
-                self.stdout_write(f"Assigning '{intervention_code}' to all {len(filtered_org_units)} org units")
-
-            # Assign one random intervention from this code to each filtered org unit
-            for org_unit in filtered_org_units:
-                intervention = random.choice(code_interventions_list)
-                all_assignments.append(
-                    InterventionAssignment(
-                        scenario=scenario,
-                        org_unit_id=org_unit,
-                        intervention=intervention,
-                        created_by=created_by,
-                    )
-                )
-
-            self.stdout_write(f"Created {len(filtered_org_units)} '{intervention_code}' assignments")
-
-        # Bulk create all assignments
-        total_assignments = len(all_assignments)
-        InterventionAssignment.objects.bulk_create(all_assignments)
-        self.stdout_write(f"\nTotal assignments created: {total_assignments}")
 
         # Create a budget for the scenario
-        self.stdout_write("\nCreating budget for scenario...")
-        budget = self._create_budget_for_scenario(scenario, created_by)
-        self.stdout_write(f"Created budget: {budget.name}")
+        # self.stdout_write("\nCreating budget for scenario...")
+        # budget = self._create_budget_for_scenario(scenario, created_by)
+        # self.stdout_write(f"Created budget: {budget.name}")
 
         # Create an SNT config
         country_out_id = OrgUnitType.objects.get(projects=self.project, short_name="Country").id
@@ -167,7 +82,6 @@ class DemoScenarioSeeder:
         )
 
         self.stdout_write("Done creating demo scenario.")
-        return scenario
 
     def _create_budget_for_scenario(self, scenario, created_by):
         """
@@ -234,3 +148,123 @@ class DemoScenarioSeeder:
         )
 
         return budget
+
+    def _create_scenarion_(
+        self, scenario_name, user, interventions, seasonality_precipitation_metric_type, pf_rate_metric_type, rate
+    ):
+        # Create the demo scenario
+        current_year = date.today().year + 1
+        scenario = Scenario.objects.create(
+            account=self.account,
+            created_by=user,
+            name=f"Demo {scenario_name}",
+            description=(
+                "This is a demonstration scenario for Burkina Faso showing various malaria "
+                "intervention strategies across different districts. The scenario includes "
+                "a mix of preventive measures (ITNs, SMC, IPTp), case management, and vaccination interventions."
+            ),
+            start_year=current_year,
+            end_year=current_year + 4,
+        )
+        self.stdout_write(f"Created scenario: {scenario.name}")
+
+        self.stdout_write("Create rule for all org units...")
+
+        all_orgunits_rules = ScenarioRule.objects.create(
+            scenario=scenario,
+            name="CM + IPTp",
+            created_by=user,
+            priority=1,
+            color="#26C6DA",
+            matching_criteria={"all": True},
+        )
+
+        # Only required for json matching criteria as it uses matching_orgunits field.
+
+        matching_criteria_seasonal = {
+            "and": [
+                {">=": [{"var": seasonality_precipitation_metric_type.id}, "seasonal"]},
+            ]
+        }
+
+        matching_orgunits = ScenarioRule.resolve_matched_org_units(self.account, matching_criteria_seasonal)
+
+        smc_rule = ScenarioRule.objects.create(
+            scenario=scenario,
+            name="SMC",
+            created_by=user,
+            priority=2,
+            color="#42A5F5",
+            org_units_matched=matching_orgunits,
+            matching_criteria=matching_criteria_seasonal,
+        )
+
+        matching_criteria_low = {
+            "and": [
+                {"<=": [{"var": pf_rate_metric_type.id}, rate]},
+            ]
+        }
+
+        matching_criteria_high = {
+            "and": [
+                {">": [{"var": pf_rate_metric_type.id}, rate]},
+            ]
+        }
+
+        matching_orgunits = ScenarioRule.resolve_matched_org_units(self.account, matching_criteria_high)
+
+        itn_dual_ai_rule = ScenarioRule.objects.create(
+            scenario=scenario,
+            name="ITN - Dual AI",
+            created_by=user,
+            priority=3,
+            color="#D4E157",
+            org_units_matched=matching_orgunits,
+            matching_criteria=matching_criteria_high,
+        )
+
+        matching_orgunits = ScenarioRule.resolve_matched_org_units(self.account, matching_criteria_low)
+
+        itn_pbo_rule = ScenarioRule.objects.create(
+            scenario=scenario,
+            name="ITN - PBO",
+            created_by=user,
+            priority=4,
+            color="#F4511E",
+            org_units_matched=matching_orgunits,
+            matching_criteria=matching_criteria_low,
+        )
+
+        self.stdout_write("Create intervention_properties for three scenario rules...")
+
+        ScenarioRuleInterventionProperties.objects.create(
+            scenario_rule=all_orgunits_rules,
+            intervention=interventions.get(code="cm_public"),
+            coverage=1,
+        )
+
+        ScenarioRuleInterventionProperties.objects.create(
+            scenario_rule=all_orgunits_rules,
+            intervention=interventions.filter(code="iptp").first(),
+            coverage=1,
+        )
+        ScenarioRuleInterventionProperties.objects.create(
+            scenario_rule=smc_rule,
+            intervention=interventions.get(code="smc", name="SMC (SP+AQ)"),
+            coverage=1,
+        )
+        ScenarioRuleInterventionProperties.objects.create(
+            scenario_rule=itn_dual_ai_rule,
+            intervention=interventions.filter(code="itn_routine", name="Dual AI").first(),
+            coverage=1,
+        )
+        ScenarioRuleInterventionProperties.objects.create(
+            scenario_rule=itn_pbo_rule,
+            intervention=interventions.filter(code="itn_routine", name="PBO").first(),
+            coverage=1,
+        )
+
+        self.stdout_write("Assign interventions to scenario...")
+        scenario.refresh_assignments(user=user)
+        assignment_count = scenario.intervention_assignments.count()
+        self.stdout_write(f"Assigned {assignment_count} interventions to scenario")

--- a/management/commands/support/demo_scenario_seeder.py
+++ b/management/commands/support/demo_scenario_seeder.py
@@ -57,10 +57,10 @@ class DemoScenarioSeeder:
         pf_rate_metric_type = metric_types.filter(code="PF_PR_RATE").first()
         seasonality_precipitation_metric_type = metric_types.filter(code="SEASONALITY_PRECIPITATION").first()
 
-        scenario_1 = self._create_scenarion_(
+        scenario_1 = self._create_scenario_(
             "NSP 1", created_by, interventions, seasonality_precipitation_metric_type, pf_rate_metric_type, rate=60
         )
-        scenario_2 = self._create_scenarion_(
+        scenario_2 = self._create_scenario_(
             "NSP 2", created_by, interventions, seasonality_precipitation_metric_type, pf_rate_metric_type, rate=80
         )
 
@@ -149,7 +149,7 @@ class DemoScenarioSeeder:
 
         return budget
 
-    def _create_scenarion_(
+    def _create_scenario_(
         self, scenario_name, user, interventions, seasonality_precipitation_metric_type, pf_rate_metric_type, rate
     ):
         # Create the demo scenario
@@ -183,7 +183,7 @@ class DemoScenarioSeeder:
 
         matching_criteria_seasonal = {
             "and": [
-                {">=": [{"var": seasonality_precipitation_metric_type.id}, "seasonal"]},
+                {"==": [{"var": seasonality_precipitation_metric_type.id}, "seasonal"]},
             ]
         }
 
@@ -255,12 +255,12 @@ class DemoScenarioSeeder:
         )
         ScenarioRuleInterventionProperties.objects.create(
             scenario_rule=itn_dual_ai_rule,
-            intervention=interventions.filter(code="itn_routine", name="Dual AI").first(),
+            intervention=interventions.get(code="itn_routine", name="Dual AI"),
             coverage=1,
         )
         ScenarioRuleInterventionProperties.objects.create(
             scenario_rule=itn_pbo_rule,
-            intervention=interventions.filter(code="itn_routine", name="PBO").first(),
+            intervention=interventions.get(code="itn_routine", name="PBO"),
             coverage=1,
         )
 


### PR DESCRIPTION
## What problem is this PR solving?

Create two scenarios with rules when recreating the demo account

### Related JIRA tickets

SNT-431

## Changes

Generate rules when creating the demo account and don't calculate fake budget anymore.

## How to test

On snt, run `manage.py recreate_demo_account`
Login using provided credentials on command log and verify that there are 2 scenarios.
Each of them work (you can check the rules and such) and run the budget, it should work as well.


## Print screen / video

<img width="878" height="226" alt="image" src="https://github.com/user-attachments/assets/075db689-3775-4bff-aa8d-21547da354fb" />

<img width="1645" height="836" alt="image" src="https://github.com/user-attachments/assets/e3c946d3-2892-4fe5-8655-87929f4f8b51" />

<img width="1650" height="835" alt="image" src="https://github.com/user-attachments/assets/6bd151a0-47ef-4842-98bf-b6a4ac58e643" />



## Notes


## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
