### PR TITLE
SNT-510 Move quantity and population to costbreakdown

### DIFF
--- a/services/budget/budget_calculation.py
+++ b/services/budget/budget_calculation.py
@@ -118,23 +118,31 @@ class BudgetCalculationService:
         """
         rows = self._compute_breakdown_line_rows(year)
 
-        intervention_totals = defaultdict(
-            lambda: {"total_cost": Decimal("0"), "total_pop": Decimal("0"), "quantity": Decimal("0")}
-        )
+        intervention_totals = defaultdict(lambda: {"total_cost": Decimal("0")})
         intervention_breakdowns = defaultdict(
             lambda: defaultdict(
-                lambda: {"id": None, "category": None, "total_cost": Decimal("0"), "quantity": Decimal("0")}
+                lambda: {
+                    "id": None,
+                    "category": None,
+                    "total_cost": Decimal("0"),
+                    "quantity": Decimal("0"),
+                    "population": Decimal("0"),
+                }
             )
         )
 
-        org_unit_totals = defaultdict(lambda: {"total_cost": Decimal("0"), "quantity": Decimal("0")})
-        org_unit_intervention_totals = defaultdict(
-            lambda: defaultdict(lambda: {"total_cost": Decimal("0"), "quantity": Decimal("0")})
-        )
+        org_unit_totals = defaultdict(lambda: {"total_cost": Decimal("0")})
+        org_unit_intervention_totals = defaultdict(lambda: defaultdict(lambda: {"total_cost": Decimal("0")}))
         org_unit_intervention_breakdowns = defaultdict(
             lambda: defaultdict(
                 lambda: defaultdict(
-                    lambda: {"id": None, "category": None, "total_cost": Decimal("0"), "quantity": Decimal("0")}
+                    lambda: {
+                        "id": None,
+                        "category": None,
+                        "total_cost": Decimal("0"),
+                        "quantity": Decimal("0"),
+                        "population": Decimal("0"),
+                    }
                 )
             )
         )
@@ -142,25 +150,21 @@ class BudgetCalculationService:
         category_totals = defaultdict(lambda: {"id": None, "total_cost": Decimal("0"), "quantity": Decimal("0")})
 
         total_cost = Decimal("0")
-        total_quantity = Decimal("0")
 
         for row in rows:
             intervention_id = row.intervention_id
 
             intervention_totals[intervention_id]["total_cost"] += row.total_cost
-            intervention_totals[intervention_id]["total_pop"] += row.population
-            intervention_totals[intervention_id]["quantity"] += row.quantity
             intervention_breakdowns[intervention_id][row.cost_line_id]["id"] = row.cost_line_id
             intervention_breakdowns[intervention_id][row.cost_line_id]["category"] = row.category
             intervention_breakdowns[intervention_id][row.cost_line_id]["total_cost"] += row.total_cost
             intervention_breakdowns[intervention_id][row.cost_line_id]["quantity"] += row.quantity
+            intervention_breakdowns[intervention_id][row.cost_line_id]["population"] += row.population
 
             if row.org_unit_id is not None:
                 org_unit_totals[row.org_unit_id]["total_cost"] += row.total_cost
-                org_unit_totals[row.org_unit_id]["quantity"] += row.quantity
 
                 org_unit_intervention_totals[row.org_unit_id][intervention_id]["total_cost"] += row.total_cost
-                org_unit_intervention_totals[row.org_unit_id][intervention_id]["quantity"] += row.quantity
                 org_unit_intervention_breakdowns[row.org_unit_id][intervention_id][row.cost_line_id]["id"] = (
                     row.cost_line_id
                 )
@@ -173,13 +177,15 @@ class BudgetCalculationService:
                 org_unit_intervention_breakdowns[row.org_unit_id][intervention_id][row.cost_line_id]["quantity"] += (
                     row.quantity
                 )
+                org_unit_intervention_breakdowns[row.org_unit_id][intervention_id][row.cost_line_id]["population"] += (
+                    row.population
+                )
 
             category_totals[row.category]["id"] = row.cost_line_id
             category_totals[row.category]["total_cost"] += row.total_cost
             category_totals[row.category]["quantity"] += row.quantity
 
             total_cost += row.total_cost
-            total_quantity += row.quantity
 
         interventions = self._build_interventions(intervention_totals, intervention_breakdowns)
         org_units_costs = self._build_org_units_costs(
@@ -192,7 +198,6 @@ class BudgetCalculationService:
         return BudgetYearResult(
             year=year,
             total_cost=total_cost,
-            quantity=total_quantity,
             interventions=interventions,
             org_units_costs=org_units_costs,
             category_costs=category_costs,
@@ -301,6 +306,7 @@ class BudgetCalculationService:
                     category=bd["category"],
                     total_cost=bd["total_cost"],
                     quantity=bd["quantity"],
+                    population=bd["population"],
                 )
                 for _, bd in sorted(intervention_breakdowns[intervention_id].items(), key=lambda x: x[0])
                 if bd["total_cost"] > 0
@@ -314,8 +320,6 @@ class BudgetCalculationService:
                     code=intervention_meta.get("code", ""),
                     type=intervention_meta.get("type", ""),
                     total_cost=totals["total_cost"],
-                    total_pop=totals["total_pop"],
-                    quantity=totals["quantity"],
                     cost_breakdown=breakdown_items,
                 )
             )
@@ -346,6 +350,7 @@ class BudgetCalculationService:
                         category=bd["category"],
                         total_cost=bd["total_cost"],
                         quantity=bd["quantity"],
+                        population=bd["population"],
                     )
                     for _, bd in sorted(
                         org_unit_intervention_breakdowns[org_unit_id][intervention_id].items(), key=lambda x: x[0]
@@ -362,7 +367,6 @@ class BudgetCalculationService:
                         code=intervention_meta.get("code", ""),
                         type=intervention_meta.get("type", ""),
                         total_cost=iv_totals["total_cost"],
-                        quantity=iv_totals["quantity"],
                         cost_breakdown=breakdown_items,
                     )
                 )
@@ -371,7 +375,6 @@ class BudgetCalculationService:
                 BudgetOrgUnitItem(
                     org_unit_id=org_unit_id,
                     total_cost=totals["total_cost"],
-                    quantity=totals["quantity"],
                     interventions=intervention_items,
                 )
             )

--- a/services/budget/dataclasses.py
+++ b/services/budget/dataclasses.py
@@ -16,6 +16,7 @@ class BudgetBreakdownItem(BudgetBaseModel):
     category: str
     total_cost: Decimal = Decimal("0.0")
     quantity: Decimal = Decimal("0.0")
+    population: Decimal = Decimal("0.0")
 
 
 class BudgetInterventionItem(BudgetBaseModel):
@@ -23,8 +24,6 @@ class BudgetInterventionItem(BudgetBaseModel):
     code: str
     type: str
     total_cost: Decimal = Decimal("0.0")
-    total_pop: Decimal = Decimal("0.0")
-    quantity: Decimal = Decimal("0.0")
     cost_breakdown: list[BudgetBreakdownItem] = Field(default_factory=list)
 
 
@@ -33,21 +32,18 @@ class BudgetOrgUnitInterventionItem(BudgetBaseModel):
     code: str
     type: str
     total_cost: Decimal = Decimal("0.0")
-    quantity: Decimal = Decimal("0.0")
     cost_breakdown: list[BudgetBreakdownItem] = Field(default_factory=list)
 
 
 class BudgetOrgUnitItem(BudgetBaseModel):
     org_unit_id: int
     total_cost: Decimal = Decimal("0.0")
-    quantity: Decimal = Decimal("0.0")
     interventions: list[BudgetOrgUnitInterventionItem] = Field(default_factory=list)
 
 
 class BudgetYearResult(BudgetBaseModel):
     year: int
     total_cost: Decimal
-    quantity: Decimal
     interventions: list[BudgetInterventionItem]
     org_units_costs: list[BudgetOrgUnitItem]
     category_costs: list[BudgetBreakdownItem]

--- a/tests/api/budget/test_views.py
+++ b/tests/api/budget/test_views.py
@@ -307,10 +307,10 @@ class BudgetAPITestCase(SNTMalariaAPITestCase):
 
         self.assertIsNotNone(smc_intervention, "SMC intervention should be in the budget")
         self.assertEqual(smc_intervention["total_cost"], 687500.0)
-        self.assertEqual(smc_intervention["total_pop"], 250000.0)
         self.assertEqual(len(smc_intervention["cost_breakdown"]), 1)
         self.assertEqual(smc_intervention["cost_breakdown"][0]["category"], "Procurement")
         self.assertEqual(smc_intervention["cost_breakdown"][0]["total_cost"], 687500.0)
+        self.assertEqual(smc_intervention["cost_breakdown"][0]["population"], 250000.0)
 
         # Find Org unit cost
         smc_org_unit_costs = None
@@ -370,10 +370,10 @@ class BudgetAPITestCase(SNTMalariaAPITestCase):
         # Internal calculator currently uses ScenarioYearlyCostAssignment for yearly multipliers,
         # and does not yet apply BudgetAssumptions coverage in the computation pipeline.
         self.assertAlmostEqual(smc_intervention["total_cost"], 687500.0)
-        self.assertAlmostEqual(smc_intervention["total_pop"], 250000.0)
         self.assertEqual(len(smc_intervention["cost_breakdown"]), 1)
         self.assertEqual(smc_intervention["cost_breakdown"][0]["category"], "Procurement")
         self.assertAlmostEqual(smc_intervention["cost_breakdown"][0]["total_cost"], 687500.0)
+        self.assertAlmostEqual(smc_intervention["cost_breakdown"][0]["population"], 250000.0)
         # Find Org unit cost
         smc_org_unit_costs = None
         for org_unit_costs in budget_2025["org_units_costs"]:

--- a/tests/services/test_budget.py
+++ b/tests/services/test_budget.py
@@ -120,12 +120,6 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
 
         result = service.calculate_year(2025)
 
-        # quantity = pop * yearly_value * ratio
-        # district_1: 1000 * 1.2 * 0.5 = 600
-        # district_2: 2000 * 1.2 * 0.5 = 1200
-        # total quantity = 1800
-        self.assertEqual(result.quantity, 1800.0)
-
         # cost = quantity * unit_cost(2.0) * buffer(1.1)
         # district_1 = 1200 * 1.1 = 1320, district_2 = 2400 * 1.1 = 2640, total = 3960
         self.assertEqual(result.total_cost, 3960.0)
@@ -133,20 +127,21 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
         self.assertEqual(len(result.interventions), 1)
         intervention = result.interventions[0]
         self.assertEqual(intervention.code, "smc")
-        self.assertEqual(intervention.quantity, 1800.0)
-        self.assertEqual(intervention.total_pop, 3000.0)
         self.assertEqual(intervention.total_cost, 3960.0)
         self.assertEqual(len(intervention.cost_breakdown), 1)
-        self.assertEqual(intervention.cost_breakdown[0].category, "Procurement")
-        self.assertEqual(intervention.cost_breakdown[0].total_cost, 3960.0)
+        breakdown = intervention.cost_breakdown[0]
+        self.assertEqual(breakdown.category, "Procurement")
+        self.assertEqual(breakdown.total_cost, 3960.0)
+        # quantity = district_1(600) + district_2(1200) = 1800
+        self.assertEqual(breakdown.quantity, 1800.0)
+        # population = district_1(1000) + district_2(2000) = 3000
+        self.assertEqual(breakdown.population, 3000.0)
 
         self.assertEqual(len(result.org_units_costs), 2)
         district_1_result = result.org_units_costs[0]
         district_2_result = result.org_units_costs[1]
 
-        self.assertEqual(district_1_result.quantity, 600.0)
         self.assertEqual(district_1_result.total_cost, 1320.0)
-        self.assertEqual(district_2_result.quantity, 1200.0)
         self.assertEqual(district_2_result.total_cost, 2640.0)
 
         self.assertEqual(len(result.category_costs), 1)
@@ -162,7 +157,6 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
         # default yearly value = 1
         # quantity = (1500 + 2500) * 1 * 0.5 = 2000
         # total_cost = 2000 * 2 * 1.1 * (1 + 0.03)^1 = 4532
-        self.assertEqual(result.quantity, 2000.0)
         self.assertEqual(result.total_cost, 4532.0)
 
     def test_missing_population_layer_line_does_not_contribute(self):
@@ -180,13 +174,12 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
 
         result = service.calculate_year(2025)
 
-        self.assertEqual(result.quantity, 600.0)
         self.assertEqual(result.total_cost, 1320.0)
         self.assertEqual(len(result.org_units_costs), 1)
         self.assertEqual(result.org_units_costs[0].org_unit_id, self.district_1.id)
         self.assertEqual(len(result.interventions), 1)
         self.assertEqual(result.interventions[0].code, "smc")
-        self.assertEqual(result.interventions[0].quantity, 600.0)
+        self.assertEqual(result.interventions[0].cost_breakdown[0].quantity, 600.0)
         self.assertEqual(result.interventions[0].total_cost, 1320.0)
 
     def test_no_assignments_results_in_zero_quantity_and_cost(self):
@@ -197,7 +190,6 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
 
         result = service.calculate_year(2025)
 
-        self.assertEqual(result.quantity, 0.0)
         self.assertEqual(result.total_cost, 0.0)
         self.assertEqual(len(result.interventions), 0)
         self.assertEqual(len(result.org_units_costs), 0)
@@ -211,7 +203,6 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
 
         result = service.calculate_year(2025)
 
-        self.assertEqual(result.quantity, 0.0)
         self.assertEqual(result.total_cost, 0.0)
         self.assertEqual(len(result.interventions), 0)
         self.assertEqual(len(result.org_units_costs), 0)
@@ -226,7 +217,6 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
 
         # quantity = (1500 + 2500) * 1 * 0.5 = 2000
         # total_cost = 2000 * 2 * 1.1 * (1 + 0)^1 = 4400
-        self.assertEqual(result.quantity, 2000.0)
         self.assertEqual(result.total_cost, 4400.0)
 
     def test_missing_yearly_multiplier_and_inflation_rate_results_in_cost_without_multipliers(self):
@@ -239,7 +229,6 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
 
         # quantity = (1500 + 2500) * 1 * 0.5 = 2000
         # total_cost = 2000 * 2 * 1.1 = 4400
-        self.assertEqual(result.quantity, 2000.0)
         self.assertEqual(result.total_cost, 4400.0)
 
     def test_fixed_cost_not_included_when_intervention_has_no_org_unit_assignment(self):
@@ -269,7 +258,6 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
         result = service.calculate_year(2025)
 
         self.assertEqual(result.total_cost, 0.0)
-        self.assertEqual(result.quantity, 0.0)
         self.assertEqual(len(result.interventions), 0)
         self.assertEqual(len(result.org_units_costs), 0)
         self.assertEqual(len(result.category_costs), 0)
@@ -304,10 +292,10 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
 
         # quantity = 4 * ratio(0.5) = 2.0
         # total_cost = 2 * unit_cost(100) * buffer(1.1) * inflation_multiplier(1.0) = 220.0
-        self.assertEqual(result.quantity, 2.0)
         self.assertEqual(result.total_cost, 220.0)
         self.assertEqual(len(result.interventions), 1)
         self.assertEqual(result.interventions[0].total_cost, 220.0)
+        self.assertEqual(result.interventions[0].cost_breakdown[0].quantity, 2.0)
         # Fixed costs are not attributed to specific org units.
         self.assertEqual(len(result.org_units_costs), 0)
 
@@ -427,7 +415,6 @@ class BudgetCalculationServiceTestCase(SNTMalariaTestCase):
         result = service.calculate_year(2025)
 
         self.assertEqual(result.total_cost, 0.0)
-        self.assertEqual(result.quantity, 0.0)
         self.assertEqual(len(result.interventions), 0)
         self.assertEqual(len(result.org_units_costs), 0)
         self.assertEqual(len(result.category_costs), 0)


### PR DESCRIPTION
## What problem is this PR solving?

Move quantity and population to costbreakdown

### Related JIRA tickets

SNT-510

## Changes

Update budget result population and quantity to be part of cost breakdown instead of intervention, org unit or total budget.

## How to test

This data is not showned at the moment, so tests are the only way to verify this.

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
