### PR TITLE
[SNT-452] add throttling on public account creation

### DIFF
--- a/api/account_setup/throttle.py
+++ b/api/account_setup/throttle.py
@@ -1,0 +1,5 @@
+from rest_framework.throttling import AnonRateThrottle
+
+
+class SNTAccountThrottle(AnonRateThrottle):
+    scope = "snt_public_account"

--- a/api/account_setup/views.py
+++ b/api/account_setup/views.py
@@ -8,6 +8,7 @@ from iaso.models import ImportGPKG, Profile, Task
 from iaso.tasks.import_gpkg_task import import_gpkg_task
 from plugins.snt_malaria.api.account_setup.permissions import SNTAccountSetupPermission
 from plugins.snt_malaria.api.account_setup.serializers import SNTAccountSetupSerializer
+from plugins.snt_malaria.api.account_setup.throttle import SNTAccountThrottle
 from plugins.snt_malaria.api.account_setup.utils import create_snt_account, transform_geo_json_to_gpkg
 from plugins.snt_malaria.models import SNTAccountSetup
 
@@ -16,6 +17,7 @@ class SNTAccountSetupViewSet(viewsets.ModelViewSet):
     serializer_class = SNTAccountSetupSerializer
     http_method_names = ["post", "head", "options"]
     permission_classes = [SNTAccountSetupPermission]
+    throttle_classes = [SNTAccountThrottle]
 
     def get_queryset(self):
         return SNTAccountSetup.objects.none()

--- a/plugin_settings.py
+++ b/plugin_settings.py
@@ -8,3 +8,6 @@ CONSTANTS = {
     "HIDE_BASIC_NAV_ITEMS": "yes",
     "ENABLE_PUBLIC_ACCOUNT_SETUP": os.environ.get("ENABLE_PUBLIC_ACCOUNT_SETUP", "false").lower() == "true",
 }
+DEFAULT_THROTTLE_RATES = {
+    "snt_public_account": os.environ.get("PUBLIC_ACCOUNT_THROTTLE_RATE", "5/hour"),
+}

--- a/tests/api/account_setup/test_views.py
+++ b/tests/api/account_setup/test_views.py
@@ -152,6 +152,28 @@ class SNTAccountSetupAPITestCase(TaskAPITestCase):
 
         self._check_nothing_has_been_created()
 
+    @override_settings(ENABLE_PUBLIC_ACCOUNT_SETUP=True)
+    def test_post_account_setup_throttling(self):
+        with open(self.JSON_FILE_PATH, "rb") as json_file:
+            payload = {
+                "username": "",
+                "password": "",
+                "password_confirmation": "",
+                "country": "BE",
+                "language": "fr",
+                "geo_json_file": SimpleUploadedFile(
+                    self.JSON_FILE_NAME, json_file.read(), content_type="application/json"
+                ),
+            }
+
+        # default value is 5 calls per hour per IP address
+        for _ in range(5):
+            response = self.client.post(self.BASE_URL, data=payload, format="multipart")
+            self.assertJSONResponse(response, status.HTTP_400_BAD_REQUEST)  # don't care about validation errors
+
+        response = self.client.post(self.BASE_URL, data=payload, format="multipart")
+        self.assertJSONResponse(response, status.HTTP_429_TOO_MANY_REQUESTS)
+
     def _check_nothing_has_been_created(self):
         # Making sure that all objects are created
         self.assertEqual(Account.objects.count(), 0)


### PR DESCRIPTION
## What problem is this PR solving?

add throttling on public account creation

### Related JIRA tickets

SNT-452

## Changes

- added throttling on public account creation

## How to test
- set the `PUBLIC_ACCOUNT_THROTTLE_RATE` env var to the value of your choice (default value = `5/hour`; see [documentation here](https://www.django-rest-framework.org/api-guide/throttling/#setting-the-throttling-policy) to know which format to use)
- spam the `api/snt_malaria/account_setup/` endpoint, after crossing the limit you should get 429 errors


## Print screen / video

/

## Notes

- this requires [a IASO PR](https://github.com/BLSQ/iaso/pull/2998) to work
- even if the DRF documentation says this is not a security feature, it should work more or less as intended as it is coupled with a captcha (see other PR)


## Doc

/
