### PR TITLE
SNT-511: Fix keys on intervention form

### DIFF
--- a/js/src/domains/settings/interventions/components/InterventionForm.tsx
+++ b/js/src/domains/settings/interventions/components/InterventionForm.tsx
@@ -84,24 +84,28 @@ export const InterventionForm: FC = () => {
             <Stack spacing={2} direction="column">
                 {values.cost_breakdown_lines &&
                     values.cost_breakdown_lines.length > 0 &&
-                    values.cost_breakdown_lines.map((line, index) => (
-                        <InterventionCostBreakdownLineForm
-                            key={`cost-details-row-${line.id}`}
-                            costBreakdownLine={line}
-                            onUpdateField={(field, value) =>
-                                setChildFieldValueAndState(
-                                    'cost_breakdown_lines',
-                                    index,
-                                    field,
-                                    value,
-                                )
-                            }
-                            onRemove={() =>
-                                removeChildValue('cost_breakdown_lines', index)
-                            }
-                            getErrors={field => getChildError(field, index)}
-                        />
-                    ))}
+                    React.Children.toArray(
+                        values.cost_breakdown_lines.map((line, index) => (
+                            <InterventionCostBreakdownLineForm
+                                costBreakdownLine={line}
+                                onUpdateField={(field, value) =>
+                                    setChildFieldValueAndState(
+                                        'cost_breakdown_lines',
+                                        index,
+                                        field,
+                                        value,
+                                    )
+                                }
+                                onRemove={() =>
+                                    removeChildValue(
+                                        'cost_breakdown_lines',
+                                        index,
+                                    )
+                                }
+                                getErrors={field => getChildError(field, index)}
+                            />
+                        )),
+                    )}
                 <Button
                     variant="text"
                     sx={{ alignSelf: 'flex-start' }}

--- a/js/src/domains/settings/interventions/index.tsx
+++ b/js/src/domains/settings/interventions/index.tsx
@@ -75,6 +75,7 @@ export const InterventionSettings: FC = () => {
                 <CardScrollable>
                     {selectedIntervention && (
                         <InterventionFormWrapper
+                            key={selectedIntervention.id}
                             interventionId={selectedIntervention.id}
                         />
                     )}


### PR DESCRIPTION
## What problem is this PR solving?

Fix keys on intervention form which ended up seeing duplicate rows

### Related JIRA tickets

SNT-511

## Changes

Properly set keys on intervention form.

## How to test

Before checking out this PR, try to reproduce it by going to **intervention settings** find one with no cost breakdown line in it.
Add two or more lines, save, you should now see twice of them.
Go to another intervention, it'll display those two even though it doesn't belong to that intervention.

Now, checkout this branch and try again, it should work better.

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
