### PR TITLE
SNT-326: Allow to edit openhexa metrics

### DIFF
--- a/js/src/domains/dataLayers/dataLayerForm/DataLayerDialog.tsx
+++ b/js/src/domains/dataLayers/dataLayerForm/DataLayerDialog.tsx
@@ -122,10 +122,15 @@ export const DataLayerDialog: FC<MetricTypeDialogProps> = ({
             }
             cancelMessage={MESSAGES.cancel}
             closeOnConfirm={false}
-            allowConfirm={formik.isValid && formik.dirty && !formik.isSubmitting}
+            allowConfirm={
+                formik.isValid && formik.dirty && !formik.isSubmitting
+            }
         >
             <ExtendedFormikProvider formik={formik}>
-                <MetricTypeForm metricType={metricTypeFormModel} />
+                <MetricTypeForm
+                    metricType={metricTypeFormModel}
+                    isRestricted={metricType?.origin === 'openhexa'}
+                />
             </ExtendedFormikProvider>
             {errorMessage && (
                 <Alert severity="error" variant="filled" sx={{ mt: 2 }}>

--- a/js/src/domains/dataLayers/dataLayerForm/DataLayerForm.tsx
+++ b/js/src/domains/dataLayers/dataLayerForm/DataLayerForm.tsx
@@ -14,10 +14,12 @@ import { LegendConfigForm } from './LegendConfigForm';
 
 type MetricTypeFormProps = {
     metricType?: MetricTypeFormModel;
+    isRestricted?: boolean;
 };
 
 export const MetricTypeForm: FC<MetricTypeFormProps> = ({
     metricType = undefined,
+    isRestricted = false,
 }) => {
     const { formatMessage } = useSafeIntl();
     const { data: legendTypeOptions, isLoading: loadingLegendTypeOptions } =
@@ -50,7 +52,7 @@ export const MetricTypeForm: FC<MetricTypeFormProps> = ({
                 label={MESSAGES.variable}
                 required
                 errors={getErrors('code')}
-                disabled={!!metricType?.id}
+                disabled={!!metricType?.id || isRestricted}
             />
             <InputComponent
                 keyValue="name"
@@ -100,6 +102,7 @@ export const MetricTypeForm: FC<MetricTypeFormProps> = ({
                         label={MESSAGES.legendType}
                         errors={getErrors('legend_type')}
                         loading={loadingLegendTypeOptions}
+                        disabled={isRestricted}
                     />
                 </Grid>
                 <Grid item xs={12} sm={6}>

--- a/js/src/domains/dataLayers/dataLayerList/DataLayerLine.tsx
+++ b/js/src/domains/dataLayers/dataLayerList/DataLayerLine.tsx
@@ -24,7 +24,6 @@ type Props = {
     onClick: () => void;
     onEdit: (metricType: MetricType) => void;
     onDelete: (metricType: number) => void;
-    readonly?: boolean;
 };
 
 const styles: SxStyles = {
@@ -41,9 +40,6 @@ const styles: SxStyles = {
                 visibility: 'visible',
             },
         },
-    },
-    metricTypeReadOnly: {
-        pr: '48px',
     },
     metricTypeSelected: {
         bgcolor: 'primary.light',
@@ -66,7 +62,6 @@ export const DataLayerLine: FC<Props> = ({
     onClick,
     onEdit,
     onDelete,
-    readonly = false,
 }) => {
     const anchorRef = React.useRef<HTMLLIElement>(null);
     const [showMoreActions, setShowMoreActions] = React.useState(false);
@@ -81,24 +76,21 @@ export const DataLayerLine: FC<Props> = ({
             sx={
                 {
                     ...styles.metricType,
-                    ...(readonly ? styles.metricTypeReadOnly : {}),
                     ...(selected ? styles.metricTypeSelected : {}),
                 } as SxProps
             }
             ref={anchorRef}
             secondaryAction={
-                readonly ? null : (
-                    <DisplayIfUserHasPerm
-                        permissions={[CorePermission.METRIC_TYPES]}
-                    >
-                        <IconButton
-                            aria-label="more-info"
-                            overrideIcon={MoreHorizIcon}
-                            tooltipMessage={MESSAGES.more}
-                            onClick={toggleMoreActions}
-                        ></IconButton>
-                    </DisplayIfUserHasPerm>
-                )
+                <DisplayIfUserHasPerm
+                    permissions={[CorePermission.METRIC_TYPES]}
+                >
+                    <IconButton
+                        aria-label="more-info"
+                        overrideIcon={MoreHorizIcon}
+                        tooltipMessage={MESSAGES.more}
+                        onClick={toggleMoreActions}
+                    ></IconButton>
+                </DisplayIfUserHasPerm>
             }
             onClick={onClick}
         >

--- a/js/src/domains/dataLayers/dataLayerList/DataLayerList.tsx
+++ b/js/src/domains/dataLayers/dataLayerList/DataLayerList.tsx
@@ -65,7 +65,6 @@ export const DataLayerList: FC<Props> = ({
                                 }
                                 onEdit={onEditMetricType}
                                 onDelete={() => deleteMetricType(metricType.id)}
-                                readonly={metricType.origin === 'openhexa'}
                                 selected={
                                     metricType.id === selectedMetricTypeId
                                 }


### PR DESCRIPTION
## What problem is this PR solving?

Allow to edit certain fields on open hexa layer

### Related JIRA tickets

SNT-326

## Changes

Allow to edit Open Hexa imported layer definition.
Only restricted fields are: 
- Variable
- Legend type

## How to test

Go to DataLayer page with Metrics imported from OpenHexa.
You should be able to edit it and to modify anything except variable, name and legend type.
Layer should still be marked as OpenHexa upon saving.

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
