### PR TITLE
SNT Navigation: Use SCENARIO_BASIC_WRITE permissions

### DIFF
--- a/js/src/constants/menu.tsx
+++ b/js/src/constants/menu.tsx
@@ -8,7 +8,7 @@ import {
 import { SvgIconProps } from '@mui/material';
 import { MESSAGES as dataLayersMessages } from '../domains/dataLayers/messages';
 import { MESSAGES } from '../domains/messages';
-import { SETTINGS_READ } from './permissions';
+import { SCENARIO_BASIC_WRITE, SETTINGS_READ } from './permissions';
 
 export const menu = [
     {
@@ -20,7 +20,7 @@ export const menu = [
     {
         label: MESSAGES.scenariosTitle,
         key: 'snt_malaria/scenarios/list',
-        permissions: [],
+        permissions: [SCENARIO_BASIC_WRITE],
         icon: (props: SvgIconProps) => (
             <FormatListBulletedOutlined {...props} />
         ),
@@ -28,7 +28,7 @@ export const menu = [
     {
         label: MESSAGES.compareCustomizeTitle,
         key: 'snt_malaria/compare-customize',
-        permissions: [],
+        permissions: [SCENARIO_BASIC_WRITE],
         icon: (props: SvgIconProps) => <CompareOutlined {...props} />,
     },
     {


### PR DESCRIPTION
## What problem is this PR solving?

Temporarly use Scenario_WRITE permission to show menuItems for non admin users

### Related JIRA tickets

SNT-436

## Changes

/

## How to test

Go to SNT Malaria, run the script `manage.py recreate_demo_account`
Login using provided credentials and check that you have 4 items on the menu.

## Print screen / video

N/A

## Notes

This is a temporarly fix to not have to HF iaso changes.
Check related IASO PR: https://github.com/BLSQ/iaso/pull/2940

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
