### PR TITLE
feature SNT-440: expose load_impact_org_unit_mappings in django admin

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,9 +1,21 @@
+import json
+
 from django import forms
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.contrib.admin import helpers
 from django.db import models
+from django.shortcuts import redirect, render
+from django.urls import path, reverse
+from django.utils.html import format_html
 
 from iaso.admin import IasoJSONEditorWidget
+from iaso.models import Account
 from plugins.snt_malaria.api.account_settings.serializers import AccountSettings
+from plugins.snt_malaria.management.commands.load_impact_org_unit_mappings import (
+    HELP_TEXT as IMPACT_MAPPING_HELP_TEXT,
+    MappingLoadError,
+    load_impact_org_unit_mappings,
+)
 
 from .models import (
     Budget,
@@ -171,6 +183,29 @@ class ImpactProviderConfigAdmin(admin.ModelAdmin):
     )
 
 
+MAPPING_FILE_HELP = format_html(
+    "<p>JSON array of {{name, reference?, children?}} nodes.</p>"
+    "<details><summary>Expected file format</summary>"
+    '<pre style="white-space: pre-wrap;">{}</pre></details>',
+    IMPACT_MAPPING_HELP_TEXT,
+)
+
+
+class LoadImpactOrgUnitMappingsForm(forms.Form):
+    account = forms.ModelChoiceField(
+        queryset=Account.objects.order_by("name"),
+        help_text="Account whose default version's org units will be mapped.",
+    )
+    mapping_file = forms.FileField(
+        label="Mapping file",
+        help_text=MAPPING_FILE_HELP,
+    )
+    overwrite = forms.BooleanField(
+        required=False,
+        help_text="Overwrite existing mappings. Without this flag only unmapped org units are processed.",
+    )
+
+
 @admin.register(ImpactOrgUnitMapping)
 class ImpactOrgUnitMappingAdmin(admin.ModelAdmin):
     list_display = ("id", "org_unit", "reference", "get_account")
@@ -179,6 +214,7 @@ class ImpactOrgUnitMappingAdmin(admin.ModelAdmin):
     search_fields = ("org_unit__name", "reference")
     list_filter = ("org_unit__version__data_source__projects__account",)
     ordering = ("org_unit__name",)
+    change_list_template = "admin/snt_malaria/impactorgunitmapping/change_list.html"
 
     def get_queryset(self, request):
         return (
@@ -192,6 +228,76 @@ class ImpactOrgUnitMappingAdmin(admin.ModelAdmin):
     def get_account(self, obj):
         accounts = {project.account.name for project in obj.org_unit.version.data_source.projects.all()}
         return ", ".join(sorted(accounts)) if accounts else "-"
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "load-from-file/",
+                self.admin_site.admin_view(self.load_from_file_view),
+                name="snt_malaria_impactorgunitmapping_load_from_file",
+            ),
+        ]
+        return custom_urls + urls
+
+    def load_from_file_view(self, request):
+        changelist_url = reverse("admin:snt_malaria_impactorgunitmapping_changelist")
+        if request.method == "POST":
+            form = LoadImpactOrgUnitMappingsForm(request.POST, request.FILES)
+            if form.is_valid():
+                uploaded = form.cleaned_data["mapping_file"]
+                try:
+                    mapping_nodes = json.load(uploaded)
+                except json.JSONDecodeError as e:
+                    form.add_error("mapping_file", f"Invalid JSON: {e}")
+                else:
+                    try:
+                        counts = load_impact_org_unit_mappings(
+                            account=form.cleaned_data["account"],
+                            mapping_nodes=mapping_nodes,
+                            overwrite=form.cleaned_data["overwrite"],
+                        )
+                    except MappingLoadError as e:
+                        form.add_error(None, str(e))
+                    else:
+                        messages.success(
+                            request,
+                            (
+                                f"Account '{form.cleaned_data['account'].name}': "
+                                f"created {counts['created']}, updated {counts['updated']}, "
+                                f"skipped {counts['skipped']} mapping(s)."
+                            ),
+                        )
+                        return redirect(changelist_url)
+        else:
+            form = LoadImpactOrgUnitMappingsForm()
+
+        fieldsets = [(None, {"fields": list(form.fields)})]
+        adminform = helpers.AdminForm(form, fieldsets, prepopulated_fields={}, model_admin=self)
+
+        context = {
+            **self.admin_site.each_context(request),
+            "title": "Load impact org unit mappings from file",
+            "adminform": adminform,
+            "errors": helpers.AdminErrorList(form, []),
+            "media": self.media + form.media,
+            "opts": self.model._meta,
+            "has_file_field": True,
+            "add": True,
+            "change": False,
+            "is_popup": False,
+            "save_as": False,
+            "show_save": True,
+            "show_save_and_add_another": False,
+            "show_save_and_continue": False,
+            "show_delete": False,
+            "has_add_permission": True,
+            "has_change_permission": True,
+            "has_delete_permission": False,
+            "has_view_permission": True,
+            "has_editable_inline_admin_formsets": False,
+        }
+        return render(request, "admin/change_form.html", context)
 
 
 @admin.register(AccountSettings)

--- a/management/commands/load_impact_org_unit_mappings.py
+++ b/management/commands/load_impact_org_unit_mappings.py
@@ -9,8 +9,7 @@ from iaso.models import Account, OrgUnit
 from plugins.snt_malaria.models import ImpactOrgUnitMapping
 
 
-class Command(BaseCommand):
-    help = """Load impact org-unit mappings from a JSON mapping file.
+HELP_TEXT = """Load impact org-unit mappings from a JSON mapping file.
 
 Creates or updates ImpactOrgUnitMapping rows that link Iaso org units
 to reference strings used by external impact databases.
@@ -65,6 +64,79 @@ same-name org units by scoping them under a parent. A node can have
 both "reference" (mapped itself) and "children" (scoping descendants).
 Nesting can be arbitrarily deep."""
 
+
+class MappingLoadError(ValueError):
+    """Raised when the provided mapping data cannot be loaded."""
+
+
+def load_impact_org_unit_mappings(account, mapping_nodes, overwrite=False, logger=None):
+    """Load impact org-unit mappings for a given account.
+
+    Args:
+        account: ``iaso.Account`` instance whose default version will be used.
+        mapping_nodes: parsed JSON payload (a list of mapping nodes).
+        overwrite: when False, existing mappings are left untouched.
+        logger: optional callable accepting a single string, used for
+            progress messages.
+
+    Returns:
+        A dict ``{"created": int, "updated": int, "skipped": int}``.
+
+    Raises:
+        MappingLoadError: when the mapping data is not a list, the account
+            has no default version, or a mapping node is ambiguous.
+    """
+    log = logger or (lambda _msg: None)
+
+    if not isinstance(mapping_nodes, list):
+        raise MappingLoadError("Mapping file must contain a JSON array of nodes.")
+
+    lookup = _build_lookup(mapping_nodes)
+
+    default_version = account.default_version
+    if default_version is None:
+        raise MappingLoadError(f"Account '{account.name}' has no default version.")
+
+    log("Loading org units...")
+    org_units = OrgUnit.objects.filter(version=default_version)
+    if not overwrite:
+        org_units = org_units.exclude(impact_mapping__isnull=False)
+
+    org_unit_list = list(org_units)
+    log(f"Loaded {len(org_unit_list)} org units.")
+    if not org_unit_list:
+        return {"created": 0, "updated": 0, "skipped": 0}
+
+    _validate_uniqueness(org_unit_list, lookup)
+
+    log("Writing mappings...")
+    created_count = 0
+    updated_count = 0
+    skipped_count = 0
+    with transaction.atomic():
+        for org_unit in org_unit_list:
+            log(f"  Processing: {org_unit.name} (id={org_unit.id})")
+            ancestors = _build_ancestors(org_unit)
+            reference = _resolve(ancestors, lookup)
+            if reference is None:
+                skipped_count += 1
+                continue
+            _, created = ImpactOrgUnitMapping.objects.update_or_create(
+                org_unit=org_unit,
+                defaults={"reference": reference},
+            )
+            if created:
+                created_count += 1
+            else:
+                updated_count += 1
+    log("Committed.")
+
+    return {"created": created_count, "updated": updated_count, "skipped": skipped_count}
+
+
+class Command(BaseCommand):
+    help = HELP_TEXT
+
     def add_arguments(self, parser):
         parser.add_argument(
             "--account",
@@ -108,11 +180,6 @@ Nesting can be arbitrarily deep."""
         except json.JSONDecodeError as e:
             raise CommandError(f"Invalid JSON in mapping file: {e}")
 
-        if not isinstance(mapping_nodes, list):
-            raise CommandError("Mapping file must contain a JSON array of nodes.")
-
-        lookup = _build_lookup(mapping_nodes)
-
         identifier = account_id if account_id else account_name
         try:
             if account_id:
@@ -122,81 +189,60 @@ Nesting can be arbitrarily deep."""
         except Account.DoesNotExist:
             raise CommandError(f"Account '{identifier}' does not exist.")
 
-        default_version = account.default_version
-        if default_version is None:
-            raise CommandError(f"Account '{identifier}' has no default version.")
+        try:
+            counts = load_impact_org_unit_mappings(
+                account=account,
+                mapping_nodes=mapping_nodes,
+                overwrite=overwrite,
+                logger=self.stdout.write,
+            )
+        except MappingLoadError as e:
+            raise CommandError(str(e))
 
-        self.stdout.write("Loading org units...")
-        org_units = OrgUnit.objects.filter(version=default_version)
-        if not overwrite:
-            org_units = org_units.exclude(impact_mapping__isnull=False)
-
-        org_unit_list = list(org_units)
-        self.stdout.write(f"Loaded {len(org_unit_list)} org units.")
-        if not org_unit_list:
+        if counts["created"] == 0 and counts["updated"] == 0 and counts["skipped"] == 0:
             self.stdout.write(self.style.WARNING("No org units to process."))
             return
 
-        self._validate_uniqueness(org_unit_list, lookup)
-
-        self.stdout.write("Writing mappings...")
-        created_count = 0
-        updated_count = 0
-        skipped_count = 0
-        with transaction.atomic():
-            for org_unit in org_unit_list:
-                self.stdout.write(f"  Processing: {org_unit.name} (id={org_unit.id})")
-                ancestors = _build_ancestors(org_unit)
-                reference = _resolve(ancestors, lookup)
-                if reference is None:
-                    skipped_count += 1
-                    continue
-                _, created = ImpactOrgUnitMapping.objects.update_or_create(
-                    org_unit=org_unit,
-                    defaults={"reference": reference},
-                )
-                if created:
-                    created_count += 1
-                else:
-                    updated_count += 1
-        self.stdout.write("Committed.")
-
         self.stdout.write(
-            self.style.SUCCESS(f"Account '{identifier}': created {created_count}, updated {updated_count} mapping(s).")
+            self.style.SUCCESS(
+                f"Account '{identifier}': created {counts['created']}, updated {counts['updated']} mapping(s)."
+            )
         )
-        if skipped_count:
-            self.stdout.write(f"Skipped {skipped_count} org unit(s) with no mapping match.")
+        if counts["skipped"]:
+            self.stdout.write(f"Skipped {counts['skipped']} org unit(s) with no mapping match.")
 
-    def _validate_uniqueness(self, org_unit_list, lookup):
-        """Validate that every mapping node resolves unambiguously.
 
-        For each node in the lookup tree, count how many org units match at
-        that scope level. If a node with a reference matches 2+ org units,
-        the mapping is ambiguous and a deeper hierarchy is needed.
-        """
-        name_counts_by_parent = Counter()
-        global_name_counts = Counter()
-        for ou in org_unit_list:
-            parent_name = ou.parent.name if ou.parent else None
-            name_counts_by_parent[(parent_name, ou.name)] += 1
-            global_name_counts[ou.name] += 1
+def _validate_uniqueness(org_unit_list, lookup):
+    """Validate that every mapping node resolves unambiguously.
 
-        self._check_scope(lookup, global_name_counts, name_counts_by_parent, scope_label="top-level")
+    For each node in the lookup tree, count how many org units match at
+    that scope level. If a node with a reference matches 2+ org units,
+    the mapping is ambiguous and a deeper hierarchy is needed.
+    """
+    name_counts_by_parent = Counter()
+    global_name_counts = Counter()
+    for ou in org_unit_list:
+        parent_name = ou.parent.name if ou.parent else None
+        name_counts_by_parent[(parent_name, ou.name)] += 1
+        global_name_counts[ou.name] += 1
 
-    def _check_scope(self, scope_lookup, global_name_counts, name_counts_by_parent, scope_label):
-        for name, node in scope_lookup.items():
-            if node["reference"] is not None:
-                if scope_label == "top-level":
-                    count = global_name_counts.get(name, 0)
-                else:
-                    count = name_counts_by_parent.get((scope_label, name), 0)
-                if count > 1:
-                    raise CommandError(
-                        f"Ambiguous mapping: {count} org units named '{name}' "
-                        f"in scope '{scope_label}'. Use a deeper hierarchy to disambiguate."
-                    )
-            if node["children"]:
-                self._check_scope(node["children"], global_name_counts, name_counts_by_parent, scope_label=name)
+    _check_scope(lookup, global_name_counts, name_counts_by_parent, scope_label="top-level")
+
+
+def _check_scope(scope_lookup, global_name_counts, name_counts_by_parent, scope_label):
+    for name, node in scope_lookup.items():
+        if node["reference"] is not None:
+            if scope_label == "top-level":
+                count = global_name_counts.get(name, 0)
+            else:
+                count = name_counts_by_parent.get((scope_label, name), 0)
+            if count > 1:
+                raise MappingLoadError(
+                    f"Ambiguous mapping: {count} org units named '{name}' "
+                    f"in scope '{scope_label}'. Use a deeper hierarchy to disambiguate."
+                )
+        if node["children"]:
+            _check_scope(node["children"], global_name_counts, name_counts_by_parent, scope_label=name)
 
 
 def _build_lookup(nodes):

--- a/templates/admin/snt_malaria/impactorgunitmapping/change_list.html
+++ b/templates/admin/snt_malaria/impactorgunitmapping/change_list.html
@@ -1,0 +1,10 @@
+{% extends "admin/change_list.html" %}
+
+{% block object-tools-items %}
+<li>
+    <a href="{% url 'admin:snt_malaria_impactorgunitmapping_load_from_file' %}" class="addlink">
+        Load mappings from file
+    </a>
+</li>
+{{ block.super }}
+{% endblock %}


### PR DESCRIPTION
## What problem is this PR solving?

refactor the existing command into a reusable function and expose it in django admin with a file uploader form so we can avoid SSH-ing into prodicution environments

<img width="594" height="433" alt="image" src="https://github.com/user-attachments/assets/38f90977-50d0-4743-8c05-30b510ba4155" />
<img width="580" height="476" alt="image" src="https://github.com/user-attachments/assets/ebd936f5-6ae3-413f-9264-e525e40e65d2" />
