### PR TITLE
[SNT-451] add captcha to public account creation endpoint

### DIFF
--- a/api/account_setup/serializers.py
+++ b/api/account_setup/serializers.py
@@ -2,6 +2,7 @@ import json
 
 import django.core.exceptions as django_exceptions
 
+from captcha import serializers as captcha_serializers
 from django.contrib.auth.models import User
 from django.contrib.auth.password_validation import validate_password
 from rest_framework import serializers
@@ -10,7 +11,7 @@ from plugins.snt_malaria.api.account_setup.utils import REQUIRED_GEO_JSON_LABELS
 from plugins.snt_malaria.models import SNTAccountSetup
 
 
-class SNTAccountSetupSerializer(serializers.ModelSerializer):
+class SNTAccountSetupSerializer(captcha_serializers.CaptchaModelSerializer):
     password = serializers.CharField(write_only=True, required=True)
     password_confirmation = serializers.CharField(write_only=True, required=True)
 
@@ -23,6 +24,8 @@ class SNTAccountSetupSerializer(serializers.ModelSerializer):
             "geo_json_file",
             "password",
             "password_confirmation",
+            "captcha_code",
+            "captcha_hashkey",
         ]
 
     def validate_username(self, value):

--- a/tests/api/account_setup/test_serializers.py
+++ b/tests/api/account_setup/test_serializers.py
@@ -1,3 +1,8 @@
+from unittest.mock import patch
+
+import captcha.conf.settings as captcha_conf_settings
+
+from captcha.models import CaptchaStore
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
 
@@ -6,10 +11,23 @@ from plugins.snt_malaria.api.account_setup.serializers import SNTAccountSetupSer
 
 
 class SNTAccountSetupSerializerTestCase(TestCase, PasswordValidationTestMixin):
+    """
+    Tests for checking the SNTAccountSetupSerializer behavior.
+    Since it contains a captcha and the django-simple-captcha lib does not handle @override_settings,
+    the lib settings are directly imported and monkey patched (https://github.com/mbi/django-simple-captcha/issues/84)
+    (e.g. @patch.object(captcha_conf_settings, "CAPTCHA_TEST_MODE", False))
+    """
+
     JSON_FILE_NAME = "geo_json_be.json"
     JSON_FILE_PATH = f"plugins/snt_malaria/tests/fixtures/{JSON_FILE_NAME}"
 
+    def setUp(self):
+        super().setUp()
+        self.captcha_key = CaptchaStore.pick()
+
+    @patch.object(captcha_conf_settings, "CAPTCHA_TEST_MODE", False)
     def test_happy_path(self):
+        captcha_code = CaptchaStore.objects.get(hashkey=self.captcha_key).response
         with open(self.JSON_FILE_PATH, "rb") as json_file:
             data = {
                 "username": "username",
@@ -20,6 +38,8 @@ class SNTAccountSetupSerializerTestCase(TestCase, PasswordValidationTestMixin):
                 "geo_json_file": SimpleUploadedFile(
                     self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
                 ),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": captcha_code,
             }
         serializer = SNTAccountSetupSerializer(data=data)
         self.assertTrue(serializer.is_valid(), serializer.errors)
@@ -35,6 +55,8 @@ class SNTAccountSetupSerializerTestCase(TestCase, PasswordValidationTestMixin):
                 "geo_json_file": SimpleUploadedFile(
                     self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
                 ),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": "passed",
             }
         serializer = SNTAccountSetupSerializer(data=data)
         self.assertFalse(serializer.is_valid())
@@ -52,6 +74,8 @@ class SNTAccountSetupSerializerTestCase(TestCase, PasswordValidationTestMixin):
                 "geo_json_file": SimpleUploadedFile(
                     self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
                 ),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": "passed",
             }
         serializer = SNTAccountSetupSerializer(data=data)
         self.assertFalse(serializer.is_valid())
@@ -70,6 +94,8 @@ class SNTAccountSetupSerializerTestCase(TestCase, PasswordValidationTestMixin):
                 "geo_json_file": SimpleUploadedFile(
                     self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
                 ),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": "passed",
             }
         serializer = SNTAccountSetupSerializer(data=data)
         self.assertTrue(serializer.is_valid(), serializer.errors)
@@ -90,6 +116,10 @@ class SNTAccountSetupSerializerTestCase(TestCase, PasswordValidationTestMixin):
         self.assertIn("This field is required.", errors["country"][0])
         self.assertIn("geo_json_file", errors)
         self.assertIn("No file was submitted.", errors["geo_json_file"][0])
+        self.assertIn("captcha_hashkey", errors)
+        self.assertIn("This field is required.", errors["captcha_hashkey"][0])
+        self.assertIn("captcha_code", errors)
+        self.assertIn("This field is required.", errors["captcha_code"][0])
 
         # optional
         self.assertNotIn("language", errors)
@@ -105,6 +135,8 @@ class SNTAccountSetupSerializerTestCase(TestCase, PasswordValidationTestMixin):
                 "geo_json_file": SimpleUploadedFile(
                     self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
                 ),
+                "captcha_hashkey": "",
+                "captcha_code": "",
             }
         serializer = SNTAccountSetupSerializer(data=data)
         self.assertFalse(serializer.is_valid())
@@ -116,6 +148,10 @@ class SNTAccountSetupSerializerTestCase(TestCase, PasswordValidationTestMixin):
         self.assertIn("This field may not be blank", errors["password"][0])
         self.assertIn("password_confirmation", errors)
         self.assertIn("This field may not be blank", errors["password_confirmation"][0])
+        self.assertIn("captcha_hashkey", errors)
+        self.assertIn("This field may not be blank", errors["captcha_hashkey"][0])
+        self.assertIn("captcha_code", errors)
+        self.assertIn("This field may not be blank", errors["captcha_code"][0])
 
         # values from dropdown lists
         self.assertIn("country", errors)
@@ -132,6 +168,8 @@ class SNTAccountSetupSerializerTestCase(TestCase, PasswordValidationTestMixin):
                 "country": "BE",
                 "language": "fr",
                 "geo_json_file": SimpleUploadedFile("hydro.xml", xml_file.read(), content_type="application/xml"),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": "passed",
             }
         serializer = SNTAccountSetupSerializer(data=data)
         self.assertFalse(serializer.is_valid())
@@ -149,6 +187,8 @@ class SNTAccountSetupSerializerTestCase(TestCase, PasswordValidationTestMixin):
                 "country": "BE",
                 "language": "fr",
                 "geo_json_file": SimpleUploadedFile("file.json", json_file.read(), content_type="application/json"),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": "passed",
             }
         serializer = SNTAccountSetupSerializer(data=data)
         self.assertFalse(serializer.is_valid())
@@ -172,6 +212,8 @@ class SNTAccountSetupSerializerTestCase(TestCase, PasswordValidationTestMixin):
                 "country": "BE",
                 "language": "fr",
                 "geo_json_file": SimpleUploadedFile("file.json", json_file.read(), content_type="application/json"),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": "passed",
             }
         serializer = SNTAccountSetupSerializer(data=data)
         self.assertFalse(serializer.is_valid())
@@ -193,6 +235,8 @@ class SNTAccountSetupSerializerTestCase(TestCase, PasswordValidationTestMixin):
                 "geo_json_file": SimpleUploadedFile(
                     self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
                 ),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": "passed",
             }
         serializer = SNTAccountSetupSerializer(data=data)
         self.assertFalse(serializer.is_valid())
@@ -211,6 +255,8 @@ class SNTAccountSetupSerializerTestCase(TestCase, PasswordValidationTestMixin):
                 "geo_json_file": SimpleUploadedFile(
                     self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
                 ),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": "passed",
             }
         serializer = SNTAccountSetupSerializer(data=data)
         self.assertFalse(serializer.is_valid())
@@ -228,9 +274,68 @@ class SNTAccountSetupSerializerTestCase(TestCase, PasswordValidationTestMixin):
                 "geo_json_file": SimpleUploadedFile(
                     self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
                 ),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": "passed",
             }
         serializer = SNTAccountSetupSerializer(data=data)
         self.assertFalse(serializer.is_valid())
         errors = serializer.errors
         self.assertIn("password", errors)
         self.assertIn(self.ERROR_PASSWORD_NUMERIC, errors["password"])
+
+    @patch.object(captcha_conf_settings, "CAPTCHA_TEST_MODE", False)
+    def test_error_captcha_fail(self):
+        with open(self.JSON_FILE_PATH, "rb") as json_file:
+            data = {
+                "username": "username",
+                "password": "secret-password-very-secure-much-wow",
+                "password_confirmation": "secret-password-very-secure-much-wow",
+                "country": "BE",
+                "geo_json_file": SimpleUploadedFile(
+                    self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
+                ),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": 123456789876543210,  # probably not the right solution
+            }
+        serializer = SNTAccountSetupSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("Invalid CAPTCHA", serializer.errors["error"])
+
+    @patch.object(captcha_conf_settings, "CAPTCHA_TEST_MODE", False)
+    def test_error_captcha_does_not_exist(self):
+        with open(self.JSON_FILE_PATH, "rb") as json_file:
+            data = {
+                "username": "username",
+                "password": "secret-password-very-secure-much-wow",
+                "password_confirmation": "secret-password-very-secure-much-wow",
+                "country": "BE",
+                "geo_json_file": SimpleUploadedFile(
+                    self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
+                ),
+                "captcha_hashkey": "f27a15cf2354424db952fc3c69d66f0b93e438d9",  # probably not the one that was created in setUp
+                "captcha_code": 123456789876543210,
+            }
+        serializer = SNTAccountSetupSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("Invalid CAPTCHA", serializer.errors["error"])
+
+    @patch.object(captcha_conf_settings, "CAPTCHA_TEST_MODE", False)
+    @patch.object(captcha_conf_settings, "CAPTCHA_TIMEOUT", 0)
+    def test_error_captcha_expired(self):
+        captcha_hashkey = CaptchaStore.pick()  # expires immediately because of CAPTCHA_TIMEOUT=0
+        captcha_code = CaptchaStore.objects.get(hashkey=captcha_hashkey).response
+        with open(self.JSON_FILE_PATH, "rb") as json_file:
+            data = {
+                "username": "username",
+                "password": "secret-password-very-secure-much-wow",
+                "password_confirmation": "secret-password-very-secure-much-wow",
+                "country": "BE",
+                "geo_json_file": SimpleUploadedFile(
+                    self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
+                ),
+                "captcha_hashkey": captcha_hashkey,
+                "captcha_code": captcha_code,
+            }
+        serializer = SNTAccountSetupSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("Invalid CAPTCHA", serializer.errors["error"])

--- a/tests/api/account_setup/test_views.py
+++ b/tests/api/account_setup/test_views.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from captcha.models import CaptchaStore
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
@@ -17,6 +18,10 @@ class SNTAccountSetupAPITestCase(TaskAPITestCase):
     JSON_FILE_NAME = "geo_json_be.json"
     JSON_FILE_PATH = f"plugins/snt_malaria/tests/fixtures/{JSON_FILE_NAME}"
 
+    def setUp(self):
+        super().setUp()
+        self.captcha_key = CaptchaStore.pick()
+
     @override_settings(ENABLE_PUBLIC_ACCOUNT_SETUP=True)
     def test_post_account_setup_public(self):
         with open(self.JSON_FILE_PATH, "rb") as json_file:
@@ -29,6 +34,8 @@ class SNTAccountSetupAPITestCase(TaskAPITestCase):
                 "geo_json_file": SimpleUploadedFile(
                     self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
                 ),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": "passed",
             }
         response = self.client.post(self.BASE_URL, data=payload, format="multipart")
         result = self.assertJSONResponse(response, status.HTTP_201_CREATED)
@@ -92,6 +99,8 @@ class SNTAccountSetupAPITestCase(TaskAPITestCase):
                 "geo_json_file": SimpleUploadedFile(
                     self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
                 ),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": "passed",
             }
 
         response = self.client.post(self.BASE_URL, data=payload, format="multipart")
@@ -116,6 +125,8 @@ class SNTAccountSetupAPITestCase(TaskAPITestCase):
                 "geo_json_file": SimpleUploadedFile(
                     self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
                 ),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": "passed",
             }
 
         response = self.client.post(self.BASE_URL, data=payload, format="multipart")
@@ -141,6 +152,8 @@ class SNTAccountSetupAPITestCase(TaskAPITestCase):
                 "geo_json_file": SimpleUploadedFile(
                     self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
                 ),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": "passed",
             }
 
         response = self.client.post(self.BASE_URL, data=payload, format="multipart")

--- a/tests/api/account_setup/test_views.py
+++ b/tests/api/account_setup/test_views.py
@@ -177,6 +177,8 @@ class SNTAccountSetupAPITestCase(TaskAPITestCase):
                 "geo_json_file": SimpleUploadedFile(
                     self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
                 ),
+                "captcha_hashkey": self.captcha_key,
+                "captcha_code": "passed",
             }
 
         # default value is 5 calls per hour per IP address


### PR DESCRIPTION
## What problem is this PR solving?

add captcha to public account creation endpoint

### Related JIRA tickets

SNT-451

## Changes

- added a captcha to `api/snt_malaria/account_setup/`
- updated tests

## How to test

- There's no frontend yet, so it's hard to test, but you can:
  1. generate a captcha (with a Bruno call for instance - see [IASO PR](https://github.com/BLSQ/iaso/pull/2995))
  3. go to the DRF web view `api/snt_malaria/account_setup/`
  4. fill out the form:
    - use the captcha `key` (ID) in `Captcha hashkey`
    - use the captcha solution in `Captcha code` 

## Print screen / video

How to find the captcha key:
<img width="1422" height="439" alt="image" src="https://github.com/user-attachments/assets/02503ca8-294a-4468-a2db-0fe893c74eb3" />

Form:
<img width="1258" height="517" alt="image" src="https://github.com/user-attachments/assets/b28fe29a-e5c8-4924-a711-91af2a62dd9f" />

## Notes

- this PR requires [a IASO PR](https://github.com/BLSQ/iaso/pull/2995) to work

## Doc
/
