### PR TITLE
fix(rules): consistent matching pipeline for match-all and criteria

### DIFF
--- a/api/scenario_rules/views.py
+++ b/api/scenario_rules/views.py
@@ -59,13 +59,12 @@ class ScenarioRuleViewSet(viewsets.ModelViewSet):
         Prepares required data for creating a new ScenarioRule that is not directly known by the serializer
         """
         user = self.request.user
-        account = user.iaso_profile.account
+        scenario = serializer.validated_data["scenario"]
         matching_criteria = serializer.validated_data.get("matching_criteria")
-        org_units_matched = ScenarioRule.resolve_matched_org_units(account, matching_criteria)
+        org_units_matched = ScenarioRule.resolve_matched_org_units(scenario.account, matching_criteria)
 
         rule: ScenarioRule = serializer.save(created_by=user, org_units_matched=org_units_matched)
-        scenario = rule.scenario
-        scenario.refresh_assignments(user)
+        rule.scenario.refresh_assignments(user)
 
     @transaction.atomic
     def create(self, request, *args, **kwargs):
@@ -83,20 +82,19 @@ class ScenarioRuleViewSet(viewsets.ModelViewSet):
 
     def perform_update(self, serializer):
         """
-        Prepares required data for updating an existing ScenarioRule that is not directly known by the serializer
+        Prepares required data for updating an existing ScenarioRule that is not directly known by the serializer.
+
+        org_units_matched is always recomputed -- using matching_criteria from the PATCH payload when
+        present, otherwise the currently persisted value. This lets edits self-heal stale cached
+        org_units_matched values even when matching_criteria is not part of the PATCH payload.
         """
         user = self.request.user
-        account = user.iaso_profile.account
-        extra_values = {
-            "updated_by": user,
-        }
-        if "matching_criteria" in serializer.validated_data:
-            matching_criteria = serializer.validated_data["matching_criteria"]
-            extra_values["org_units_matched"] = ScenarioRule.resolve_matched_org_units(account, matching_criteria)
+        instance = serializer.instance
+        matching_criteria = serializer.validated_data.get("matching_criteria", instance.matching_criteria)
+        org_units_matched = ScenarioRule.resolve_matched_org_units(instance.scenario.account, matching_criteria)
 
-        rule: ScenarioRule = serializer.save(**extra_values)
-        scenario = rule.scenario
-        scenario.refresh_assignments(user)
+        rule: ScenarioRule = serializer.save(updated_by=user, org_units_matched=org_units_matched)
+        rule.scenario.refresh_assignments(user)
 
     @transaction.atomic
     def update(self, request, *args, **kwargs):

--- a/api/scenarios/utils.py
+++ b/api/scenarios/utils.py
@@ -192,6 +192,9 @@ def create_rules_from_import(
 
         rules.append(rule)
 
+    for rule in rules:
+        rule.org_units_matched = ScenarioRule.resolve_matched_org_units(scenario.account, rule.matching_criteria)
+
     ScenarioRule.objects.bulk_create(rules)
 
     for rule, group in zip(rules, groups):

--- a/management/commands/support/demo_scenario_seeder.py
+++ b/management/commands/support/demo_scenario_seeder.py
@@ -170,7 +170,12 @@ class DemoScenarioSeeder:
 
         self.stdout_write("Create rule for all org units...")
 
-        all_orgunits_rules = ScenarioRule.objects.create(
+        def create_rule(**kwargs):
+            matching_criteria = kwargs.get("matching_criteria")
+            org_units_matched = ScenarioRule.resolve_matched_org_units(self.account, matching_criteria)
+            return ScenarioRule.objects.create(org_units_matched=org_units_matched, **kwargs)
+
+        all_orgunits_rules = create_rule(
             scenario=scenario,
             name="CM + IPTp",
             created_by=user,
@@ -179,23 +184,18 @@ class DemoScenarioSeeder:
             matching_criteria={"all": True},
         )
 
-        # Only required for json matching criteria as it uses matching_orgunits field.
-
         matching_criteria_seasonal = {
             "and": [
                 {"==": [{"var": seasonality_precipitation_metric_type.id}, "seasonal"]},
             ]
         }
 
-        matching_orgunits = ScenarioRule.resolve_matched_org_units(self.account, matching_criteria_seasonal)
-
-        smc_rule = ScenarioRule.objects.create(
+        smc_rule = create_rule(
             scenario=scenario,
             name="SMC",
             created_by=user,
             priority=2,
             color="#42A5F5",
-            org_units_matched=matching_orgunits,
             matching_criteria=matching_criteria_seasonal,
         )
 
@@ -211,27 +211,21 @@ class DemoScenarioSeeder:
             ]
         }
 
-        matching_orgunits = ScenarioRule.resolve_matched_org_units(self.account, matching_criteria_high)
-
-        itn_dual_ai_rule = ScenarioRule.objects.create(
+        itn_dual_ai_rule = create_rule(
             scenario=scenario,
             name="ITN - Dual AI",
             created_by=user,
             priority=3,
             color="#D4E157",
-            org_units_matched=matching_orgunits,
             matching_criteria=matching_criteria_high,
         )
 
-        matching_orgunits = ScenarioRule.resolve_matched_org_units(self.account, matching_criteria_low)
-
-        itn_pbo_rule = ScenarioRule.objects.create(
+        itn_pbo_rule = create_rule(
             scenario=scenario,
             name="ITN - PBO",
             created_by=user,
             priority=4,
             color="#F4511E",
-            org_units_matched=matching_orgunits,
             matching_criteria=matching_criteria_low,
         )
 

--- a/models/scenario.py
+++ b/models/scenario.py
@@ -14,7 +14,7 @@ from iaso.utils.models.soft_deletable import (
     SoftDeletableModel,
 )
 from iaso.utils.validators import JSONSchemaValidator
-from plugins.snt_malaria.models.account_settings import get_intervention_org_unit_type_id, get_intervention_org_units
+from plugins.snt_malaria.models.account_settings import get_intervention_org_units
 
 
 class Scenario(SoftDeletableModel):
@@ -180,30 +180,31 @@ class ScenarioRule(models.Model):
         """Evaluate matching_criteria and return the raw list of matched org unit IDs.
 
         This is the criteria-only result, before exclusion/inclusion overrides.
-        - match-all: returns all valid org units at the configured intervention level.
-        - criteria: evaluates against MetricValues, also scoped to the intervention level.
+
+        1. start from the account's valid geo-located org units at the configured
+           intervention_org_unit_type level (get_intervention_org_units)
+        2. if matching_criteria is JSONLogic, intersect with org units whose MetricValues satisfy it
+           (match-all skips this step - every org unit qualifies)
         """
         if matching_criteria is None:
             return []
-        if isinstance(matching_criteria, dict) and matching_criteria.get("all"):
-            return list(get_intervention_org_units(account).values_list("id", flat=True))
-        metric_values = MetricValue.objects.filter(metric_type__account=account, org_unit_id__isnull=False)
-        type_id = get_intervention_org_unit_type_id(account)
-        if type_id:
-            metric_values = metric_values.filter(org_unit__org_unit_type_id=type_id)
-        q = jsonlogic_to_exists_q_clauses(matching_criteria, metric_values, "metric_type_id", "org_unit_id")
-        return list(metric_values.filter(q).distinct().values_list("org_unit_id", flat=True))
+
+        org_units = get_intervention_org_units(account)
+        is_match_all = isinstance(matching_criteria, dict) and matching_criteria.get("all")
+
+        if not is_match_all:
+            metric_values = MetricValue.objects.filter(metric_type__account=account, org_unit_id__isnull=False)
+            q = jsonlogic_to_exists_q_clauses(matching_criteria, metric_values, "metric_type_id", "org_unit_id")
+            matched_ids = metric_values.filter(q).distinct().values_list("org_unit_id", flat=True)
+            org_units = org_units.filter(id__in=matched_ids)
+
+        return list(org_units.values_list("id", flat=True).distinct())
 
     def _compute_org_unit_ids(self) -> set[int]:
         """Resolve the set of org unit ids this rule targets based on its matching mode."""
         if self.matching_criteria is None:
             return set(self.org_units_included)
-        is_match_all = isinstance(self.matching_criteria, dict) and self.matching_criteria.get("all")
-        matched = (
-            set(self.resolve_matched_org_units(self.scenario.account, self.matching_criteria))
-            if is_match_all
-            else set(self.org_units_matched)
-        )
+        matched = set(self.org_units_matched)
         if not matched and not self.org_units_included:
             return set()
         return (matched - set(self.org_units_excluded)) | set(self.org_units_included)

--- a/models/scenario.py
+++ b/models/scenario.py
@@ -190,15 +190,14 @@ class ScenarioRule(models.Model):
             return []
 
         org_units = get_intervention_org_units(account)
-        is_match_all = isinstance(matching_criteria, dict) and matching_criteria.get("all")
 
-        if not is_match_all:
-            metric_values = MetricValue.objects.filter(metric_type__account=account, org_unit_id__isnull=False)
-            q = jsonlogic_to_exists_q_clauses(matching_criteria, metric_values, "metric_type_id", "org_unit_id")
-            matched_ids = metric_values.filter(q).distinct().values_list("org_unit_id", flat=True)
-            org_units = org_units.filter(id__in=matched_ids)
+        if isinstance(matching_criteria, dict) and matching_criteria.get("all"):
+            return list(org_units.values_list("id", flat=True).distinct())
 
-        return list(org_units.values_list("id", flat=True).distinct())
+        metric_values = MetricValue.objects.filter(metric_type__account=account, org_unit_id__isnull=False)
+        q = jsonlogic_to_exists_q_clauses(matching_criteria, metric_values, "metric_type_id", "org_unit_id")
+        matched_ids = metric_values.filter(q).distinct().values_list("org_unit_id", flat=True)
+        return list(org_units.filter(id__in=matched_ids).values_list("id", flat=True).distinct())
 
     def _compute_org_unit_ids(self) -> set[int]:
         """Resolve the set of org unit ids this rule targets based on its matching mode."""

--- a/tests/api/scenario_rules/test_views.py
+++ b/tests/api/scenario_rules/test_views.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from rest_framework import status
 
 from iaso.utils.colors import DEFAULT_COLOR
-from plugins.snt_malaria.models import InterventionAssignment, Scenario, ScenarioRule
+from plugins.snt_malaria.models import AccountSettings, InterventionAssignment, Scenario, ScenarioRule
 from plugins.snt_malaria.tests.api.scenario_rules.common_base import ScenarioRulesTestBase
 
 
@@ -847,3 +847,47 @@ class ScenarioRuleAPITestCase(ScenarioRulesTestBase):
             self.scenario_rule_1.org_units_matched,
             [self.district_1.id, self.district_2.id, self.district_3.id],
         )
+
+    def test_patch_without_matching_criteria_refreshes_org_units_matched(self):
+        """
+        A PATCH that does not include matching_criteria must still refresh org_units_matched
+        so stale cached IDs self-heal when a user edits the rule.
+        """
+        from django.contrib.gis.geos import Point
+
+        from iaso.models import OrgUnit, OrgUnitType
+
+        region_type = OrgUnitType.objects.create(name="REGION")
+        region = OrgUnit.objects.create(
+            org_unit_type=region_type,
+            name="Region 1",
+            version=self.version,
+            validation_status=OrgUnit.VALIDATION_VALID,
+            location=Point(x=4, y=50, z=100),
+        )
+
+        AccountSettings.objects.create(account=self.account, intervention_org_unit_type=self.out_district)
+
+        stale_match_all_rule = ScenarioRule.objects.create(
+            name="Stale match-all",
+            priority=3,
+            color="#123456",
+            matching_criteria={"all": True},
+            created_by=self.user_with_full_perm,
+            scenario=self.scenario,
+            org_units_matched=[self.district_1.id, self.district_2.id, self.district_3.id, region.id],
+        )
+
+        payload = {"name": "Renamed"}
+        self.client.force_authenticate(user=self.user_with_full_perm)
+        response = self.client.patch(f"{self.BASE_URL}{stale_match_all_rule.id}/", payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        stale_match_all_rule.refresh_from_db()
+        self.assertEqual(stale_match_all_rule.name, "Renamed")
+        self.assertEqual(stale_match_all_rule.matching_criteria, {"all": True})
+        self.assertCountEqual(
+            stale_match_all_rule.org_units_matched,
+            [self.district_1.id, self.district_2.id, self.district_3.id],
+        )
+        self.assertNotIn(region.id, stale_match_all_rule.org_units_matched)

--- a/tests/models/test_scenario_rule.py
+++ b/tests/models/test_scenario_rule.py
@@ -553,6 +553,7 @@ class ScenarioRuleMatchAllTestCase(TestCase):
             matching_criteria={"all": True},
             created_by=self.user,
             scenario=self.scenario,
+            org_units_matched=[self.org_unit_1.id, self.org_unit_2.id, self.org_unit_3.id],
         )
         ScenarioRuleInterventionProperties.objects.create(
             scenario_rule=rule,
@@ -576,6 +577,7 @@ class ScenarioRuleMatchAllTestCase(TestCase):
             matching_criteria={"all": True},
             created_by=self.user,
             scenario=self.scenario,
+            org_units_matched=[self.org_unit_1.id, self.org_unit_2.id, self.org_unit_3.id],
             org_units_excluded=[self.org_unit_3.id],
         )
         ScenarioRuleInterventionProperties.objects.create(
@@ -602,6 +604,7 @@ class ScenarioRuleMatchAllTestCase(TestCase):
             matching_criteria={"all": True},
             created_by=self.user,
             scenario=self.scenario,
+            org_units_matched=[self.org_unit_1.id, self.org_unit_2.id, self.org_unit_3.id],
             org_units_excluded=[self.org_unit_2.id],
             org_units_included=[self.org_unit_2.id],
         )
@@ -746,3 +749,23 @@ class ResolveMatchedOrgUnitsInterventionTypeScopeTestCase(TestCase):
         AccountSettings.objects.create(account=self.account, intervention_org_unit_type=self.district_type)
         result = ScenarioRule.resolve_matched_org_units(self.account, None)
         self.assertEqual(result, [])
+
+    def test_unified_pipeline_match_all_and_criteria_produce_same_intervention_scope(self):
+        """Both match-all and JSONLogic go through the same pipeline and apply the
+        intervention_org_unit_type filter, so when all org units
+        satisfy a criteria, both modes return the exact same intervention-level set."""
+        AccountSettings.objects.create(account=self.account, intervention_org_unit_type=self.district_type)
+        metric_type = MetricType.objects.get(account=self.account, code="POP")
+
+        match_all_result = ScenarioRule.resolve_matched_org_units(self.account, {"all": True})
+
+        # ">=1" is satisfied by every org unit with a POP MetricValue (region + both districts),
+        # so the only thing narrowing the result is the intervention_org_unit_type filter.
+        criteria = {"and": [{">=": [{"var": metric_type.id}, 1]}]}
+        criteria_result = ScenarioRule.resolve_matched_org_units(self.account, criteria)
+
+        expected = [self.district_1.id, self.district_2.id]
+        self.assertCountEqual(match_all_result, expected)
+        self.assertCountEqual(criteria_result, expected)
+        self.assertNotIn(self.region.id, match_all_result)
+        self.assertNotIn(self.region.id, criteria_result)


### PR DESCRIPTION

## What problem is this PR solving?

Consistent matching pipeline for match-all and criteria-based rules

## Changes

Now both, criteria-based and match-all rules generate `org_units_matched` which caches them on the rule.

In addition we re-match org units when updated, regardless of whether the matching criteria were updated. This helps with avoiding stale org units in old rules