### PR TITLE
Feature SNT-429: change PfPR reduction -> evolution

### DIFF
--- a/js/src/constants/translations/en.json
+++ b/js/src/constants/translations/en.json
@@ -166,7 +166,7 @@
     "iaso.snt_malaria.impactSettings.notIncluded": "Not included",
     "iaso.snt_malaria.impact.cases": "Cases",
     "iaso.snt_malaria.impact.severeCases": "Severe cases",
-    "iaso.snt_malaria.impact.pfprReduction": "PfPR reduction",
+    "iaso.snt_malaria.impact.pfprEvolution": "PfPR evolution",
     "iaso.snt_malaria.impact.totalCosts": "Total Cumulative Costs (USD)",
     "iaso.snt_malaria.impact.targetLabel": "{year} Target: {value}",
     "iaso.snt_malaria.impact.budgetLabel": "2030 Budget: {value}",

--- a/js/src/constants/translations/fr.json
+++ b/js/src/constants/translations/fr.json
@@ -165,7 +165,7 @@
     "iaso.snt_malaria.impactSettings.notIncluded": "Non inclus",
     "iaso.snt_malaria.impact.cases": "Cas",
     "iaso.snt_malaria.impact.severeCases": "Cas graves",
-    "iaso.snt_malaria.impact.pfprReduction": "Réduction PfPR",
+    "iaso.snt_malaria.impact.pfprEvolution": "Évolution PfPR",
     "iaso.snt_malaria.impact.totalCosts": "Coûts cumulatifs totaux (USD)",
     "iaso.snt_malaria.impact.targetLabel": "Objectif {year} : {value}",
     "iaso.snt_malaria.impact.budgetLabel": "Budget 2030 : {value}",

--- a/js/src/domains/compareCustomize/components/MetricsSummary.tsx
+++ b/js/src/domains/compareCustomize/components/MetricsSummary.tsx
@@ -1,8 +1,8 @@
 import React, { FC, useMemo } from 'react';
-import TrendingDownOutlinedIcon from '@mui/icons-material/TrendingDownOutlined';
 import MonetizationOnOutlinedIcon from '@mui/icons-material/MonetizationOnOutlined';
 import PersonOutlineOutlinedIcon from '@mui/icons-material/PersonOutlineOutlined';
 import SentimentVeryDissatisfiedOutlinedIcon from '@mui/icons-material/SentimentVeryDissatisfiedOutlined';
+import TimelineOutlinedIcon from '@mui/icons-material/TimelineOutlined';
 import { Grid, Typography } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
 import { SxStyles } from 'Iaso/types/general';
@@ -10,11 +10,12 @@ import { MESSAGES } from '../../messages';
 import {
     formatBigNumber,
     formatPercentValue,
+    formatSignedPercentValue,
 } from '../../planning/libs/cost-utils';
 import { useComparisonDataContext } from '../ComparisonDataContext';
 import {
     getCumulativeCosts,
-    getPfprReduction,
+    getPfprEvolution,
 } from '../utils/impactCalculations';
 import { MetricCard, buildMetricEntries } from './MetricCard';
 
@@ -46,34 +47,58 @@ export const MetricsSummary: FC = () => {
 
     const casesEntries = useMemo(
         () =>
-            buildMetricEntries(scenarios, impactsByScenarioId, d => d?.number_cases?.value ?? undefined, formatBigNumber, {
-                relative: true,
-                positiveIsGreen: false,
-            }),
+            buildMetricEntries(
+                scenarios,
+                impactsByScenarioId,
+                d => d?.number_cases?.value ?? undefined,
+                formatBigNumber,
+                {
+                    relative: true,
+                    positiveIsGreen: false,
+                },
+            ),
         [scenarios, impactsByScenarioId],
     );
     const severeCasesEntries = useMemo(
         () =>
-            buildMetricEntries(scenarios, impactsByScenarioId, d => d?.number_severe_cases?.value ?? undefined, formatBigNumber, {
-                relative: true,
-                positiveIsGreen: false,
-            }),
+            buildMetricEntries(
+                scenarios,
+                impactsByScenarioId,
+                d => d?.number_severe_cases?.value ?? undefined,
+                formatBigNumber,
+                {
+                    relative: true,
+                    positiveIsGreen: false,
+                },
+            ),
         [scenarios, impactsByScenarioId],
     );
     const pfprEntries = useMemo(
         () =>
-            buildMetricEntries(scenarios, impactsByScenarioId, getPfprReduction, formatPercentValue, {
-                relative: false,
-                positiveIsGreen: true,
-            }),
+            buildMetricEntries(
+                scenarios,
+                impactsByScenarioId,
+                getPfprEvolution,
+                formatSignedPercentValue,
+                {
+                    relative: false,
+                    positiveIsGreen: false,
+                },
+            ),
         [scenarios, impactsByScenarioId],
     );
     const costsEntries = useMemo(
         () =>
-            buildMetricEntries(scenarios, budgetsByScenarioId, getCumulativeCosts, formatBigNumber, {
-                relative: true,
-                positiveIsGreen: false,
-            }),
+            buildMetricEntries(
+                scenarios,
+                budgetsByScenarioId,
+                getCumulativeCosts,
+                formatBigNumber,
+                {
+                    relative: true,
+                    positiveIsGreen: false,
+                },
+            ),
         [scenarios, budgetsByScenarioId],
     );
 
@@ -87,8 +112,7 @@ export const MetricsSummary: FC = () => {
             <Typography variant="caption" sx={styles.subtext}>
                 {formatMessage(MESSAGES.impactTargetLabel, {
                     year: targetYear,
-                    value:
-                        metricValue != null ? formatter(metricValue) : '-',
+                    value: metricValue != null ? formatter(metricValue) : '-',
                 })}
             </Typography>
         );
@@ -116,12 +140,15 @@ export const MetricsSummary: FC = () => {
                 )}
             />
             <MetricCard
-                title={formatMessage(MESSAGES.impactPfprReduction)}
-                icon={TrendingDownOutlinedIcon}
+                title={formatMessage(MESSAGES.impactPfprEvolution)}
+                icon={TimelineOutlinedIcon}
                 isLoading={isImpactLoading}
                 entries={pfprEntries}
                 keyPrefix="pfpr"
-                subtext={targetYearSubtext('prevalence_rate', formatPercentValue)}
+                subtext={targetYearSubtext(
+                    'prevalence_rate',
+                    formatPercentValue,
+                )}
             />
             <MetricCard
                 title={formatMessage(MESSAGES.impactTotalCosts)}

--- a/js/src/domains/compareCustomize/utils/impactCalculations.ts
+++ b/js/src/domains/compareCustomize/utils/impactCalculations.ts
@@ -58,19 +58,17 @@ export const getCumulativeCosts = (
 };
 
 /**
- * Computes the relative PfPR reduction between the first and last year
- * in the impact response: `(start - end) / start`.
- * Returns `undefined` when fewer than two years of data are available
- * or the starting prevalence is zero.
+ * Relative PfPR evolution between the first and last year in the impact
+ * response: `(end - start) / start`. Negative when prevalence decreases,
+ * positive when it increases. Returns `undefined` when fewer than two years
+ * of data are available or the starting prevalence is zero.
  */
-export const getPfprReduction = (
+export const getPfprEvolution = (
     impact?: ScenarioImpactMetrics,
 ): number | undefined => {
     const byYear = impact?.by_year;
     if (!byYear || byYear.length < 2) return undefined;
-    const years = [...new Set(byYear.map(yr => yr.year))].sort(
-        (a, b) => a - b,
-    );
+    const years = [...new Set(byYear.map(yr => yr.year))].sort((a, b) => a - b);
     const minYear = years[0];
     const maxYear = years[years.length - 1];
     if (minYear === maxYear) return undefined;
@@ -79,5 +77,5 @@ export const getPfprReduction = (
     const start = startData?.prevalence_rate?.value;
     const end = endData?.prevalence_rate?.value;
     if (start == null || end == null || start <= 0) return undefined;
-    return (start - end) / start;
+    return (end - start) / start;
 };

--- a/js/src/domains/messages.ts
+++ b/js/src/domains/messages.ts
@@ -423,9 +423,9 @@ export const MESSAGES = defineMessages({
         id: 'iaso.snt_malaria.compareCustomize.impactDifferencesTitle',
         defaultMessage: 'Impact differences',
     },
-    impactPfprReduction: {
-        id: 'iaso.snt_malaria.impact.pfprReduction',
-        defaultMessage: 'PfPR reduction',
+    impactPfprEvolution: {
+        id: 'iaso.snt_malaria.impact.pfprEvolution',
+        defaultMessage: 'PfPR evolution',
     },
     impactRefLabel: {
         id: 'iaso.snt_malaria.label.impactRef',

--- a/js/src/domains/planning/libs/cost-utils.tsx
+++ b/js/src/domains/planning/libs/cost-utils.tsx
@@ -39,6 +39,11 @@ export const formatPercentValue = (value: number) => {
     return `${(value * 100).toFixed(0)}%`;
 };
 
+export const formatSignedPercentValue = (value: number) => {
+    const pct = Math.round(value * 100);
+    return `${pct > 0 ? '+' : ''}${pct}%`;
+};
+
 export const formatBigNumber = (value: number) => {
     const abs = Math.abs(value);
     const sign = value < 0 ? '-' : '';


### PR DESCRIPTION
## What problem is this PR solving?

Change PfPR reduction widget with confusing double negation to evolution

### Related JIRA tickets

SNT-429

## Changes

Now the sign of the numbers follows the intuition: Negative number --> reduction, positive number --> increase, hence "evolution"

<img width="1160" height="671" alt="image" src="https://github.com/user-attachments/assets/a64af084-b3db-4ef4-a226-13fbd1e626f6" />
