### PR TITLE
SNT-485 handle fix costs

### DIFF
--- a/api/intervention_cost_breakdown_line/serializers.py
+++ b/api/intervention_cost_breakdown_line/serializers.py
@@ -46,6 +46,7 @@ class InterventionCostBreakdownLineWriteListSerializer(serializers.ListSerialize
                         "intervention",
                         "updated_by",
                         "population_layer",
+                        "cost_driver",
                     ],
                 )
             if lines_to_delete:
@@ -84,6 +85,7 @@ class InterventionCostBreakdownLineSerializer(serializers.ModelSerializer):
             "category_label",
             "intervention",
             "population_layer",
+            "cost_driver",
         ]
 
     def get_unit_type_label(self, obj):
@@ -137,10 +139,12 @@ class InterventionCostBreakdownLineWriteSerializer(serializers.ModelSerializer):
         return fields
 
     def validate(self, attrs):
+        print(f"COUCOU MTF {attrs.get('population_layer')}")
         attrs = super().validate(attrs)
         attrs["cost_driver"] = (
             InterventionCostBreakdownLine.CostDriver.POPULATION
             if attrs.get("population_layer")
             else InterventionCostBreakdownLine.CostDriver.FIXED_COST
         )
+        print(attrs["cost_driver"])
         return attrs

--- a/api/intervention_cost_breakdown_line/serializers.py
+++ b/api/intervention_cost_breakdown_line/serializers.py
@@ -139,12 +139,10 @@ class InterventionCostBreakdownLineWriteSerializer(serializers.ModelSerializer):
         return fields
 
     def validate(self, attrs):
-        print(f"COUCOU MTF {attrs.get('population_layer')}")
         attrs = super().validate(attrs)
         attrs["cost_driver"] = (
             InterventionCostBreakdownLine.CostDriver.POPULATION
             if attrs.get("population_layer")
             else InterventionCostBreakdownLine.CostDriver.FIXED_COST
         )
-        print(attrs["cost_driver"])
         return attrs

--- a/api/scenario_yearly_cost_assignment/serializers.py
+++ b/api/scenario_yearly_cost_assignment/serializers.py
@@ -1,8 +1,8 @@
-from django.db import transaction
+import math
+
 from rest_framework import serializers
 
 from plugins.snt_malaria.models import InterventionCostBreakdownLine, Scenario, ScenarioYearlyCostAssignment
-from plugins.snt_malaria.models.intervention import Intervention
 
 
 class ScenarioYearlyCostAssignmentSerializer(serializers.ModelSerializer):
@@ -25,6 +25,16 @@ class ScenarioYearlyCostAssignmentSerializer(serializers.ModelSerializer):
             ).filter(intervention__intervention_category__account=account)
         return fields
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        value = float(instance.value)
+        if instance.cost_line.cost_driver == InterventionCostBreakdownLine.CostDriver.POPULATION:
+            value *= 100
+
+        data["value"] = f"{math.floor(value)}"
+
+        return data
+
 
 class ScenarioYearlyCostAssignmentQuerySerializer(serializers.Serializer):
     scenario = serializers.PrimaryKeyRelatedField(queryset=Scenario.objects.none())
@@ -40,13 +50,8 @@ class ScenarioYearlyCostAssignmentQuerySerializer(serializers.Serializer):
 
 
 class ScenarioYearlyCostAssignmentUpsertSerializer(serializers.Serializer):
-    intervention = serializers.PrimaryKeyRelatedField(
-        queryset=InterventionCostBreakdownLine.objects.none(), required=True
-    )
     scenario = serializers.PrimaryKeyRelatedField(queryset=Scenario.objects.none(), required=True)
-    cost_line = serializers.PrimaryKeyRelatedField(
-        queryset=InterventionCostBreakdownLine.objects.none(), required=False
-    )
+    cost_line = serializers.PrimaryKeyRelatedField(queryset=InterventionCostBreakdownLine.objects.none(), required=True)
     year = serializers.IntegerField(max_value=2100, min_value=2000, required=True)
     value = serializers.DecimalField(max_digits=19, decimal_places=2, required=True)
 
@@ -56,59 +61,34 @@ class ScenarioYearlyCostAssignmentUpsertSerializer(serializers.Serializer):
         if request:
             account = request.user.iaso_profile.account
 
-            fields["intervention"].queryset = Intervention.objects.select_related("intervention_category").filter(
-                intervention_category__account=account
-            )
             fields["scenario"].queryset = Scenario.objects.select_related("account").filter(account=account)
             fields["cost_line"].queryset = InterventionCostBreakdownLine.objects.select_related(
                 "intervention__intervention_category"
             ).filter(intervention__intervention_category__account=account)
         return fields
 
-    def validate_intervention(self, value):
-        if not value.cost_breakdown_lines.exists():
-            raise serializers.ValidationError(f"Intervention {value.id} does not have any cost breakdown line.")
-        return value
-
-    def validate_cost_line(self, value):
-        if value and value.cost_driver == InterventionCostBreakdownLine.CostDriver.POPULATION:
-            raise serializers.ValidationError(
-                "Cost line should not be a population cost line, population cost lines are automatically assigned when no cost line is provided."
-            )
-
-        if value and value.intervention_id != self.initial_data.get("intervention"):
-            raise serializers.ValidationError("Cost line does not belong to the specified intervention.")
-        return value
-
     def validate_scenario(self, value):
         if value.is_locked:
             raise serializers.ValidationError("Cannot assign yearly cost to a locked scenario.")
         return value
 
-    # Save info, if cost_line is provided, update or create the assignment for this cost line
-    # if not provided update or create the assignment for all population cost lines of the intervention
-    @transaction.atomic
     def save(self, **kwargs):
-        intervention = self.validated_data["intervention"]
-        year = self.validated_data["year"]
-        value = self.validated_data["value"]
+        year = self.validated_data.get("year", self.instance.year if self.instance else None)
+        cost_line = self.validated_data.get("cost_line", self.instance.cost_line if self.instance else None)
+        scenario = self.validated_data.get("scenario", self.instance.scenario if self.instance else None)
 
-        if not self.validated_data.get("cost_line"):
-            cost_lines = intervention.cost_breakdown_lines.filter(
-                cost_driver=InterventionCostBreakdownLine.CostDriver.POPULATION
+        defaults = {}
+        if "value" in self.validated_data:
+            value = self.validated_data["value"]
+            defaults["value"] = (
+                value / 100 if cost_line.cost_driver == InterventionCostBreakdownLine.CostDriver.POPULATION else value
             )
-        else:
-            cost_lines = [self.validated_data["cost_line"]]
 
-        scenario = self.validated_data["scenario"]
-        assignments = []
-        for cost_line in cost_lines:
-            assignment, _ = ScenarioYearlyCostAssignment.objects.update_or_create(
-                scenario=scenario,
-                cost_line=cost_line,
-                year=year,
-                defaults={"value": value},
-            )
-            assignments.append(assignment)
+        assignment, _ = ScenarioYearlyCostAssignment.objects.update_or_create(
+            scenario=scenario,
+            cost_line=cost_line,
+            year=year,
+            defaults=defaults,
+        )
 
-        return assignments
+        return assignment

--- a/api/scenario_yearly_cost_assignment/serializers.py
+++ b/api/scenario_yearly_cost_assignment/serializers.py
@@ -1,5 +1,3 @@
-import math
-
 from rest_framework import serializers
 
 from plugins.snt_malaria.models import InterventionCostBreakdownLine, Scenario, ScenarioYearlyCostAssignment
@@ -31,7 +29,7 @@ class ScenarioYearlyCostAssignmentSerializer(serializers.ModelSerializer):
         if instance.cost_line.cost_driver == InterventionCostBreakdownLine.CostDriver.POPULATION:
             value *= 100
 
-        data["value"] = f"{math.floor(value)}"
+        data["value"] = f"{round(value)}"
 
         return data
 
@@ -84,11 +82,11 @@ class ScenarioYearlyCostAssignmentUpsertSerializer(serializers.Serializer):
                 value / 100 if cost_line.cost_driver == InterventionCostBreakdownLine.CostDriver.POPULATION else value
             )
 
-        assignment, _ = ScenarioYearlyCostAssignment.objects.update_or_create(
+        self.instance, _ = ScenarioYearlyCostAssignment.objects.update_or_create(
             scenario=scenario,
             cost_line=cost_line,
             year=year,
             defaults=defaults,
         )
 
-        return assignment
+        return self.instance

--- a/api/scenario_yearly_cost_assignment/views.py
+++ b/api/scenario_yearly_cost_assignment/views.py
@@ -40,28 +40,33 @@ class ScenarioYearlyCostAssignmentViewSet(viewsets.ModelViewSet):
     def _recalculate_budget(self, scenario):
         BudgetCalculationService(scenario).calculate_and_save_all_years(self.request.user)
 
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        response_serializer = ScenarioYearlyCostAssignmentSerializer(serializer.instance, context=self.get_serializer_context())
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+    def perform_create(self, serializer):
+        response = super().perform_create(serializer)
+        # After creating/updating the ScenarioYearlyCostAssignment, we need to recalculate the budget for the related scenario to reflect the changes in the assigned costs
+        scenario = serializer.validated_data["scenario"]
+        self._recalculate_budget(scenario)
+
+        return response
+
+    def update(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=kwargs.pop("partial", False))
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+        response_serializer = ScenarioYearlyCostAssignmentSerializer(serializer.instance, context=self.get_serializer_context())
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
+
     def perform_update(self, serializer):
         response = super().perform_update(serializer)
         # After creating/updating the ScenarioYearlyCostAssignment, we need to recalculate the budget for the related scenario to reflect the changes in the assigned costs
         scenario = serializer.instance.scenario
-        budget_service = BudgetCalculationService(scenario)
-        budget_service.calculate_and_save_all_years(self.request.user)
+        self._recalculate_budget(scenario)
 
         return response
-
-    def post(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        result = serializer.save()
-        self._recalculate_budget(serializer.validated_data["scenario"])
-        response_serializer = ScenarioYearlyCostAssignmentSerializer(result, context=self.get_serializer_context())
-        return Response(response_serializer.data, status=status.HTTP_200_OK)
-
-    def partial_update(self, request, *args, **kwargs):
-        instance = self.get_object()
-        serializer = self.get_serializer(instance, data=request.data, partial=True)
-        serializer.is_valid(raise_exception=True)
-        result = serializer.save()
-        self._recalculate_budget(serializer.validated_data.get("scenario", instance.scenario))
-        response_serializer = ScenarioYearlyCostAssignmentSerializer(result, context=self.get_serializer_context())
-        return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/api/scenario_yearly_cost_assignment/views.py
+++ b/api/scenario_yearly_cost_assignment/views.py
@@ -44,7 +44,9 @@ class ScenarioYearlyCostAssignmentViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
-        response_serializer = ScenarioYearlyCostAssignmentSerializer(serializer.instance, context=self.get_serializer_context())
+        response_serializer = ScenarioYearlyCostAssignmentSerializer(
+            serializer.instance, context=self.get_serializer_context()
+        )
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
     def perform_create(self, serializer):
@@ -60,7 +62,9 @@ class ScenarioYearlyCostAssignmentViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(instance, data=request.data, partial=kwargs.pop("partial", False))
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
-        response_serializer = ScenarioYearlyCostAssignmentSerializer(serializer.instance, context=self.get_serializer_context())
+        response_serializer = ScenarioYearlyCostAssignmentSerializer(
+            serializer.instance, context=self.get_serializer_context()
+        )
         return Response(response_serializer.data, status=status.HTTP_200_OK)
 
     def perform_update(self, serializer):

--- a/api/scenario_yearly_cost_assignment/views.py
+++ b/api/scenario_yearly_cost_assignment/views.py
@@ -40,8 +40,6 @@ class ScenarioYearlyCostAssignmentViewSet(viewsets.ModelViewSet):
     def _recalculate_budget(self, scenario):
         BudgetCalculationService(scenario).calculate_and_save_all_years(self.request.user)
 
-        return response
-
     def perform_update(self, serializer):
         response = super().perform_update(serializer)
         # After creating/updating the ScenarioYearlyCostAssignment, we need to recalculate the budget for the related scenario to reflect the changes in the assigned costs

--- a/api/scenario_yearly_cost_assignment/views.py
+++ b/api/scenario_yearly_cost_assignment/views.py
@@ -18,7 +18,7 @@ class ScenarioYearlyCostAssignmentViewSet(viewsets.ModelViewSet):
     def get_serializer_class(self):
         if self.action == "list":
             return ScenarioYearlyCostAssignmentQuerySerializer
-        if self.action == "patch":
+        if self.action in ["create", "partial_update"]:
             return ScenarioYearlyCostAssignmentUpsertSerializer
         return ScenarioYearlyCostAssignmentSerializer
 
@@ -37,12 +37,8 @@ class ScenarioYearlyCostAssignmentViewSet(viewsets.ModelViewSet):
 
         return Response(list_serializer.data, status=status.HTTP_200_OK)
 
-    def perform_create(self, serializer):
-        response = super().perform_create(serializer)
-        # After creating/updating the ScenarioYearlyCostAssignment, we need to recalculate the budget for the related scenario to reflect the changes in the assigned costs
-        scenario = serializer.validated_data["scenario"]
-        budget_service = BudgetCalculationService(scenario)
-        budget_service.calculate_and_save_all_years(self.request.user)
+    def _recalculate_budget(self, scenario):
+        BudgetCalculationService(scenario).calculate_and_save_all_years(self.request.user)
 
         return response
 
@@ -59,5 +55,15 @@ class ScenarioYearlyCostAssignmentViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         result = serializer.save()
-        response_serializer = ScenarioYearlyCostAssignmentSerializer(result, many=True)
+        self._recalculate_budget(serializer.validated_data["scenario"])
+        response_serializer = ScenarioYearlyCostAssignmentSerializer(result, context=self.get_serializer_context())
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+    def partial_update(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        result = serializer.save()
+        self._recalculate_budget(serializer.validated_data.get("scenario", instance.scenario))
+        response_serializer = ScenarioYearlyCostAssignmentSerializer(result, context=self.get_serializer_context())
         return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/js/src/domains/interventions/types/interventionCostBreakdownLine.ts
+++ b/js/src/domains/interventions/types/interventionCostBreakdownLine.ts
@@ -8,4 +8,5 @@ export type InterventionCostBreakdownLine = {
     id: number;
     intervention: number;
     population_layer: number | null;
+    cost_driver: 'population' | 'fixed_cost';
 };

--- a/js/src/domains/planning/components/budgeting/BudgetRow.tsx
+++ b/js/src/domains/planning/components/budgeting/BudgetRow.tsx
@@ -109,10 +109,7 @@ export const BudgetRow: FC<Props> = ({
                         key={`cost_line_${line.id}`}
                         yearRange={yearRange}
                         isEditable={isEditable}
-                        costLineId={line.id}
-                        coverageByYear={line.coverageByYear}
-                        totalCost={line.totalCost}
-                        label={line.label}
+                        costLine={line}
                     />
                 ))}
         </>

--- a/js/src/domains/planning/components/budgeting/BudgetTable.tsx
+++ b/js/src/domains/planning/components/budgeting/BudgetTable.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import {
     Paper,
     Table,
@@ -15,7 +15,11 @@ import { InterventionCostBreakdownLine } from '../../../interventions/types';
 import { MESSAGES } from '../../../messages';
 import { usePlanningContext } from '../../contexts/PlanningContext';
 import { getColorRange } from '../../libs/color-utils';
-import { BudgetIntervention } from '../../types/budget';
+import {
+    BudgetIntervention,
+    BudgetInterventionCostLine,
+} from '../../types/budget';
+import { InterventionPlan } from '../../types/interventionAssignments';
 import { BudgetRow, BudgetRowData } from './BudgetRow';
 import { BudgetTotalRow } from './BudgetTotalRow';
 import { CostLineRowData, CostLineYearlyCoverage } from './CostLineRow';
@@ -71,7 +75,6 @@ export const BudgetTable: FC = ({}) => {
                 {};
             const defaultRowsByIntervention: Record<number, CostLineRowData[]> =
                 {};
-
             if (costLines) {
                 costLines.forEach(line => {
                     lineRecord[line.id] = line;
@@ -82,6 +85,7 @@ export const BudgetTable: FC = ({}) => {
                         id: line.id,
                         label: line.name,
                         subLabel: '',
+                        costDriver: line.cost_driver,
                         totalCost: 0,
                         coverageByYear: (yearlyCoverageByCostLine[line.id] ||
                             {}) as Record<number, CostLineYearlyCoverage>,
@@ -127,6 +131,44 @@ export const BudgetTable: FC = ({}) => {
         [budgets],
     );
 
+    const populateInterventionCost = useCallback(
+        (plan: InterventionPlan) => {
+            const orgUnitCount = plan.org_units.length || 0;
+            const preListedCostBreakdowns = (
+                defaultCostRowDataByIntervention[plan.intervention.id] || []
+            ).map(costLine => ({
+                ...costLine,
+                totalCost: 0,
+            }));
+
+            return {
+                interventionId: plan.intervention.id,
+                interventionLabel: plan.intervention.short_name,
+                orgUnitCount,
+                yearCosts: {} as Record<number, number>,
+                totalCost: 0,
+                costBreakdowns: preListedCostBreakdowns,
+            };
+        },
+        [defaultCostRowDataByIntervention],
+    );
+
+    const populateCostLine = useCallback(
+        (costLine: BudgetInterventionCostLine) => {
+            const breakdownLine = costBreakdownLineRecord[costLine.id];
+            return {
+                id: costLine.id,
+                label: breakdownLine ? breakdownLine.name : '',
+                subLabel: '',
+                costDriver: breakdownLine?.cost_driver ?? 'population',
+                totalCost: costLine.total_cost,
+                coverageByYear: (yearlyCoverageByCostLine[costLine.id] ||
+                    {}) as Record<number, CostLineYearlyCoverage>,
+            };
+        },
+        [costBreakdownLineRecord, yearlyCoverageByCostLine],
+    );
+
     useEffect(() => {
         const rows = [] as BudgetRowData[];
         const costs = {
@@ -135,25 +177,9 @@ export const BudgetTable: FC = ({}) => {
             interventionTotals: [] as { label: string; totalCost: number }[],
         };
         interventionPlans.forEach(plan => {
-            const orgUnitCount = plan.org_units.length || 0;
             const yearlyInterventions =
                 interventionCosts[plan.intervention.id] || [];
-
-            const preListedCostBreakdowns = (
-                defaultCostRowDataByIntervention[plan.intervention.id] || []
-            ).map(costLine => ({
-                ...costLine,
-                totalCost: 0,
-            }));
-
-            const row = {
-                interventionId: plan.intervention.id,
-                interventionLabel: plan.intervention.short_name,
-                orgUnitCount,
-                yearCosts: {} as Record<number, number>,
-                totalCost: 0,
-                costBreakdowns: preListedCostBreakdowns,
-            };
+            const row = populateInterventionCost(plan);
 
             yearlyInterventions.forEach(intervention => {
                 row.yearCosts[intervention.year] = intervention.total_cost;
@@ -170,17 +196,8 @@ export const BudgetTable: FC = ({}) => {
                     if (existingCostLine) {
                         existingCostLine.totalCost += costLine.total_cost;
                     } else {
-                        const breakdownLine =
-                            costBreakdownLineRecord[costLine.id];
-                        row.costBreakdowns.push({
-                            id: costLine.id,
-                            label: breakdownLine ? breakdownLine.name : '',
-                            subLabel: '',
-                            totalCost: costLine.total_cost,
-                            coverageByYear: (yearlyCoverageByCostLine[
-                                costLine.id
-                            ] || {}) as Record<number, CostLineYearlyCoverage>,
-                        });
+                        const costBreakdown = populateCostLine(costLine);
+                        row.costBreakdowns.push(costBreakdown);
                     }
                 });
             });
@@ -200,8 +217,8 @@ export const BudgetTable: FC = ({}) => {
         interventionCosts,
         setBudgetRows,
         defaultCostRowDataByIntervention,
-        costBreakdownLineRecord,
-        yearlyCoverageByCostLine,
+        populateCostLine,
+        populateInterventionCost,
     ]);
 
     const colors = useMemo(() => {

--- a/js/src/domains/planning/components/budgeting/CostLineRow.tsx
+++ b/js/src/domains/planning/components/budgeting/CostLineRow.tsx
@@ -14,17 +14,15 @@ export type CostLineRowData = {
     id: number;
     label: string;
     subLabel: string;
+    costDriver: 'population' | 'fixed_cost';
     totalCost: number;
     coverageByYear: Record<number, CostLineYearlyCoverage>;
 };
 
 type Props = {
+    costLine: CostLineRowData;
     yearRange: number[];
-    costLineId: number;
     isEditable: boolean;
-    coverageByYear: Record<number, CostLineYearlyCoverage>;
-    totalCost: number;
-    label: string;
 };
 
 const styles = {
@@ -39,28 +37,23 @@ const clampPercentage = (value: number) => {
     return Math.min(100, Math.max(0, value));
 };
 
-export const CostLineRow: FC<Props> = ({
-    yearRange,
-    costLineId,
-    isEditable,
-    coverageByYear,
-    totalCost,
-    label,
-}) => {
+export const CostLineRow: FC<Props> = ({ costLine, yearRange, isEditable }) => {
     const { saveYearlyCoverage } = usePlanningContext();
     const [coverageInputsByYear, setCoverageInputsByYear] = React.useState<
         Record<number, string>
     >({});
 
+    const defaultCoverage = costLine.costDriver === 'fixed_cost' ? 0 : 100;
+
     React.useEffect(() => {
         const nextCoverageInputsByYear: Record<number, string> = {};
         yearRange.forEach(year => {
             nextCoverageInputsByYear[year] = String(
-                coverageByYear[year]?.value ?? 100,
+                costLine.coverageByYear[year]?.value ?? defaultCoverage,
             );
         });
         setCoverageInputsByYear(nextCoverageInputsByYear);
-    }, [coverageByYear, yearRange]);
+    }, [costLine.coverageByYear, yearRange, defaultCoverage]);
 
     const handleCoverageChange = React.useCallback(
         (year: number, nextValue: string) => {
@@ -79,23 +72,28 @@ export const CostLineRow: FC<Props> = ({
             }
 
             saveYearlyCoverage({
-                assignmentId: coverageByYear[year]?.id,
-                costLineId,
+                assignmentId: costLine.coverageByYear[year]?.id,
+                costLineId: costLine.id,
                 year,
                 value: parsedValue,
             });
         },
-        [costLineId, coverageByYear, saveYearlyCoverage],
+        [costLine, saveYearlyCoverage],
     );
 
     const normalizeCoverageValue = React.useCallback(
         (year: number) => {
+            if (costLine.costDriver === 'fixed_cost') return;
+
             setCoverageInputsByYear(current => {
                 const rawValue = current[year] ?? '';
                 if (rawValue.trim() === '') {
                     return {
                         ...current,
-                        [year]: String(coverageByYear[year]?.value ?? 100),
+                        [year]: String(
+                            costLine.coverageByYear[year]?.value ??
+                                defaultCoverage,
+                        ),
                     };
                 }
 
@@ -103,7 +101,10 @@ export const CostLineRow: FC<Props> = ({
                 if (!Number.isFinite(parsedValue)) {
                     return {
                         ...current,
-                        [year]: String(coverageByYear[year]?.value ?? 100),
+                        [year]: String(
+                            costLine.coverageByYear[year]?.value ??
+                                defaultCoverage,
+                        ),
                     };
                 }
 
@@ -113,31 +114,35 @@ export const CostLineRow: FC<Props> = ({
                 };
             });
         },
-        [coverageByYear],
+        [costLine, defaultCoverage],
     );
 
     return (
         <TableRow sx={styles.costLineRow}>
             <TableCell align="left" colSpan={2} sx={styles.buffer}>
                 <Typography variant="body2" component="span">
-                    {label}
+                    {costLine.label}
                 </Typography>
             </TableCell>
             {yearRange.map(year => (
-                <TableCell key={`cost_line_${label}_${year}`} align="center">
+                <TableCell
+                    key={`cost_line_${costLine.label}_${year}`}
+                    align="center"
+                >
                     <YearlyCoverageInput
-                        value={coverageInputsByYear[year] ?? '100'}
+                        value={coverageInputsByYear[year]}
                         onChange={nextValue =>
                             handleCoverageChange(year, nextValue)
                         }
                         onBlur={() => normalizeCoverageValue(year)}
                         disabled={!isEditable}
+                        percentage={costLine.costDriver !== 'fixed_cost'}
                     />
                 </TableCell>
             ))}
             <TableCell align="center">
                 <Typography variant="body2" component="span">
-                    {formatBigNumber(totalCost)}
+                    {formatBigNumber(costLine.totalCost)}
                 </Typography>
             </TableCell>
             <TableCell></TableCell>

--- a/js/src/domains/planning/components/budgeting/YearlyCoverageInput.tsx
+++ b/js/src/domains/planning/components/budgeting/YearlyCoverageInput.tsx
@@ -27,7 +27,7 @@ export const YearlyCoverageInput: FC<Props> = ({
             min: 0,
             ...(percentage ? { max: 100 } : {}),
             step: 1,
-            inputMode: percentage ? 'decimal' : 'numeric',
+            inputMode: 'numeric',
             style: { paddingRight: percentage ? '0' : '1rem' },
         }}
         InputProps={

--- a/js/src/domains/planning/components/budgeting/YearlyCoverageInput.tsx
+++ b/js/src/domains/planning/components/budgeting/YearlyCoverageInput.tsx
@@ -23,6 +23,7 @@ export const YearlyCoverageInput: FC<Props> = ({
         disabled={disabled}
         type="number"
         size="small"
+        onFocus={e => e.target.select()}
         inputProps={{
             min: 0,
             ...(percentage ? { max: 100 } : {}),

--- a/js/src/domains/planning/components/budgeting/YearlyCoverageInput.tsx
+++ b/js/src/domains/planning/components/budgeting/YearlyCoverageInput.tsx
@@ -2,10 +2,11 @@ import React, { FC } from 'react';
 import { InputAdornment, TextField } from '@mui/material';
 
 type Props = {
-    value: string;
+    value?: string;
     onChange: (value: string) => void;
     onBlur?: () => void;
     disabled?: boolean;
+    percentage?: boolean;
 };
 
 export const YearlyCoverageInput: FC<Props> = ({
@@ -13,28 +14,31 @@ export const YearlyCoverageInput: FC<Props> = ({
     onChange,
     onBlur,
     disabled = false,
-}) => {
-    return (
-        <TextField
-            value={value}
-            onChange={event => {
-                onChange(event.target.value);
-            }}
-            onBlur={onBlur}
-            disabled={disabled}
-            type="number"
-            size="small"
-            inputProps={{
-                min: 0,
-                max: 100,
-                step: 1,
-                inputMode: 'decimal',
-                style: { paddingRight: '0' },
-            }}
-            InputProps={{
-                endAdornment: <InputAdornment position="end">%</InputAdornment>,
-            }}
-            sx={{ width: 95 }}
-        />
-    );
-};
+    percentage = false,
+}) => (
+    <TextField
+        value={value ?? (percentage ? '100' : '0')}
+        onChange={event => onChange(event.target.value)}
+        onBlur={onBlur}
+        disabled={disabled}
+        type="number"
+        size="small"
+        inputProps={{
+            min: 0,
+            ...(percentage ? { max: 100 } : {}),
+            step: 1,
+            inputMode: percentage ? 'decimal' : 'numeric',
+            style: { paddingRight: percentage ? '0' : '1rem' },
+        }}
+        InputProps={
+            percentage
+                ? {
+                      endAdornment: (
+                          <InputAdornment position="end">%</InputAdornment>
+                      ),
+                  }
+                : undefined
+        }
+        sx={{ width: 95 }}
+    />
+);

--- a/js/src/domains/planning/contexts/PlanningContext.tsx
+++ b/js/src/domains/planning/contexts/PlanningContext.tsx
@@ -145,12 +145,6 @@ export const PlanningProvider = ({
             value,
         }: SaveYearlyCoverageParams) => {
             const debounceKey = toCoverageKey(costLineId, year);
-            const parsedValue = Number(value);
-            if (!Number.isFinite(parsedValue)) {
-                return;
-            }
-
-            const clampedValue = Math.min(100, Math.max(0, parsedValue));
 
             timeoutServiceRef.current.debounce(
                 debounceKey,
@@ -160,7 +154,7 @@ export const PlanningProvider = ({
                         scenario: scenarioId,
                         costLine: costLineId,
                         year,
-                        value: clampedValue,
+                        value,
                     });
                 },
                 DEBOUNCE_MS,

--- a/js/src/domains/planning/hooks/useGetScenarioYearlyCostAssignments.tsx
+++ b/js/src/domains/planning/hooks/useGetScenarioYearlyCostAssignments.tsx
@@ -3,13 +3,6 @@ import { getRequest } from 'Iaso/libs/Api';
 import { useSnackQuery } from 'Iaso/libs/apiHooks';
 import { ScenarioYearlyCostAssignment } from '../types/interventionAssignments';
 
-const transformScenarioYearlyCostAssignment = (
-    assignment: ScenarioYearlyCostAssignment,
-) => ({
-    ...assignment,
-    value: Number(assignment.value) * 100,
-});
-
 export const useGetScenarioYearlyCostAssignments = (
     scenarioId: number,
 ): UseQueryResult<ScenarioYearlyCostAssignment[], Error> => {
@@ -25,8 +18,6 @@ export const useGetScenarioYearlyCostAssignments = (
         options: {
             cacheTime: Infinity,
             enabled: Boolean(scenarioId),
-            select: (data: ScenarioYearlyCostAssignment[]) =>
-                data.map(transformScenarioYearlyCostAssignment),
         },
     });
 };

--- a/js/src/domains/planning/hooks/useSaveScenarioYearlyCostAssignment.tsx
+++ b/js/src/domains/planning/hooks/useSaveScenarioYearlyCostAssignment.tsx
@@ -5,20 +5,16 @@ import { useSnackMutation } from 'Iaso/libs/apiHooks';
 type ScenarioYearlyCostAssignmentPayload = {
     id?: number;
     scenario: number;
-    intervention?: number;
     year: number;
     value: number;
-    costLine?: number;
+    costLine: number;
 };
-
-const transformPercentageValue = (value: number) => (value ?? 0) / 100;
 
 export const useSaveScenarioYearlyCostAssignment = (): UseMutationResult =>
     useSnackMutation({
         mutationFn: ({
             id,
             scenario,
-            intervention,
             year,
             value,
             costLine,
@@ -28,17 +24,16 @@ export const useSaveScenarioYearlyCostAssignment = (): UseMutationResult =>
                       `/api/snt_malaria/scenario_yearly_cost_assignments/${id}/`,
                       {
                           scenario,
-                          value: transformPercentageValue(value),
+                          value,
                       },
                   )
                 : postRequest(
                       '/api/snt_malaria/scenario_yearly_cost_assignments/',
                       {
                           scenario,
-                          intervention,
-                          ...(costLine ? { cost_line: costLine } : {}),
+                          cost_line: costLine,
                           year,
-                          value: transformPercentageValue(value),
+                          value,
                       },
                   ),
         invalidateQueryKey: [

--- a/services/budget/budget_calculation.py
+++ b/services/budget/budget_calculation.py
@@ -228,6 +228,10 @@ class BudgetCalculationService:
                     rows.append(lineToAdd)
         return rows
 
+    def _get_yearly_value(self, line, year):
+        default = Decimal("0") if line.cost_driver == "fixed_cost" else Decimal("1")
+        return self.yearly_value_by_key.get((line.id, year), default)
+
     def _compute_population_cost_row(self, line, org_unit_id, year, inflation_multiplier, intervention_id):
         """
         Calculate using population as quantity and yearly value is a ratio applied on this quantity.
@@ -239,7 +243,7 @@ class BudgetCalculationService:
         if population <= 0:
             return None
 
-        yearly_value = self.yearly_value_by_key.get((line.id, year), Decimal("1"))
+        yearly_value = self._get_yearly_value(line, year)
         unit_ratio = line.unit_type.ratio if line.unit_type and line.unit_type.ratio is not None else Decimal("1")
 
         # Doing the same as before here, quantity is modified by the unit ratio and the yearly coverage.
@@ -264,7 +268,7 @@ class BudgetCalculationService:
         """
         Calculate using yearly value as quantity. Added once per intervention regardless of org units.
         """
-        yearly_value = self.yearly_value_by_key.get((line.id, year), Decimal("1"))
+        yearly_value = self._get_yearly_value(line, year)
         unit_ratio = line.unit_type.ratio if line.unit_type and line.unit_type.ratio is not None else Decimal("1")
         quantity = yearly_value * Decimal(str(unit_ratio))
         line_cost = self._compute_cost_(quantity, line.unit_cost, inflation_multiplier)

--- a/services/budget/budget_calculation.py
+++ b/services/budget/budget_calculation.py
@@ -52,10 +52,7 @@ class BudgetCalculationService:
             org_unit_ids.add(assignment.org_unit_id)
 
         population_cost_lines = list(
-            InterventionCostBreakdownLine.objects.filter(
-                intervention_id__in=intervention_ids,
-                cost_driver=InterventionCostBreakdownLine.CostDriver.POPULATION,
-            )
+            InterventionCostBreakdownLine.objects.filter(intervention_id__in=intervention_ids)
             .select_related("population_layer", "unit_type", "intervention")
             .order_by("intervention_id", "id")
         )
@@ -158,23 +155,24 @@ class BudgetCalculationService:
             intervention_breakdowns[intervention_id][row.cost_line_id]["total_cost"] += row.total_cost
             intervention_breakdowns[intervention_id][row.cost_line_id]["quantity"] += row.quantity
 
-            org_unit_totals[row.org_unit_id]["total_cost"] += row.total_cost
-            org_unit_totals[row.org_unit_id]["quantity"] += row.quantity
+            if row.org_unit_id is not None:
+                org_unit_totals[row.org_unit_id]["total_cost"] += row.total_cost
+                org_unit_totals[row.org_unit_id]["quantity"] += row.quantity
 
-            org_unit_intervention_totals[row.org_unit_id][intervention_id]["total_cost"] += row.total_cost
-            org_unit_intervention_totals[row.org_unit_id][intervention_id]["quantity"] += row.quantity
-            org_unit_intervention_breakdowns[row.org_unit_id][intervention_id][row.cost_line_id]["id"] = (
-                row.cost_line_id
-            )
-            org_unit_intervention_breakdowns[row.org_unit_id][intervention_id][row.cost_line_id]["category"] = (
-                row.category
-            )
-            org_unit_intervention_breakdowns[row.org_unit_id][intervention_id][row.cost_line_id]["total_cost"] += (
-                row.total_cost
-            )
-            org_unit_intervention_breakdowns[row.org_unit_id][intervention_id][row.cost_line_id]["quantity"] += (
-                row.quantity
-            )
+                org_unit_intervention_totals[row.org_unit_id][intervention_id]["total_cost"] += row.total_cost
+                org_unit_intervention_totals[row.org_unit_id][intervention_id]["quantity"] += row.quantity
+                org_unit_intervention_breakdowns[row.org_unit_id][intervention_id][row.cost_line_id]["id"] = (
+                    row.cost_line_id
+                )
+                org_unit_intervention_breakdowns[row.org_unit_id][intervention_id][row.cost_line_id]["category"] = (
+                    row.category
+                )
+                org_unit_intervention_breakdowns[row.org_unit_id][intervention_id][row.cost_line_id]["total_cost"] += (
+                    row.total_cost
+                )
+                org_unit_intervention_breakdowns[row.org_unit_id][intervention_id][row.cost_line_id]["quantity"] += (
+                    row.quantity
+                )
 
             category_totals[row.category]["id"] = row.cost_line_id
             category_totals[row.category]["total_cost"] += row.total_cost
@@ -210,6 +208,7 @@ class BudgetCalculationService:
         """
 
         rows = []
+        seen_fixed_cost_line_ids = set()
         years_offset = year - self.start_year
         inflation_multiplier = (Decimal("1") + self.inflation_rate) ** years_offset
         for assignment in self.assignments:
@@ -217,38 +216,73 @@ class BudgetCalculationService:
             org_unit_id = assignment.org_unit_id
 
             for line in self.cost_lines_by_intervention_id.get(intervention.id, []):
-                if line.population_layer_id is None:
-                    continue
-
-                population = self.population_by_key.get((org_unit_id, year, line.population_layer_id), Decimal("0"))
-                if population <= 0:
-                    continue
-
-                yearly_value = self.yearly_value_by_key.get((line.id, year), Decimal("1"))
-                unit_ratio = (
-                    line.unit_type.ratio if line.unit_type and line.unit_type.ratio is not None else Decimal("1")
-                )
-
-                # Doing the same as before here, quantity is modified by the unit ratio and the yearly coverage.
-                quantity = population * yearly_value * Decimal(str(unit_ratio))
-                line_cost = quantity * Decimal(str(line.unit_cost)) * inflation_multiplier * self.buffer
-                if line_cost <= 0:
-                    continue
-
-                category = line.get_category_display()
-                rows.append(
-                    BudgetLineRow(
-                        cost_line_id=line.id,
-                        org_unit_id=org_unit_id,
-                        intervention_id=intervention.id,
-                        category=category,
-                        population=population,
-                        quantity=quantity,
-                        total_cost=line_cost,
+                lineToAdd = None
+                if line.cost_driver == "population":
+                    lineToAdd = self._compute_population_cost_row(
+                        line, org_unit_id, year, inflation_multiplier, intervention.id
                     )
-                )
-
+                elif line.cost_driver == "fixed_cost" and line.id not in seen_fixed_cost_line_ids:
+                    seen_fixed_cost_line_ids.add(line.id)
+                    lineToAdd = self._compute_fixed_cost_row(line, year, inflation_multiplier, intervention.id)
+                if lineToAdd:
+                    rows.append(lineToAdd)
         return rows
+
+    def _compute_population_cost_row(self, line, org_unit_id, year, inflation_multiplier, intervention_id):
+        """
+        Calculate using population as quantity and yearly value is a ratio applied on this quantity.
+        """
+        if line.population_layer_id is None:
+            return None
+
+        population = self.population_by_key.get((org_unit_id, year, line.population_layer_id), Decimal("0"))
+        if population <= 0:
+            return None
+
+        yearly_value = self.yearly_value_by_key.get((line.id, year), Decimal("1"))
+        unit_ratio = line.unit_type.ratio if line.unit_type and line.unit_type.ratio is not None else Decimal("1")
+
+        # Doing the same as before here, quantity is modified by the unit ratio and the yearly coverage.
+        quantity = population * yearly_value * Decimal(str(unit_ratio))
+        line_cost = self._compute_cost_(quantity, line.unit_cost, inflation_multiplier)
+
+        if line_cost <= 0:
+            return None
+
+        category = line.get_category_display()
+        return BudgetLineRow(
+            cost_line_id=line.id,
+            org_unit_id=org_unit_id,
+            intervention_id=intervention_id,
+            category=category,
+            population=population,
+            quantity=quantity,
+            total_cost=line_cost,
+        )
+
+    def _compute_fixed_cost_row(self, line, year, inflation_multiplier, intervention_id):
+        """
+        Calculate using yearly value as quantity. Added once per intervention regardless of org units.
+        """
+        yearly_value = self.yearly_value_by_key.get((line.id, year), Decimal("1"))
+        unit_ratio = line.unit_type.ratio if line.unit_type and line.unit_type.ratio is not None else Decimal("1")
+        quantity = yearly_value * Decimal(str(unit_ratio))
+        line_cost = self._compute_cost_(quantity, line.unit_cost, inflation_multiplier)
+        if line_cost <= 0:
+            return None
+
+        category = line.get_category_display()
+        return BudgetLineRow(
+            cost_line_id=line.id,
+            org_unit_id=None,
+            intervention_id=intervention_id,
+            category=category,
+            quantity=quantity,
+            total_cost=line_cost,
+        )
+
+    def _compute_cost_(self, quantity, unit_cost, inflation_multiplier):
+        return quantity * Decimal(str(unit_cost)) * inflation_multiplier * self.buffer
 
     def _build_interventions(self, intervention_totals, intervention_breakdowns):
         """

--- a/services/budget/dataclasses.py
+++ b/services/budget/dataclasses.py
@@ -55,9 +55,9 @@ class BudgetYearResult(BudgetBaseModel):
 
 class BudgetLineRow(BudgetBaseModel):
     cost_line_id: int
-    org_unit_id: int
+    org_unit_id: Optional[int]
     intervention_id: int
     category: str
-    population: Decimal
+    population: Decimal = Decimal("0")
     quantity: Decimal
     total_cost: Decimal

--- a/tests/api/budget/test_views.py
+++ b/tests/api/budget/test_views.py
@@ -155,7 +155,6 @@ class BudgetAPITestCase(SNTMalariaAPITestCase):
         self.assertEqual(result["scenario"], self.scenario.id)
         self.assertEqual(len(result["results"]), 4)
         for yearly_result in result["results"]:
-            print(yearly_result)
             self.assertEqual(yearly_result["total_cost"], 0)
 
     def test_calculate_budget_missing_scenario(self):

--- a/tests/api/scenario_yearly_cost_assignments/test_serializers.py
+++ b/tests/api/scenario_yearly_cost_assignments/test_serializers.py
@@ -108,13 +108,33 @@ class ScenarioYearlyCostAssignmentSerializerBaseTestCase(SNTMalariaTestCase):
 
 
 class ScenarioYearlyCostAssignmentSerializerTests(ScenarioYearlyCostAssignmentSerializerBaseTestCase):
+    def test_to_representation_multiplies_value_by_100_for_population_lines(self):
+        assignment = ScenarioYearlyCostAssignment.objects.create(
+            scenario=self.scenario,
+            cost_line=self.population_line_1,
+            year=2026,
+            value="1.50",
+        )
+        serializer = ScenarioYearlyCostAssignmentSerializer(assignment, context=self._context_for(self.user))
+        self.assertEqual(serializer.data["value"], "150")
+
+    def test_to_representation_does_not_modify_value_for_fixed_cost_lines(self):
+        assignment = ScenarioYearlyCostAssignment.objects.create(
+            scenario=self.scenario,
+            cost_line=self.fixed_cost_line,
+            year=2026,
+            value="150",
+        )
+        serializer = ScenarioYearlyCostAssignmentSerializer(assignment, context=self._context_for(self.user))
+        self.assertEqual(serializer.data["value"], "150")
+
     def test_create_is_scoped_to_scenario_and_cost_line_account(self):
         serializer = ScenarioYearlyCostAssignmentSerializer(
             data={
                 "scenario": self.other_account_scenario.id,
                 "year": 2026,
                 "cost_line": self.population_line_1.id,
-                "value": "12.00",
+                "value": "12",
             },
             context=self._context_for(self.user),
         )
@@ -126,7 +146,7 @@ class ScenarioYearlyCostAssignmentSerializerTests(ScenarioYearlyCostAssignmentSe
                 "scenario": self.scenario.id,
                 "year": 2026,
                 "cost_line": self.other_account_cost_line.id,
-                "value": "12.00",
+                "value": "12",
             },
             context=self._context_for(self.user),
         )
@@ -134,270 +154,128 @@ class ScenarioYearlyCostAssignmentSerializerTests(ScenarioYearlyCostAssignmentSe
         self.assertIn("cost_line", serializer.errors)
 
 
-class ScenarioYearlyCostAssignmentUpsertManySerializerTests(ScenarioYearlyCostAssignmentSerializerBaseTestCase):
-    def test_save_updates_population_lines_for_current_scenario_only(self):
-        ScenarioYearlyCostAssignment.objects.create(
-            scenario=self.scenario,
-            cost_line=self.population_line_1,
-            year=2026,
-            value="1.00",
-        )
-        ScenarioYearlyCostAssignment.objects.create(
-            scenario=self.scenario,
-            cost_line=self.population_line_2,
-            year=2026,
-            value="2.00",
-        )
-        ScenarioYearlyCostAssignment.objects.create(
-            scenario=self.scenario,
-            cost_line=self.fixed_cost_line,
-            year=2026,
-            value="3.00",
-        )
-        ScenarioYearlyCostAssignment.objects.create(
-            scenario=self.other_user_scenario,
-            cost_line=self.population_line_1,
-            year=2026,
-            value="4.00",
-        )
-
-        serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
-            data={
-                "intervention": self.intervention.id,
-                "scenario": self.scenario.id,
-                "year": 2026,
-                "value": "99.00",
-            },
-            context=self._context_for(self.user),
-        )
-        self.assertTrue(serializer.is_valid(), serializer.errors)
-
-        result = serializer.save()
-
-        self.assertEqual(len(result), 2)
-
-        current_scenario_assignments = ScenarioYearlyCostAssignment.objects.filter(
-            scenario=self.scenario,
-            year=2026,
-        )
-        self.assertEqual(current_scenario_assignments.count(), 3)
-
-        updated_line_1 = current_scenario_assignments.get(cost_line=self.population_line_1)
-        updated_line_2 = current_scenario_assignments.get(cost_line=self.population_line_2)
-        unchanged_fixed_line = current_scenario_assignments.get(cost_line=self.fixed_cost_line)
-
-        other_scenario_assignment = ScenarioYearlyCostAssignment.objects.get(
-            scenario=self.other_user_scenario,
-            cost_line=self.population_line_1,
-            year=2026,
-        )
-
-        self.assertEqual(str(updated_line_1.value), "99.00")
-        self.assertEqual(str(updated_line_2.value), "99.00")
-        self.assertEqual(str(unchanged_fixed_line.value), "3.00")
-        self.assertEqual(str(other_scenario_assignment.value), "4.00")
-
-    def test_save_updates_only_the_given_cost_line_when_cost_line_is_provided(self):
-        ScenarioYearlyCostAssignment.objects.create(
-            scenario=self.scenario,
-            cost_line=self.population_line_1,
-            year=2026,
-            value="1.00",
-        )
-        ScenarioYearlyCostAssignment.objects.create(
-            scenario=self.scenario,
-            cost_line=self.population_line_2,
-            year=2026,
-            value="2.00",
-        )
-        ScenarioYearlyCostAssignment.objects.create(
-            scenario=self.scenario,
-            cost_line=self.fixed_cost_line,
-            year=2026,
-            value="3.00",
-        )
-
-        serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
-            data={
-                "intervention": self.intervention.id,
-                "scenario": self.scenario.id,
-                "cost_line": self.fixed_cost_line.id,
-                "year": 2026,
-                "value": "99.00",
-            },
-            context=self._context_for(self.user),
-        )
-        self.assertTrue(serializer.is_valid(), serializer.errors)
-
-        result = serializer.save()
-
-        self.assertEqual(len(result), 1)
-
-        current_scenario_assignments = ScenarioYearlyCostAssignment.objects.filter(
-            scenario=self.scenario,
-            year=2026,
-        )
-        self.assertEqual(current_scenario_assignments.count(), 3)
-
-        changed_fixed_line = current_scenario_assignments.get(cost_line=self.fixed_cost_line)
-        unchanged_line_1 = current_scenario_assignments.get(cost_line=self.population_line_1)
-        unchanged_line_2 = current_scenario_assignments.get(cost_line=self.population_line_2)
-
-        self.assertEqual(str(changed_fixed_line.value), "99.00")
-        self.assertEqual(str(unchanged_line_1.value), "1.00")
-        self.assertEqual(str(unchanged_line_2.value), "2.00")
-
-    def test_validate_rejects_intervention_without_cost_breakdown_lines(self):
-        empty_intervention = self.create_snt_intervention(
-            name="Empty Intervention",
-            intervention_category=self.category,
-            code="empty_intervention",
-        )
-
-        serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
-            data={
-                "intervention": empty_intervention.id,
-                "scenario": self.scenario.id,
-                "year": 2026,
-                "value": "99.00",
-            },
-            context=self._context_for(self.user),
-        )
-
-        self.assertFalse(serializer.is_valid())
-        self.assertIn("intervention", serializer.errors)
-
-    def test_required_fields_are_enforced(self):
-        base_data = {
-            "intervention": self.intervention.id,
+class ScenarioYearlyCostAssignmentUpsertSerializerTests(ScenarioYearlyCostAssignmentSerializerBaseTestCase):
+    def _base_data(self, cost_line=None, value="99"):
+        return {
             "scenario": self.scenario.id,
+            "cost_line": (cost_line or self.fixed_cost_line).id,
             "year": 2026,
-            "value": "99.00",
+            "value": value,
         }
 
-        for field_name in ("intervention", "scenario", "year", "value"):
+    def test_save_creates_new_assignment(self):
+        serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
+            data=self._base_data(self.fixed_cost_line, "50"),
+            context=self._context_for(self.user),
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        result = serializer.save()
+        self.assertEqual(result.scenario, self.scenario)
+        self.assertEqual(result.cost_line, self.fixed_cost_line)
+        self.assertEqual(result.year, 2026)
+        self.assertEqual(str(result.value), "50.00")
+
+    def test_save_updates_existing_assignment(self):
+        existing = ScenarioYearlyCostAssignment.objects.create(
+            scenario=self.scenario, cost_line=self.fixed_cost_line, year=2026, value="10.00"
+        )
+        serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
+            data=self._base_data(self.fixed_cost_line, "20.00"),
+            context=self._context_for(self.user),
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        result = serializer.save()
+        self.assertEqual(result.id, existing.id)
+        self.assertEqual(str(result.value), "20.00")
+
+    def test_save_divides_value_by_100_for_population_driver(self):
+        serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
+            data=self._base_data(self.population_line_1, "75.00"),
+            context=self._context_for(self.user),
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        result = serializer.save()
+        self.assertEqual(str(result.value), "0.75")
+
+    def test_save_does_not_divide_value_for_fixed_cost_driver(self):
+        serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
+            data=self._base_data(self.fixed_cost_line, "500.00"),
+            context=self._context_for(self.user),
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        result = serializer.save()
+        self.assertEqual(str(result.value), "500.00")
+
+    def test_patch_uses_instance_year_and_cost_line(self):
+        assignment = ScenarioYearlyCostAssignment.objects.create(
+            scenario=self.scenario, cost_line=self.fixed_cost_line, year=2026, value="10.00"
+        )
+        serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
+            instance=assignment,
+            data={"scenario": self.scenario.id, "value": "50.00"},
+            partial=True,
+            context=self._context_for(self.user),
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        result = serializer.save()
+        self.assertEqual(result.id, assignment.id)
+        self.assertEqual(result.year, 2026)
+        self.assertEqual(result.cost_line, self.fixed_cost_line)
+        self.assertEqual(str(result.value), "50.00")
+
+    def test_patch_without_value_leaves_value_unchanged(self):
+        assignment = ScenarioYearlyCostAssignment.objects.create(
+            scenario=self.scenario, cost_line=self.fixed_cost_line, year=2026, value="10.00"
+        )
+        serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
+            instance=assignment,
+            data={"scenario": self.scenario.id},
+            partial=True,
+            context=self._context_for(self.user),
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        result = serializer.save()
+        self.assertEqual(str(result.value), "10.00")
+
+    def test_required_fields_are_enforced(self):
+        for field_name in ("scenario", "cost_line", "year", "value"):
             with self.subTest(field_name=field_name):
-                data = dict(base_data)
+                data = dict(self._base_data())
                 data.pop(field_name)
-
                 serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
-                    data=data,
-                    context=self._context_for(self.user),
+                    data=data, context=self._context_for(self.user)
                 )
-
                 self.assertFalse(serializer.is_valid())
                 self.assertIn(field_name, serializer.errors)
 
-    def test_rejects_intervention_from_other_account(self):
-        serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
-            data={
-                "intervention": self.other_account_intervention.id,
-                "scenario": self.scenario.id,
-                "year": 2026,
-                "value": "99.00",
-            },
-            context=self._context_for(self.user),
-        )
-
-        self.assertFalse(serializer.is_valid())
-        self.assertIn("intervention", serializer.errors)
-
     def test_reject_locked_scenario(self):
         serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
-            data={
-                "intervention": self.intervention.id,
-                "scenario": self.locked_scenario.id,
-                "year": 2026,
-                "value": "99.00",
-            },
+            data={**self._base_data(), "scenario": self.locked_scenario.id},
             context=self._context_for(self.user),
         )
-
         self.assertFalse(serializer.is_valid())
         self.assertIn("scenario", serializer.errors)
 
     def test_rejects_scenario_from_other_account(self):
         serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
-            data={
-                "intervention": self.intervention.id,
-                "scenario": self.other_account_scenario.id,
-                "year": 2026,
-                "value": "99.00",
-            },
+            data={**self._base_data(), "scenario": self.other_account_scenario.id},
             context=self._context_for(self.user),
         )
-
         self.assertFalse(serializer.is_valid())
         self.assertIn("scenario", serializer.errors)
 
+    def test_rejects_cost_line_from_other_account(self):
+        serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
+            data={**self._base_data(), "cost_line": self.other_account_cost_line.id},
+            context=self._context_for(self.user),
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("cost_line", serializer.errors)
+
     def test_value_must_be_decimal(self):
         serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
-            data={
-                "intervention": self.intervention.id,
-                "scenario": self.scenario.id,
-                "year": 2026,
-                "value": "1a2,00",
-            },
+            data={**self._base_data(), "value": "1a2,00"},
             context=self._context_for(self.user),
         )
-
         self.assertFalse(serializer.is_valid())
         self.assertIn("value", serializer.errors)
-
-    def test_cost_line_other_account(self):
-        serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
-            data={
-                "intervention": self.intervention.id,
-                "scenario": self.scenario.id,
-                "cost_line": self.other_account_cost_line.id,
-                "year": 2026,
-                "value": "99.00",
-            },
-            context=self._context_for(self.user),
-        )
-
-        self.assertFalse(serializer.is_valid())
-        self.assertIn("cost_line", serializer.errors)
-
-    def test_cost_line_not_belonging_to_intervention(self):
-        other_intervention_cost_line = self.create_snt_intervention(
-            name="Other Intervention",
-            intervention_category=self.category,
-            code="other_intervention",
-        ).cost_breakdown_lines.create(
-            name="Other Intervention Cost Line",
-            category="Procurement",
-            cost_driver=InterventionCostBreakdownLine.CostDriver.POPULATION,
-            unit_cost=50,
-            unit_type=self.unit_type,
-            created_by=self.user,
-        )
-
-        serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
-            data={
-                "intervention": self.intervention.id,
-                "scenario": self.scenario.id,
-                "cost_line": other_intervention_cost_line.id,
-                "year": 2026,
-                "value": "99.00",
-            },
-            context=self._context_for(self.user),
-        )
-
-        self.assertFalse(serializer.is_valid())
-        self.assertIn("cost_line", serializer.errors)
-
-    def test_cost_line_must_be_fixed_cost_when_provided(self):
-        serializer = ScenarioYearlyCostAssignmentUpsertSerializer(
-            data={
-                "intervention": self.intervention.id,
-                "scenario": self.scenario.id,
-                "cost_line": self.population_line_1.id,
-                "year": 2026,
-                "value": "99.00",
-            },
-            context=self._context_for(self.user),
-        )
-
-        self.assertFalse(serializer.is_valid())
-        self.assertIn("cost_line", serializer.errors)

--- a/tests/api/scenario_yearly_cost_assignments/test_views.py
+++ b/tests/api/scenario_yearly_cost_assignments/test_views.py
@@ -186,7 +186,7 @@ class ScenarioYearlyCostAssignmentAPITestCase(SNTMalariaAPITestCase):
 
     def test_create_is_scoped_per_scenario(self):
         valid_response = self._post_create_payload(self.user_with_full_perm, self.scenario, self.population_line_1)
-        valid_result = self.assertJSONResponse(valid_response, status.HTTP_201_CREATED)
+        valid_result = self.assertJSONResponse(valid_response, status.HTTP_200_OK)
         self.assertEqual(valid_result["scenario"], self.scenario.id)
 
         cross_account_response = self._post_create_payload(
@@ -199,7 +199,7 @@ class ScenarioYearlyCostAssignmentAPITestCase(SNTMalariaAPITestCase):
 
     def test_create_allows_basic_access_same_account(self):
         response = self._post_create_payload(self.user_with_basic_perm, self.scenario, self.population_line_1)
-        result = self.assertJSONResponse(response, status.HTTP_201_CREATED)
+        result = self.assertJSONResponse(response, status.HTTP_200_OK)
 
         self.assertEqual(result["scenario"], self.scenario.id)
         self.assertEqual(result["cost_line"], self.population_line_1.id)
@@ -209,13 +209,11 @@ class ScenarioYearlyCostAssignmentAPITestCase(SNTMalariaAPITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    # This work for locked scenario too, scenario lock state is validate in serializer.
-    def test_create_allows_full_access_locked_scenario(self):
+    def test_create_rejects_locked_scenario(self):
         response = self._post_create_payload(self.user_with_full_perm, self.locked_scenario, self.population_line_1)
-        result = self.assertJSONResponse(response, status.HTTP_201_CREATED)
+        result = self.assertJSONResponse(response, status.HTTP_400_BAD_REQUEST)
 
-        self.assertEqual(result["scenario"], self.locked_scenario.id)
-        self.assertEqual(result["cost_line"], self.population_line_1.id)
+        self.assertIn("scenario", result)
 
     def test_forbidden_when_user_has_no_access_to_scenario(self):
         assignment = self._create_scenario_yearly_cost(self.scenario, self.population_line_1, value="5.00")
@@ -237,7 +235,8 @@ class ScenarioYearlyCostAssignmentAPITestCase(SNTMalariaAPITestCase):
 
         assignment.refresh_from_db()
         self.assertEqual(result["id"], assignment.id)
-        self.assertEqual(str(assignment.value), "20.00")
+        # population driver: API receives percentage (20.00), stored as fraction (0.20)
+        self.assertEqual(str(assignment.value), "0.20")
 
     def test_updating_single_assignment_allows_basic_access_when_user_created_the_scenario(self):
         assignment = self._create_scenario_yearly_cost(self.other_user_scenario, self.population_line_1, value="5.00")
@@ -247,7 +246,8 @@ class ScenarioYearlyCostAssignmentAPITestCase(SNTMalariaAPITestCase):
 
         assignment.refresh_from_db()
         self.assertEqual(result["id"], assignment.id)
-        self.assertEqual(str(assignment.value), "21.00")
+        # population driver: API receives percentage (21.00), stored as fraction (0.21)
+        self.assertEqual(str(assignment.value), "0.21")
 
     def test_updating_single_assignment_forbids_no_access_same_account(self):
         assignment = self._create_scenario_yearly_cost(self.scenario, self.population_line_1, value="5.00")

--- a/tests/api/scenario_yearly_cost_assignments/test_views.py
+++ b/tests/api/scenario_yearly_cost_assignments/test_views.py
@@ -230,13 +230,13 @@ class ScenarioYearlyCostAssignmentAPITestCase(SNTMalariaAPITestCase):
     def test_updating_single_assignment_works(self):
         assignment = self._create_scenario_yearly_cost(self.scenario, self.population_line_1, value="5.00")
 
-        response = self._patch_assignment_value(self.user_with_full_perm, assignment, "20.00")
+        response = self._patch_assignment_value(self.user_with_full_perm, assignment, "29.00")
         result = self.assertJSONResponse(response, status.HTTP_200_OK)
 
         assignment.refresh_from_db()
         self.assertEqual(result["id"], assignment.id)
         # population driver: API receives percentage (20.00), stored as fraction (0.20)
-        self.assertEqual(str(assignment.value), "0.20")
+        self.assertEqual(str(assignment.value), "0.29")
 
     def test_updating_single_assignment_allows_basic_access_when_user_created_the_scenario(self):
         assignment = self._create_scenario_yearly_cost(self.other_user_scenario, self.population_line_1, value="5.00")
@@ -254,6 +254,20 @@ class ScenarioYearlyCostAssignmentAPITestCase(SNTMalariaAPITestCase):
 
         response = self._patch_assignment_value(self.user_no_perm, assignment, "22.00")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_assignment_value_rounding_for_population_driver(self):
+        # float(Decimal("0.29")) * 100 == 28.999... which math.floor would truncate to 28.
+        # The serializer must round correctly so the API returns "29", not "28".
+        for stored_value, expected_display in [("0.29", "29"), ("0.57", "57"), ("0.03", "3")]:
+            with self.subTest(stored_value=stored_value):
+                ScenarioYearlyCostAssignment.objects.filter(scenario=self.scenario).delete()
+                self._create_scenario_yearly_cost(self.scenario, self.population_line_1, value=stored_value)
+
+                response = self._list_assignments(self.user_no_perm, self.scenario)
+                result = self.assertJSONResponse(response, status.HTTP_200_OK)
+
+                self.assertEqual(len(result), 1)
+                self.assertEqual(result[0]["value"], expected_display)
 
     def test_deleting_assignment_is_not_allowed(self):
         assignment = self._create_scenario_yearly_cost(self.scenario, self.population_line_1, value="5.00")

--- a/tests/api/scenario_yearly_cost_assignments/test_views.py
+++ b/tests/api/scenario_yearly_cost_assignments/test_views.py
@@ -186,7 +186,7 @@ class ScenarioYearlyCostAssignmentAPITestCase(SNTMalariaAPITestCase):
 
     def test_create_is_scoped_per_scenario(self):
         valid_response = self._post_create_payload(self.user_with_full_perm, self.scenario, self.population_line_1)
-        valid_result = self.assertJSONResponse(valid_response, status.HTTP_200_OK)
+        valid_result = self.assertJSONResponse(valid_response, status.HTTP_201_CREATED)
         self.assertEqual(valid_result["scenario"], self.scenario.id)
 
         cross_account_response = self._post_create_payload(
@@ -199,7 +199,7 @@ class ScenarioYearlyCostAssignmentAPITestCase(SNTMalariaAPITestCase):
 
     def test_create_allows_basic_access_same_account(self):
         response = self._post_create_payload(self.user_with_basic_perm, self.scenario, self.population_line_1)
-        result = self.assertJSONResponse(response, status.HTTP_200_OK)
+        result = self.assertJSONResponse(response, status.HTTP_201_CREATED)
 
         self.assertEqual(result["scenario"], self.scenario.id)
         self.assertEqual(result["cost_line"], self.population_line_1.id)

--- a/tests/services/test_budget.py
+++ b/tests/services/test_budget.py
@@ -70,18 +70,6 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
             created_by=self.user,
         )
 
-        # Should be skipped for now by the internal calculator.
-        self.fixed_cost_line = InterventionCostBreakdownLine.objects.create(
-            intervention=self.intervention_smc,
-            name="SMC fixed",
-            category=InterventionCostBreakdownLine.InterventionCostBreakdownLineCategory.OPERATIONAL,
-            unit_type=self.unit_type,
-            population_layer=self.metric_under_5,
-            cost_driver=InterventionCostBreakdownLine.CostDriver.FIXED_COST,
-            unit_cost=Decimal("999.00"),
-            created_by=self.user,
-        )
-
         # Missing population layer should contribute zero.
         self.no_population_layer_line = InterventionCostBreakdownLine.objects.create(
             intervention=self.intervention_iptp,
@@ -177,16 +165,14 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
         self.assertEqual(result.quantity, 2000.0)
         self.assertEqual(result.total_cost, 4532.0)
 
-    def test_skips_fixed_cost_and_missing_population_layer_lines(self):
+    def test_missing_population_layer_line_does_not_contribute(self):
         service = BudgetCalculationService(self.scenario)
 
         result = service.calculate_year(2025)
 
+        # IPTp has a cost line with population_layer=None — it should produce nothing.
         self.assertEqual(len(result.interventions), 1)
         self.assertEqual(result.interventions[0].code, "smc")
-
-        categories = [c.category for c in result.category_costs]
-        self.assertNotIn("Operational", categories)
 
     def test_missing_population_metric_value_contributes_zero_for_orgunit(self):
         MetricValue.objects.filter(metric_type=self.metric_under_5, org_unit=self.district_2, year=2025).delete()
@@ -255,3 +241,156 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
         # total_cost = 2000 * 2 * 1.1 = 4400
         self.assertEqual(result.quantity, 2000.0)
         self.assertEqual(result.total_cost, 4400.0)
+
+    def test_fixed_cost_not_included_when_intervention_has_no_org_unit_assignment(self):
+        """An intervention with only a fixed cost line and no org unit assignment contributes nothing."""
+        scenario = self.create_snt_scenario(self.account, self.user, start_year=2025, end_year=2025)
+        category = self.create_snt_intervention_category()
+        intervention = self.create_snt_intervention(intervention_category=category, code="unassigned_fixed")
+        fixed_line = InterventionCostBreakdownLine.objects.create(
+            intervention=intervention,
+            name="Unassigned fixed cost",
+            category=InterventionCostBreakdownLine.InterventionCostBreakdownLineCategory.OPERATIONAL,
+            unit_type=self.unit_type,
+            population_layer=None,
+            cost_driver=InterventionCostBreakdownLine.CostDriver.FIXED_COST,
+            unit_cost=Decimal("500.00"),
+            created_by=self.user,
+        )
+        ScenarioYearlyCostAssignment.objects.create(
+            scenario=scenario,
+            cost_line=fixed_line,
+            year=2025,
+            value=Decimal("3"),
+        )
+        # No InterventionAssignment created — intervention is never assigned to an org unit.
+
+        service = BudgetCalculationService(scenario)
+        result = service.calculate_year(2025)
+
+        self.assertEqual(result.total_cost, 0.0)
+        self.assertEqual(result.quantity, 0.0)
+        self.assertEqual(len(result.interventions), 0)
+        self.assertEqual(len(result.org_units_costs), 0)
+        self.assertEqual(len(result.category_costs), 0)
+
+    def test_fixed_cost_added_once_with_multiple_org_unit_assignments(self):
+        """Fixed cost line is counted exactly once regardless of how many org units the intervention covers."""
+        scenario = self.create_snt_scenario(self.account, self.user, start_year=2025, end_year=2025)
+        category = self.create_snt_intervention_category()
+        intervention = self.create_snt_intervention(intervention_category=category, code="fixed_only_multi")
+        self.create_snt_assignment(scenario, self.district_1, intervention)
+        self.create_snt_assignment(scenario, self.district_2, intervention)
+
+        fixed_line = InterventionCostBreakdownLine.objects.create(
+            intervention=intervention,
+            name="Multi-district fixed cost",
+            category=InterventionCostBreakdownLine.InterventionCostBreakdownLineCategory.OPERATIONAL,
+            unit_type=self.unit_type,
+            population_layer=None,
+            cost_driver=InterventionCostBreakdownLine.CostDriver.FIXED_COST,
+            unit_cost=Decimal("100.00"),
+            created_by=self.user,
+        )
+        ScenarioYearlyCostAssignment.objects.create(
+            scenario=scenario,
+            cost_line=fixed_line,
+            year=2025,
+            value=Decimal("4"),
+        )
+
+        service = BudgetCalculationService(scenario)
+        result = service.calculate_year(2025)
+
+        # quantity = 4 * ratio(0.5) = 2.0
+        # total_cost = 2 * unit_cost(100) * buffer(1.1) * inflation_multiplier(1.0) = 220.0
+        self.assertEqual(result.quantity, 2.0)
+        self.assertEqual(result.total_cost, 220.0)
+        self.assertEqual(len(result.interventions), 1)
+        self.assertEqual(result.interventions[0].total_cost, 220.0)
+        # Fixed costs are not attributed to specific org units.
+        self.assertEqual(len(result.org_units_costs), 0)
+
+    def test_fixed_and_population_costs_combined_with_second_population_only_intervention(self):
+        """Fixed cost appears once in totals; population costs accumulate per org unit independently.
+        A second intervention with only a population cost line is unaffected by the fixed cost.
+        """
+        scenario = self.create_snt_scenario(self.account, self.user, start_year=2025, end_year=2025)
+        category = self.create_snt_intervention_category()
+
+        # Intervention A: population + fixed cost, assigned to two districts.
+        intervention_a = self.create_snt_intervention(intervention_category=category, code="iv_a")
+        self.create_snt_assignment(scenario, self.district_1, intervention_a)
+        self.create_snt_assignment(scenario, self.district_2, intervention_a)
+        pop_line_a = InterventionCostBreakdownLine.objects.create(
+            intervention=intervention_a,
+            name="IV-A population",
+            category=InterventionCostBreakdownLine.InterventionCostBreakdownLineCategory.PROCUREMENT,
+            unit_type=self.unit_type,
+            population_layer=self.metric_under_5,
+            cost_driver=InterventionCostBreakdownLine.CostDriver.POPULATION,
+            unit_cost=Decimal("2.00"),
+            created_by=self.user,
+        )
+        fixed_line_a = InterventionCostBreakdownLine.objects.create(
+            intervention=intervention_a,
+            name="IV-A fixed cost",
+            category=InterventionCostBreakdownLine.InterventionCostBreakdownLineCategory.OPERATIONAL,
+            unit_type=self.unit_type,
+            population_layer=None,
+            cost_driver=InterventionCostBreakdownLine.CostDriver.FIXED_COST,
+            unit_cost=Decimal("100.00"),
+            created_by=self.user,
+        )
+        ScenarioYearlyCostAssignment.objects.create(
+            scenario=scenario, cost_line=pop_line_a, year=2025, value=Decimal("1.0"),
+        )
+        ScenarioYearlyCostAssignment.objects.create(
+            scenario=scenario, cost_line=fixed_line_a, year=2025, value=Decimal("4"),
+        )
+
+        # Intervention B: population cost only, assigned to district_1.
+        intervention_b = self.create_snt_intervention(intervention_category=category, code="iv_b")
+        self.create_snt_assignment(scenario, self.district_1, intervention_b)
+        pop_line_b = InterventionCostBreakdownLine.objects.create(
+            intervention=intervention_b,
+            name="IV-B population",
+            category=InterventionCostBreakdownLine.InterventionCostBreakdownLineCategory.PROCUREMENT,
+            unit_type=self.unit_type,
+            population_layer=self.metric_under_5,
+            cost_driver=InterventionCostBreakdownLine.CostDriver.POPULATION,
+            unit_cost=Decimal("3.00"),
+            created_by=self.user,
+        )
+        ScenarioYearlyCostAssignment.objects.create(
+            scenario=scenario, cost_line=pop_line_b, year=2025, value=Decimal("1.0"),
+        )
+
+        service = BudgetCalculationService(scenario)
+        result = service.calculate_year(2025)
+
+        # IV-A population (district_1): 1000 * 1.0 * 0.5 = 500 qty → 500 * 2 * 1.1 = 1100
+        # IV-A population (district_2): 2000 * 1.0 * 0.5 = 1000 qty → 1000 * 2 * 1.1 = 2200
+        # IV-A fixed cost (once):          4 * 0.5 = 2 qty          →    2 * 100 * 1.1 = 220
+        # IV-A total = 1100 + 2200 + 220 = 3520
+
+        # IV-B population (district_1): 1000 * 1.0 * 0.5 = 500 qty → 500 * 3 * 1.1 = 1650
+        # IV-B total = 1650
+
+        # Grand total = 3520 + 1650 = 5170
+        self.assertEqual(result.total_cost, 5170.0)
+        self.assertEqual(len(result.interventions), 2)
+
+        iv_a = next(i for i in result.interventions if i.code == "iv_a")
+        iv_b = next(i for i in result.interventions if i.code == "iv_b")
+        self.assertEqual(iv_a.total_cost, 3520.0)
+        self.assertEqual(iv_b.total_cost, 1650.0)
+
+        # Fixed cost rows have no org_unit_id and are excluded from the per-org-unit breakdown.
+        # district_1: IV-A pop (1100) + IV-B pop (1650) = 2750
+        # district_2: IV-A pop (2200) only
+        self.assertEqual(len(result.org_units_costs), 2)
+        d1 = next(o for o in result.org_units_costs if o.org_unit_id == self.district_1.id)
+        d2 = next(o for o in result.org_units_costs if o.org_unit_id == self.district_2.id)
+        self.assertEqual(d1.total_cost, 2750.0)
+        self.assertEqual(d2.total_cost, 2200.0)

--- a/tests/services/test_budget.py
+++ b/tests/services/test_budget.py
@@ -343,10 +343,16 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
             created_by=self.user,
         )
         ScenarioYearlyCostAssignment.objects.create(
-            scenario=scenario, cost_line=pop_line_a, year=2025, value=Decimal("1.0"),
+            scenario=scenario,
+            cost_line=pop_line_a,
+            year=2025,
+            value=Decimal("1.0"),
         )
         ScenarioYearlyCostAssignment.objects.create(
-            scenario=scenario, cost_line=fixed_line_a, year=2025, value=Decimal("4"),
+            scenario=scenario,
+            cost_line=fixed_line_a,
+            year=2025,
+            value=Decimal("4"),
         )
 
         # Intervention B: population cost only, assigned to district_1.
@@ -363,7 +369,10 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
             created_by=self.user,
         )
         ScenarioYearlyCostAssignment.objects.create(
-            scenario=scenario, cost_line=pop_line_b, year=2025, value=Decimal("1.0"),
+            scenario=scenario,
+            cost_line=pop_line_b,
+            year=2025,
+            value=Decimal("1.0"),
         )
 
         service = BudgetCalculationService(scenario)

--- a/tests/services/test_budget.py
+++ b/tests/services/test_budget.py
@@ -394,3 +394,31 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
         d2 = next(o for o in result.org_units_costs if o.org_unit_id == self.district_2.id)
         self.assertEqual(d1.total_cost, 2750.0)
         self.assertEqual(d2.total_cost, 2200.0)
+
+    def test_fixed_cost_defaults_to_zero_when_no_yearly_assignment(self):
+        """Fixed cost line with no ScenarioYearlyCostAssignment defaults yearly_value to 0 and contributes nothing."""
+        scenario = self.create_snt_scenario(self.account, self.user, start_year=2025, end_year=2025)
+        category = self.create_snt_intervention_category()
+        intervention = self.create_snt_intervention(intervention_category=category, code="fixed_no_assignment")
+        self.create_snt_assignment(scenario, self.district_1, intervention)
+
+        InterventionCostBreakdownLine.objects.create(
+            intervention=intervention,
+            name="Fixed cost without yearly assignment",
+            category=InterventionCostBreakdownLine.InterventionCostBreakdownLineCategory.OPERATIONAL,
+            unit_type=self.unit_type,
+            population_layer=None,
+            cost_driver=InterventionCostBreakdownLine.CostDriver.FIXED_COST,
+            unit_cost=Decimal("500.00"),
+            created_by=self.user,
+        )
+        # No ScenarioYearlyCostAssignment created — yearly_value defaults to 0 for fixed costs.
+
+        service = BudgetCalculationService(scenario)
+        result = service.calculate_year(2025)
+
+        self.assertEqual(result.total_cost, 0.0)
+        self.assertEqual(result.quantity, 0.0)
+        self.assertEqual(len(result.interventions), 0)
+        self.assertEqual(len(result.org_units_costs), 0)
+        self.assertEqual(len(result.category_costs), 0)


### PR DESCRIPTION
## What problem is this PR solving?

Handle cost lines with fixed cost.

### Related JIRA tickets

SNT-485

## Changes

- Change input to accept non percentage value
- Transform value to percentage on API instead of FE
- Select content of input on focus
- Cleaned up logic for coverage as we are updating per cost line, we don't need to batch update.
- 

## How to test

Go to SNT interventions.
Add a cost with no population.
Go to a scenario where there is at least one assignment for that intervention.
On budget view, you should see that cost line under the intervention cost. 
By default it should be 0.
Changing the quantity will update the cost, you can verify the value (cost * buffer (1,1) * cost_unit_ratio * coverage).



## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
