### PR TITLE
SNT-436 Cleanup nav permissions

### DIFF
--- a/js/src/constants/menu.tsx
+++ b/js/src/constants/menu.tsx
@@ -8,7 +8,7 @@ import {
 import { SvgIconProps } from '@mui/material';
 import { MESSAGES as dataLayersMessages } from '../domains/dataLayers/messages';
 import { MESSAGES } from '../domains/messages';
-import { SCENARIO_BASIC_WRITE, SETTINGS_READ } from './permissions';
+import { SETTINGS_READ } from './permissions';
 
 export const menu = [
     {
@@ -20,7 +20,7 @@ export const menu = [
     {
         label: MESSAGES.scenariosTitle,
         key: 'snt_malaria/scenarios/list',
-        permissions: [SCENARIO_BASIC_WRITE],
+        permissions: [],
         icon: (props: SvgIconProps) => (
             <FormatListBulletedOutlined {...props} />
         ),
@@ -28,7 +28,7 @@ export const menu = [
     {
         label: MESSAGES.compareCustomizeTitle,
         key: 'snt_malaria/compare-customize',
-        permissions: [SCENARIO_BASIC_WRITE],
+        permissions: [],
         icon: (props: SvgIconProps) => <CompareOutlined {...props} />,
     },
     {


### PR DESCRIPTION
## What problem is this PR solving?

Quick alignment with a fix merge in IASO, we don't need custom permission for always accessible menu items now.

### Related JIRA tickets

SNT-436

## Changes

There was a bug in IASO when given an empty permission list on a menu item would act as if nobody except admin has access.

As this has been fixed in IASO, this is a cleanup story to remove the role from SNT always accessible nav items.

## How to test

Have a non admin account and verify that navigation without permission are visible.

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
