### PR TITLE
fix SNT-439: flaky input field height

### DIFF
--- a/js/src/constants/theme.ts
+++ b/js/src/constants/theme.ts
@@ -68,8 +68,16 @@ export const theme = createTheme({
         },
         MuiInputBase: {
             styleOverrides: {
+                // bluesquare-components' TextInput sets `min-height: 56px`
+                // on the input, which makes our text fields look too tall
+                // after some navigation. We set `min-height: 0` to counter
+                // that, but sometimes their rule wins instead of ours
+                // depending on the order things load. The `&&` is a little
+                // trick to make sure our rule always wins.
                 root: {
-                    minHeight: '0',
+                    '&&': {
+                        minHeight: 0,
+                    },
                     input: {
                         padding: '8.5px 14px',
                     },


### PR DESCRIPTION
## What problem is this PR solving?

This fixes a race condition of style sheets that makes our input fields render higher than initially after some navigation 

### Related JIRA tickets

SNT-439

## Changes

Initial state when loading the page
<img width="631" height="388" alt="image" src="https://github.com/user-attachments/assets/cbac2e2b-6524-4ae1-a9fd-2914ef4e74c3" />

Styles break after some page navigation (inputs are higher)
<img width="639" height="423" alt="image" src="https://github.com/user-attachments/assets/392706ce-6d36-4c60-bb6e-555844b87dc5" />