### PR TITLE
SNT-433: Apply inflation on costs

### DIFF
--- a/api/budget/utils.py
+++ b/api/budget/utils.py
@@ -139,16 +139,22 @@ def build_cost_dataframe(account, start_year, end_year):
     # Convert to DataFrame
     df = pd.DataFrame(cost_lines_data)
 
-    # Duplicate data across scenario years
+    inflation_rate = float(budget_settings.inflation_rate)
+
+    # Duplicate data across scenario years, applying annual inflation compounding.
+    # unit_cost is treated as the start_year base cost; each subsequent year is
+    # compounded by (1 + inflation_rate) ** years_from_start.
     dfs_by_year = []
-    for year in [year for year in range(start_year, end_year + 1)]:
+    for year in range(start_year, end_year + 1):
         df_year = df.copy()
         df_year["cost_year_for_analysis"] = year
+        years_offset = year - start_year
+        df_year["usd_cost"] = df_year["usd_cost"] * (1 + inflation_rate) ** years_offset
         dfs_by_year.append(df_year)
     df = pd.concat(dfs_by_year, ignore_index=True)
 
     # BudgetSettings fields
-    # NOTE: not supported yet by budget script
+    # inflation_rate is already applied per-year to usd_cost above; kept here for audit.
     df["exchange_rate"] = budget_settings.exchange_rate
     df["inflation_factor"] = budget_settings.inflation_rate
 

--- a/tests/api/budget/test_views.py
+++ b/tests/api/budget/test_views.py
@@ -450,6 +450,68 @@ class ScenarioAPITestCase(APITestCase):
                 self.assertEqual(item.get("pop_total"), "15000000")
                 self.assertEqual(item.get("pop_under_5"), "150000")
 
+    def test_calculate_budget_inflation_applied_per_year(self):
+        """
+        Verify that unit_cost in cost_input is compounded by the account inflation_rate
+        for each year after start_year, and that this flows through to higher budget
+        totals in later years.
+
+        start_year offset: (1 + rate)^0 = 1.0  (unchanged)
+        year+1 offset:     (1 + rate)^1
+        year+N offset:     (1 + rate)^N
+        """
+        InterventionAssignment.objects.create(
+            scenario=self.scenario,
+            org_unit=self.district1,
+            intervention=self.intervention_chemo_smc,
+            created_by=self.user_with_full_perm,
+        )
+
+        self.client.force_authenticate(user=self.user_with_full_perm)
+        response = self.client.post(BASE_URL, {"scenario": self.scenario.id}, format="json")
+
+        result = self.assertJSONResponse(response, status.HTTP_201_CREATED)
+
+        budget = Budget.objects.get(id=result["id"])
+        inflation_rate = float(self.budget_settings.inflation_rate)  # 0.03
+        base_unit_cost = 2.5  # unit_cost of the SMC cost line created in setUp
+        start_year = self.scenario.start_year  # 2025
+        end_year = self.scenario.end_year  # 2028
+
+        # --- Verify cost_input rows: each year's usd_cost must be compounded ---
+        smc_cost_by_year = {}
+        for row in budget.cost_input:
+            if row["code_intervention"] == "smc":
+                year = int(row["cost_year_for_analysis"])
+                smc_cost_by_year[year] = float(row["usd_cost"])
+
+        for year in range(start_year, end_year + 1):
+            expected = base_unit_cost * (1 + inflation_rate) ** (year - start_year)
+            self.assertAlmostEqual(
+                smc_cost_by_year[year],
+                expected,
+                places=6,
+                msg=f"usd_cost for year {year} should be {expected}",
+            )
+
+        # --- Verify results: later years should cost more than start_year ---
+        results_by_year = {r["year"]: r for r in result["results"]}
+
+        def smc_total_cost(year):
+            interventions = results_by_year[year]["interventions"]
+            smc = next(i for i in interventions if i["code"] == "smc")
+            return smc["total_cost"]
+
+        cost_2025 = smc_total_cost(2025)
+        for year in range(start_year + 1, end_year + 1):
+            expected_ratio = (1 + inflation_rate) ** (year - start_year)
+            self.assertAlmostEqual(
+                smc_total_cost(year),
+                cost_2025 * expected_ratio,
+                places=3,
+                msg=f"SMC total_cost for {year} should be {expected_ratio:.4f}x the 2025 cost",
+            )
+
     def test_list_budgets(self):
         """
         This endpoint is available to all authenticated users, regardless of permissions.


### PR DESCRIPTION
## What problem is this PR solving?

Apply inflation when calculating costs

### Related JIRA tickets

SNT-433

## Changes

Instead of duplicating cost per year, apply the inflation using the formula: 

cost * (1+inflation_rate) ^ year

## How to test

Configure your costs for interventions in the interventions settings (You will need to select correct unit otherwise it will be ignored, you could just create the demo account to have all set up for you).
Create a scenario with a rule targetting that intervention. 
Checkout develop and run the budget.
Now checkout this branch and run again the budget. 
Make sure you si it increase by a bit based on the formula and the inflation of 0.03

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
