### PR TITLE
Feature SNT-502: cost unit type seeding

### DIFF
--- a/js/src/domains/planning/index.tsx
+++ b/js/src/domains/planning/index.tsx
@@ -5,10 +5,10 @@ import {
     useRedirectToReplace,
     useSafeIntl,
 } from 'bluesquare-components';
-import { useNavigate } from 'react-router';
 import TopBar from 'Iaso/components/nav/TopBarComponent';
 import { useParamsObject } from 'Iaso/routing/hooks/useParamsObject';
 import { SxStyles } from 'Iaso/types/general';
+import { useNavigate } from 'react-router';
 import { CardStyled } from '../../components/CardStyled';
 import {
     MainColumn,

--- a/js/src/domains/settings/interventions/components/InterventionForm.tsx
+++ b/js/src/domains/settings/interventions/components/InterventionForm.tsx
@@ -41,12 +41,16 @@ export const InterventionForm: FC = () => {
     });
 
     const defaultBreakdownLine: Partial<InterventionCostBreakdownLine> =
-        useMemo(
-            () => ({
-                unit_type: costUnitTypeOptions[0]?.value || '',
-            }),
-            [costUnitTypeOptions],
-        );
+        useMemo(() => {
+            // "Each" is the seeded default unit (ratio 1); fall back to the
+            // first option for accounts that renamed or removed it.
+            const defaultUnit =
+                costUnitTypeOptions.find(option => option.label === 'Each') ??
+                costUnitTypeOptions[0];
+            return {
+                unit_type: defaultUnit?.value || '',
+            };
+        }, [costUnitTypeOptions]);
 
     return (
         <Stack spacing={3}>

--- a/management/commands/seed_interventions.py
+++ b/management/commands/seed_interventions.py
@@ -6,8 +6,19 @@ from .support.intervention_seeder import InterventionSeeder
 
 
 class Command(BaseCommand):
-    help = "Populate the database with intervention categories and interventions"
+    help = "Populate the database with cost unit types, intervention categories and interventions"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--cost-units-only",
+            action="store_true",
+            help="Only seed/update the default cost unit types and migrate legacy ones, without touching interventions",
+        )
 
     def handle(self, *args, **options):
         for account in Account.objects.all():
-            InterventionSeeder(account, self.stdout.write).create_interventions()
+            seeder = InterventionSeeder(account, self.stdout.write)
+            if options["cost_units_only"]:
+                seeder.seed_cost_unit_types()
+            else:
+                seeder.create_interventions()

--- a/management/commands/support/intervention_seeder.py
+++ b/management/commands/support/intervention_seeder.py
@@ -1,19 +1,146 @@
 """
-Create interventions for a given account
+Create cost unit types and interventions for a given account
 """
 
-from iaso.models import User
+from decimal import Decimal
+
+from iaso.models import MetricType, User
 from plugins.snt_malaria.models.budget_settings import BudgetSettings
-from plugins.snt_malaria.models.cost_breakdown import (
-    InterventionCostBreakdownLine,
-    InterventionCostUnitType,
-)
+from plugins.snt_malaria.models.cost_breakdown import InterventionCostBreakdownLine
 from plugins.snt_malaria.models.cost_unit_type import CostUnitType
 from plugins.snt_malaria.models.intervention import Intervention, InterventionAssignment, InterventionCategory
 
 
 # Alias for brevity
 CostCategory = InterventionCostBreakdownLine.InterventionCostBreakdownLineCategory
+
+# Explicit \n-joined strings (not triple-quoted) so the stored text keeps its
+# blank lines and the intentionally indented middle line, without picking up
+# Python source indentation.
+SP_TABLET_0_1_DESCRIPTION = (
+    "Each eligible child receives SP at four routine immunization touchpoints per year, "
+    "with age-specific dosing:"
+    "\n\n"
+    "    Children aged 0\u20131 years receive 1 tablet of SP per contact."
+    "\n\n"
+    "To account for underdosing due to low weight, which affects approximately 25% of children "
+    "in each age group, a scaling factor of 0.75 is applied to both age groups. This factor "
+    "reflects the average reduction in tablets required due to dose adjustment "
+    "(e.g., half tablets for underweight infants)."
+)
+
+SP_TABLET_1_2_DESCRIPTION = (
+    "Each eligible child receives SP at four routine immunization touchpoints per year, "
+    "with age-specific dosing:"
+    "\n\n"
+    "    Children aged 1\u20132 years receive 2 tablets of SP per contact."
+    "\n\n"
+    "To account for underdosing due to low weight, which affects approximately 25% of children "
+    "in each age group, a scaling factor of 0.75 is applied to both age groups. This factor "
+    "reflects the average reduction in tablets required due to dose adjustment "
+    "(e.g., half tablets for underweight infants)."
+)
+
+# Default cost unit types seeded for every account.
+# `value` is interpreted via `invert_value` to produce the canonical ratio
+# (invert_value=True means ratio = 1 / value).
+COST_UNIT_TYPES = [
+    {
+        "name": "Net",
+        "value": Decimal("1.8"),
+        "invert_value": True,
+        "description": "One net is assumed to protect 1.8 people by default.",
+    },
+    {
+        "name": "Bale",
+        "value": Decimal("90"),
+        "invert_value": True,
+        "description": "One bale contains enough nets to cover 90 people people. "
+        "(1.8 person per net * 50 nets per bale)",
+    },
+    {
+        "name": "IPTp Blister Pack",
+        "value": Decimal("3"),
+        "invert_value": False,
+        "description": "Number of ANC touchpoints per woman",
+    },
+    {
+        "name": "SMC 3 cycles",
+        "value": Decimal("3"),
+        "invert_value": False,
+        "description": "Number of monthly cycles",
+    },
+    {
+        "name": "SMC 4 cycles",
+        "value": Decimal("4"),
+        "invert_value": False,
+        "description": "Number of monthly cycles",
+    },
+    {
+        "name": "SMC 5 cycles",
+        "value": Decimal("5"),
+        "invert_value": False,
+        "description": "Number of monthly cycles",
+    },
+    {
+        "name": "SP Tablet 0-1",
+        "value": Decimal("0.75"),
+        "invert_value": False,
+        "description": SP_TABLET_0_1_DESCRIPTION,
+    },
+    {
+        "name": "SP Tablet 1-2",
+        "value": Decimal("1.5"),
+        "invert_value": False,
+        "description": SP_TABLET_1_2_DESCRIPTION,
+    },
+    {
+        "name": "Vaccine dose",
+        "value": Decimal("4"),
+        "invert_value": False,
+        "description": "Four vaccine doses are assumed per person reached.",
+    },
+    {
+        "name": "Days",
+        "value": Decimal("1"),
+        "invert_value": False,
+        "description": "Number of days",
+    },
+    {
+        "name": "Each",
+        "value": Decimal("1"),
+        "invert_value": False,
+        "description": "Default unit",
+    },
+]
+
+# Legacy enum-label unit names -> new default unit names. These rows were
+# created by the enum->model conversion in migration
+# 0041_costunittype_and_costbreakdown_updates (one CostUnitType per account per
+# legacy InterventionCostUnitType key, named with the enum label) and by
+# earlier runs of this seeder.
+LEGACY_UNIT_MAPPING = {
+    "per ITN": "Net",
+    "per bale": "Bale",
+    "per SP": "IPTp Blister Pack",
+    "per SPAQ pack 3-11 month olds": "SP Tablet 0-1",
+    "per SPAQ pack 12-59 month olds": "SP Tablet 1-2",
+    "per child": "Each",
+    "per dose": "Vaccine dose",
+}
+
+# Legacy labels without a sensible counterpart in the new units. "Other" in
+# particular must not be auto-mapped: migration 0041 dumped every unknown
+# legacy key into it, so its lines could be anything. These are only reported
+# so they can be handled manually.
+UNMAPPED_LEGACY_UNIT_NAMES = [
+    "per SPAQ pack 5-10 years olds",
+    "per RDT kit",
+    "per AL",
+    "per 60mg powder",
+    "per RAS",
+    "Other",
+]
 
 # Hard code for now to match InterventionSettings.tsx startYear
 
@@ -52,14 +179,16 @@ CATEGORIES_AND_INTERVENTIONS = {
                     {
                         "name": "IPTp (SP) Procurement",
                         "unit_cost": "0.51",
-                        "unit_type": InterventionCostUnitType.PER_SP,
+                        "unit_type": "IPTp Blister Pack",
                         "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
                     },
                     {
                         "name": "IPTp (SP) Distribution",
                         "unit_cost": "0.13",
-                        "unit_type": InterventionCostUnitType.PER_SP,
+                        "unit_type": "IPTp Blister Pack",
                         "category": CostCategory.DELIVERY,
+                        "population_layer_code": None,
                     },
                 ],
             },
@@ -76,14 +205,23 @@ CATEGORIES_AND_INTERVENTIONS = {
                     {
                         "name": "PMC (SP) Procurement",
                         "unit_cost": "0.20",
-                        "unit_type": InterventionCostUnitType.PER_SP,
+                        "unit_type": "SP Tablet 0-1",
                         "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
+                    },
+                    {
+                        "name": "PMC (SP) Procurement",
+                        "unit_cost": "0.20",
+                        "unit_type": "SP Tablet 1-2",
+                        "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
                     },
                     {
                         "name": "PMC (SP) Operational",
                         "unit_cost": "0.08",
-                        "unit_type": InterventionCostUnitType.PER_CHILD,
+                        "unit_type": "Each",
                         "category": CostCategory.OPERATIONAL,
+                        "population_layer_code": None,
                     },
                 ],
             },
@@ -94,23 +232,25 @@ CATEGORIES_AND_INTERVENTIONS = {
                 "description": "",
                 "cost_settings": [
                     {
-                        "id": 196,
                         "name": "SMC (SP+AQ) Procurement",
                         "unit_cost": "0.24",
-                        "unit_type": InterventionCostUnitType.PER_SPAQ_3_11_MONTHS,
+                        "unit_type": "SP Tablet 0-1",
                         "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
                     },
                     {
                         "name": "SMC (SP+AQ) Procurement",
                         "unit_cost": "0.27",
-                        "unit_type": InterventionCostUnitType.PER_SPAQ_12_59_MONTHS,
+                        "unit_type": "SP Tablet 1-2",
                         "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
                     },
                     {
                         "name": "SMC (SP+AQ) Operational",
                         "unit_cost": "1.33",
-                        "unit_type": InterventionCostUnitType.PER_CHILD,
+                        "unit_type": "Each",
                         "category": CostCategory.OPERATIONAL,
+                        "population_layer_code": None,
                     },
                 ],
             },
@@ -148,14 +288,16 @@ CATEGORIES_AND_INTERVENTIONS = {
                     {
                         "name": "Dual AI Procurement",
                         "unit_cost": "3.49",
-                        "unit_type": InterventionCostUnitType.PER_ITN,
+                        "unit_type": "Net",
                         "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
                     },
                     {
                         "name": "Dual AI Distribution",
                         "unit_cost": "6.25",
-                        "unit_type": InterventionCostUnitType.PER_BALE,
+                        "unit_type": "Bale",
                         "category": CostCategory.DELIVERY,
+                        "population_layer_code": None,
                     },
                 ],
             },
@@ -168,14 +310,16 @@ CATEGORIES_AND_INTERVENTIONS = {
                     {
                         "name": "PBO Procurement",
                         "unit_cost": "3.49",
-                        "unit_type": InterventionCostUnitType.PER_ITN,
+                        "unit_type": "Net",
                         "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
                     },
                     {
                         "name": "PBO Distribution",
                         "unit_cost": "6.25",
-                        "unit_type": InterventionCostUnitType.PER_BALE,
+                        "unit_type": "Bale",
                         "category": CostCategory.DELIVERY,
+                        "population_layer_code": None,
                     },
                 ],
             },
@@ -188,14 +332,16 @@ CATEGORIES_AND_INTERVENTIONS = {
                     {
                         "name": "Standard Pyrethroid Procurement",
                         "unit_cost": "0.87",
-                        "unit_type": InterventionCostUnitType.PER_ITN,
+                        "unit_type": "Net",
                         "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
                     },
                     {
                         "name": "Standard Pyrethroid Distribution",
                         "unit_cost": "6.25",
-                        "unit_type": InterventionCostUnitType.PER_BALE,
+                        "unit_type": "Bale",
                         "category": CostCategory.DELIVERY,
+                        "population_layer_code": None,
                     },
                 ],
             },
@@ -212,14 +358,16 @@ CATEGORIES_AND_INTERVENTIONS = {
                     {
                         "name": "Dual AI Procurement",
                         "unit_cost": "3.49",
-                        "unit_type": InterventionCostUnitType.PER_ITN,
+                        "unit_type": "Net",
                         "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
                     },
                     {
                         "name": "Dual AI Operational",
                         "unit_cost": "0.36",
-                        "unit_type": InterventionCostUnitType.PER_ITN,
+                        "unit_type": "Net",
                         "category": CostCategory.OPERATIONAL,
+                        "population_layer_code": None,
                     },
                 ],
             },
@@ -232,14 +380,16 @@ CATEGORIES_AND_INTERVENTIONS = {
                     {
                         "name": "PBO Procurement",
                         "unit_cost": "0.87",
-                        "unit_type": InterventionCostUnitType.PER_ITN,
+                        "unit_type": "Net",
                         "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
                     },
                     {
                         "name": "PBO Operational",
                         "unit_cost": "0.36",
-                        "unit_type": InterventionCostUnitType.PER_ITN,
+                        "unit_type": "Net",
                         "category": CostCategory.OPERATIONAL,
+                        "population_layer_code": None,
                     },
                 ],
             },
@@ -252,14 +402,16 @@ CATEGORIES_AND_INTERVENTIONS = {
                     {
                         "name": "Standard Pyrethroid Procurement",
                         "unit_cost": "3.49",
-                        "unit_type": InterventionCostUnitType.PER_ITN,
+                        "unit_type": "Net",
                         "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
                     },
                     {
                         "name": "Standard Pyrethroid Operational",
                         "unit_cost": "0.36",
-                        "unit_type": InterventionCostUnitType.PER_ITN,
+                        "unit_type": "Net",
                         "category": CostCategory.OPERATIONAL,
+                        "population_layer_code": None,
                     },
                 ],
             },
@@ -276,14 +428,16 @@ CATEGORIES_AND_INTERVENTIONS = {
                     {
                         "name": "Dual AI Procurement",
                         "unit_cost": "3.49",
-                        "unit_type": InterventionCostUnitType.PER_ITN,
+                        "unit_type": "Net",
                         "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
                     },
                     {
                         "name": "Dual AI Distribution",
                         "unit_cost": "6.25",
-                        "unit_type": InterventionCostUnitType.PER_BALE,
+                        "unit_type": "Bale",
                         "category": CostCategory.DELIVERY,
+                        "population_layer_code": None,
                     },
                 ],
             },
@@ -296,14 +450,16 @@ CATEGORIES_AND_INTERVENTIONS = {
                     {
                         "name": "PBO Procurement",
                         "unit_cost": "3.49",
-                        "unit_type": InterventionCostUnitType.PER_ITN,
+                        "unit_type": "Net",
                         "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
                     },
                     {
                         "name": "PBO Distribution",
                         "unit_cost": "6.25",
-                        "unit_type": InterventionCostUnitType.PER_BALE,
+                        "unit_type": "Bale",
                         "category": CostCategory.DELIVERY,
+                        "population_layer_code": None,
                     },
                 ],
             },
@@ -316,14 +472,16 @@ CATEGORIES_AND_INTERVENTIONS = {
                     {
                         "name": "Standard Pyrethroid Procurement",
                         "unit_cost": "0.87",
-                        "unit_type": InterventionCostUnitType.PER_ITN,
+                        "unit_type": "Net",
                         "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
                     },
                     {
                         "name": "Standard Pyrethroid Distribution",
                         "unit_cost": "6.25",
-                        "unit_type": InterventionCostUnitType.PER_BALE,
+                        "unit_type": "Bale",
                         "category": CostCategory.DELIVERY,
+                        "population_layer_code": None,
                     },
                 ],
             },
@@ -340,14 +498,16 @@ CATEGORIES_AND_INTERVENTIONS = {
                     {
                         "name": "R21 Procurement",
                         "unit_cost": "4.00",
-                        "unit_type": InterventionCostUnitType.PER_DOSE,
+                        "unit_type": "Vaccine dose",
                         "category": CostCategory.PROCUREMENT,
+                        "population_layer_code": None,
                     },
                     {
                         "name": "R21 Operational",
                         "unit_cost": "1.00",
-                        "unit_type": InterventionCostUnitType.PER_CHILD,
+                        "unit_type": "Each",
                         "category": CostCategory.OPERATIONAL,
+                        "population_layer_code": None,
                     },
                 ],
             },
@@ -377,32 +537,101 @@ class InterventionSeeder:
         self.account = account
         self.stdout_write = stdout_writer or print
 
+    def seed_cost_unit_types(self, print_progress=True):
+        """Upsert the default cost unit types and migrate legacy enum-label units.
+
+        Idempotent and non-destructive (apart from removing legacy units whose
+        lines have been re-pointed), so it is safe to run standalone on live
+        accounts.
+        """
+        created_count = 0
+        updated_count = 0
+        for unit_data in COST_UNIT_TYPES:
+            _, created = CostUnitType.objects.update_or_create(
+                account=self.account,
+                name=unit_data["name"],
+                defaults={
+                    "value": unit_data["value"],
+                    "invert_value": unit_data["invert_value"],
+                    "description": unit_data["description"],
+                },
+            )
+            if created:
+                created_count += 1
+            else:
+                updated_count += 1
+        if print_progress:
+            self.stdout_write(
+                f"Cost unit types for account {self.account.name}: {created_count} created, {updated_count} updated"
+            )
+
+        self._migrate_legacy_cost_unit_types(print_progress)
+
+    def _migrate_legacy_cost_unit_types(self, print_progress):
+        """Re-point breakdown lines from legacy enum-label units to the new ones,
+        then delete the legacy unit rows."""
+        legacy_units = CostUnitType.objects.filter(account=self.account, name__in=LEGACY_UNIT_MAPPING.keys())
+        for legacy_unit in legacy_units:
+            new_unit = CostUnitType.objects.get(account=self.account, name=LEGACY_UNIT_MAPPING[legacy_unit.name])
+            moved_lines = InterventionCostBreakdownLine.objects.filter(unit_type=legacy_unit).update(unit_type=new_unit)
+            legacy_unit.delete()
+            if print_progress:
+                self.stdout_write(
+                    f"\tMigrated legacy cost unit '{legacy_unit.name}' -> '{new_unit.name}' "
+                    f"({moved_lines} cost breakdown lines re-pointed)"
+                )
+
+        unmapped_units = CostUnitType.objects.filter(account=self.account, name__in=UNMAPPED_LEGACY_UNIT_NAMES)
+        for unmapped_unit in unmapped_units:
+            if print_progress:
+                self.stdout_write(
+                    f"\tLegacy cost unit '{unmapped_unit.name}' has no mapping to a new unit, "
+                    "left untouched - please review manually"
+                )
+
     def create_interventions(self):
+        # Always seed/refresh cost unit types, even when intervention seeding
+        # is skipped below.
+        self.seed_cost_unit_types()
+
         if InterventionCategory.objects.filter(account=self.account).exists():
             response = (
                 input(
-                    f"Interventions already exist for account {self.account.name}. Do you want to override them? (y/N): "
+                    f"Interventions already exist for account {self.account.name}. "
+                    "Do you want to override them? Answering 'n' keeps them and only creates missing ones. (y/N): "
                 )
                 .strip()
                 .lower()
             )
             if response != "y":
-                self.stdout_write(f"Skipping account {self.account.name}, already has interventions")
-                return
-            # Delete existing interventions and categories for this account
-            InterventionCostBreakdownLine.objects.filter(
-                intervention__intervention_category__account=self.account
-            ).delete()
-            InterventionAssignment.objects.filter(intervention__intervention_category__account=self.account).delete()
-            Intervention.objects.filter(intervention_category__account=self.account).delete()
-            InterventionCategory.objects.filter(account=self.account).delete()
-            self.stdout_write(f"Existing interventions for account {self.account.name} have been deleted.")
+                self.stdout_write(
+                    f"Keeping existing interventions for account {self.account.name}, creating missing ones only"
+                )
+            else:
+                # Delete existing interventions and categories for this account.
+                # Breakdown lines must go first: CostUnitType is protected by them.
+                InterventionCostBreakdownLine.objects.filter(
+                    intervention__intervention_category__account=self.account
+                ).delete()
+                InterventionAssignment.objects.filter(
+                    intervention__intervention_category__account=self.account
+                ).delete()
+                Intervention.objects.filter(intervention_category__account=self.account).delete()
+                InterventionCategory.objects.filter(account=self.account).delete()
+                CostUnitType.objects.filter(account=self.account).delete()
+                self.stdout_write(f"Existing interventions for account {self.account.name} have been deleted.")
+                # Reseed the units from a clean slate.
+                self.seed_cost_unit_types()
 
-        self.stdout_write(f"Creating interventions for account {self.account.name}:")
         created_by = User.objects.filter(iaso_profile__account=self.account).first()
+        if created_by is None:
+            self.stdout_write(f"Skipping interventions for account {self.account.name}: no user to set as created_by")
+            return
+        self.stdout_write(f"Creating interventions for account {self.account.name}:")
         self._create_interventions(created_by)
 
     def create_interventions_for_api_account(self, user):
+        self.seed_cost_unit_types(print_progress=False)
         self._create_interventions(user, print_progress=False)
 
     def _create_interventions(self, user, print_progress=True):
@@ -410,11 +639,14 @@ class InterventionSeeder:
         self._create_budget_settings(print_progress)
 
         for category_name, data in CATEGORIES_AND_INTERVENTIONS.items():
+            # Look up on the unique constraint ([account, name]) only, so
+            # existing rows with a diverging short_name are matched instead of
+            # triggering a duplicate INSERT.
             category, created = InterventionCategory.objects.get_or_create(
                 name=category_name,
-                short_name=data.get("short_name", category_name),
                 account=self.account,
                 defaults={
+                    "short_name": data.get("short_name", category_name),
                     # "description": data["description"],
                     "created_by": user,
                 },
@@ -423,12 +655,13 @@ class InterventionSeeder:
                 self.stdout_write(f"Created category: {category_name}")
 
             for intervention_data in data["interventions"]:
+                # Same here: unique constraint is [intervention_category, name].
                 intervention, created = Intervention.objects.get_or_create(
                     name=intervention_data["name"],
-                    short_name=intervention_data.get("short_name", intervention_data["name"]),
                     intervention_category=category,
-                    code=intervention_data["code"],
                     defaults={
+                        "short_name": intervention_data.get("short_name", intervention_data["name"]),
+                        "code": intervention_data["code"],
                         "description": intervention_data["description"],
                         "created_by": user,
                     },
@@ -459,23 +692,25 @@ class InterventionSeeder:
     def _create_cost_breakdown_lines(self, intervention, cost_settings, created_by, print_progress):
         """Create cost breakdown lines for a given intervention."""
         for cost_data in cost_settings:
-            unit_type_key = (
-                cost_data["unit_type"].value
-                if isinstance(cost_data["unit_type"], InterventionCostUnitType)
-                else cost_data["unit_type"]
-            )
-            unit_type_label = unit_type_key
-            try:
-                unit_type_label = str(InterventionCostUnitType(unit_type_key).label)
-            except ValueError:
-                unit_type_label = str(unit_type_key)
+            # Guaranteed to exist: seed_cost_unit_types() runs before this.
+            unit_type = CostUnitType.objects.get(account=self.account, name=cost_data["unit_type"])
 
-            unit_type, _ = CostUnitType.objects.get_or_create(account=self.account, name=unit_type_label)
+            # Metric layers come from data imports and may not exist yet at
+            # seed time, so resolve leniently and leave the line without a
+            # layer when the code is unknown for this account.
+            population_layer = None
+            if cost_data.get("population_layer_code"):
+                population_layer = MetricType.objects.filter(
+                    account=self.account, code=cost_data["population_layer_code"]
+                ).first()
+
             InterventionCostBreakdownLine.objects.create(
                 intervention=intervention,
                 name=cost_data["name"],
                 category=cost_data["category"],
                 unit_type=unit_type,
+                population_layer=population_layer,
+                cost_driver=InterventionCostBreakdownLine.CostDriver.POPULATION,
                 unit_cost=cost_data["unit_cost"],
                 created_by=created_by,
             )

--- a/migrations/0040_intervention_allowed_cost_unit_types.py
+++ b/migrations/0040_intervention_allowed_cost_unit_types.py
@@ -4,39 +4,39 @@ import django.contrib.postgres.fields
 
 from django.db import migrations, models
 
-from plugins.snt_malaria.models.cost_breakdown import InterventionCostUnitType
-
 
 class Migration(migrations.Migration):
     dependencies = [
         ("snt_malaria", "0039_alter_budgetassumptions_unique_together_and_more"),
     ]
 
+    # Values inlined from the (since removed) InterventionCostUnitType enum:
+    # data migrations must not import from models.
     def add_allowed_cost_unit_types(apps, schema_editor):
         Intervention = apps.get_model("snt_malaria", "Intervention")
         db_alias = schema_editor.connection.alias
         for intervention in Intervention.objects.using(db_alias).all():
             if intervention.code in ["iptp", "pmc"]:
-                intervention.allowed_cost_unit_types = [InterventionCostUnitType.PER_SP.value]
+                intervention.allowed_cost_unit_types = ["PER_SP"]
             elif intervention.code in ["itn_campaign", "itn_school"]:
                 intervention.allowed_cost_unit_types = [
-                    InterventionCostUnitType.PER_ITN.value,
-                    InterventionCostUnitType.PER_BALE.value,
+                    "PER_ITN",
+                    "PER_BALE",
                 ]
             elif intervention.code in ["itn_routine"]:
-                intervention.allowed_cost_unit_types = [InterventionCostUnitType.PER_ITN.value]
+                intervention.allowed_cost_unit_types = ["PER_ITN"]
             elif intervention.code in ["smc", "smc_3", "smc_4", "smc_5"]:
                 intervention.allowed_cost_unit_types = [
-                    InterventionCostUnitType.PER_SPAQ_3_11_MONTHS.value,
-                    InterventionCostUnitType.PER_SPAQ_12_59_MONTHS.value,
+                    "PER_SPAQ_3_11_MONTHS",
+                    "PER_SPAQ_12_59_MONTHS",
                 ]
             elif intervention.code in ["vacc"]:
                 intervention.allowed_cost_unit_types = [
-                    InterventionCostUnitType.PER_CHILD.value,
-                    InterventionCostUnitType.PER_DOSE.value,
+                    "PER_CHILD",
+                    "PER_DOSE",
                 ]
             else:
-                intervention.allowed_cost_unit_types = [InterventionCostUnitType.OTHER.value]
+                intervention.allowed_cost_unit_types = ["OTHER"]
             intervention.save(using=db_alias)
 
     operations = [

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,10 +1,7 @@
 from .account_settings import AccountSettings
 from .budget import Budget
 from .budget_settings import BudgetSettings
-from .cost_breakdown import (
-    InterventionCostBreakdownLine,
-    InterventionCostUnitType,
-)
+from .cost_breakdown import InterventionCostBreakdownLine
 from .cost_unit_type import CostUnitType
 from .impact_org_unit_mapping import ImpactOrgUnitMapping
 from .impact_provider_config import ImpactProviderConfig
@@ -27,7 +24,6 @@ __all__ = [
     "ScenarioRuleInterventionProperties",
     "CostUnitType",
     "InterventionCostBreakdownLine",
-    "InterventionCostUnitType",
     "ScenarioYearlyCostAssignment",
     "ImpactOrgUnitMapping",
     "ImpactProviderConfig",

--- a/models/cost_breakdown.py
+++ b/models/cost_breakdown.py
@@ -5,23 +5,6 @@ from django.utils.translation import gettext_lazy as _
 from plugins.snt_malaria.models.intervention import Intervention
 
 
-# TODO this should be moved to intervention seeder only.
-class InterventionCostUnitType(models.TextChoices):
-    PER_ITN = "PER_ITN", _("per ITN")
-    PER_SP = "PER_SP", _("per SP")
-    PER_CHILD = "PER_CHILD", _("per child")
-    PER_DOSE = "PER_DOSE", _("per dose")
-    PER_SPAQ_3_11_MONTHS = "PER_SPAQ_3_11_MONTHS", _("per SPAQ pack 3-11 month olds")
-    PER_SPAQ_12_59_MONTHS = "PER_SPAQ_12_59_MONTHS", _("per SPAQ pack 12-59 month olds")
-    PER_SPAQ_5_10_YEARS = "PER_SPAQ_5_10_YEARS", _("per SPAQ pack 5-10 years olds")
-    PER_RDT_KIT = "PER_RDT_KIT", _("per RDT kit")
-    PER_AL = "PER_AL", _("per AL")
-    PER_60MG_POWDER = "PER_60MG_POWDER", _("per 60mg powder")
-    PER_RAS = "PER_RAS", _("per RAS")
-    PER_BALE = "PER_BALE", _("per bale")
-    OTHER = "OTHER", _("Other")
-
-
 class InterventionCostBreakdownLine(models.Model):
     class InterventionCostBreakdownLineCategory(models.TextChoices):
         PROCUREMENT = "Procurement", _("Procurement")

--- a/tests/api/account_setup/test_utils.py
+++ b/tests/api/account_setup/test_utils.py
@@ -101,7 +101,7 @@ class SNTAccountSetupAPIUtilsTestCase(TestCase):
         # see intervention_seeder.py to understand why these values
         self.assertEqual(InterventionCategory.objects.filter(account=account).count(), 8)
         self.assertEqual(Intervention.objects.count(), 21)
-        self.assertEqual(InterventionCostBreakdownLine.objects.count(), 27)
+        self.assertEqual(InterventionCostBreakdownLine.objects.count(), 28)
 
     @patch("plugins.snt_malaria.api.account_setup.utils.uuid")
     def test_create_snt_account_error_data_source_already_taken(self, mock_uuid):

--- a/tests/api/account_setup/test_views.py
+++ b/tests/api/account_setup/test_views.py
@@ -65,7 +65,7 @@ class SNTAccountSetupAPITestCase(TaskAPITestCase):
         # see intervention_seeder.py to understand why these values
         self.assertEqual(InterventionCategory.objects.count(), 8)
         self.assertEqual(Intervention.objects.count(), 21)
-        self.assertEqual(InterventionCostBreakdownLine.objects.count(), 27)
+        self.assertEqual(InterventionCostBreakdownLine.objects.count(), 28)
 
         # Checking if the import task was launched with the right parameters
         self.assertEqual(Task.objects.count(), 1)


### PR DESCRIPTION
## What problem is this PR solving?

Seed cost unit types with the intervention seeder

### Related JIRA tickets

SNT-502

## Changes

* Added a `COST_UNIT_TYPES` catalog and a `seed_cost_unit_types()` step that idempotently creates/updates the per-account `CostUnitType` rows (`name`, `value`, `invert_value`, `description`)
* Reworked the cost-line seed data: each breakdown line now references its unit by name plus `population_layer_code` and `cost_driver`, replacing the old `InterventionCostUnitType` enum
* Added `LEGACY_UNIT_MAPPING` to migrate accounts seeded with the old enum labels: existing cost lines are re-pointed to the new units and the legacy unit rows deleted
* Split the cost line "PMC (SP) Procurement" into two lines: "SP Tablet 0–1" and "SP Tablet 1–2" (total seeded lines 27 -> 28)
* Added a `--cost-units-only` flag to the `seed_interventions` command.
* Newly added cost lines default to "Each" now, falling back to the first option

## How to test

### Old types migration

- Before you run anything, check that you have an account with the legacy unit types from the previous enum-to-model migration. You should see something like this (no conversion factor, no description):

   <img width="600" alt="image" src="https://github.com/user-attachments/assets/c5437965-2015-4657-ab63-d540f70d2185" />

- Now first create an additional cost unit type in the interface, e. g. `Test` and enter some values and save it.
- Now run the intervention seeder with:
   ```sh
   docker compose exec iaso ./manage.py seed_interventions --cost-units-only
   ```
- The script should have succeeded and you should have all new unit types (see Table 1 below) plus your manually created `Test` unit type:
   
   <img width="600" alt="image" src="https://github.com/user-attachments/assets/781dbf88-9b2a-4e02-9541-2ba54706c698" />

### From scratch creation

- Utilize account creation to create a fresh account
- Check that all Interventions, Unit Types and cost breakdown lines are present in the new account (refer to Table 1 and Table 2 below)

### Default type

- Make sure you have the new cost unit types seeded in your current account
- Create a new cost breakdown line
- The pre-selected option in the unit dropdown should be `Each`

## Notes

### Table 1: All new Unit types with their values

| Unit type | Value | Direction | Description |
| --- | --- | --- | --- |
| Net | 1.8 | Inverse | One net is assumed to protect 1.8 people by default. |
| Bale | 90 | Inverse | One bale contains enough nets to cover 90 people people. (1.8 person per net * 50 nets per bale) |
| IPTp&nbsp;Blister&nbsp;Pack | 3 | Direct | Number of ANC touchpoints per woman |
| SMC&nbsp;3&nbsp;cycles | 3 | Direct | Number of monthly cycles |
| SMC&nbsp;4&nbsp;cycles | 4 | Direct | Number of monthly cycles |
| SMC&nbsp;5&nbsp;cycles | 5 | Direct | Number of monthly cycles |
| SP&nbsp;Tablet&nbsp;0-1 | 0.75 | Direct | Each eligible child receives SP at four routine immunization touchpoints per year, with age-specific dosing:<br><br>Children aged 0–1 years receive 1 tablet of SP per contact.<br><br>To account for underdosing due to low weight, which affects approximately 25% of children in each age group, a scaling factor of 0.75 is applied to both age groups. This factor reflects the average reduction in tablets required due to dose adjustment (e.g., half tablets for underweight infants). |
| SP&nbsp;Tablet&nbsp;1-2 | 1.5 | Direct | Each eligible child receives SP at four routine immunization touchpoints per year, with age-specific dosing:<br><br>Children aged 1–2 years receive 2 tablets of SP per contact.<br><br>To account for underdosing due to low weight, which affects approximately 25% of children in each age group, a scaling factor of 0.75 is applied to both age groups. This factor reflects the average reduction in tablets required due to dose adjustment (e.g., half tablets for underweight infants). |
| Vaccine&nbsp;dose | 4 | Direct | Four vaccine doses are assumed per person reached. |
| Days | 1 | Direct | Number of days |
| Each | 1 | Direct | Default unit |

### Table 2: All cost breakdown lines that get created

| Intervention&nbsp;category | Intervention | Cost line | Category | Unit&nbsp;type | Unit&nbsp;cost |
| --- | --- | --- | --- | --- | --- |
| IPTp | IPTp (SP) | IPTp (SP) Procurement | Procurement | IPTp&nbsp;Blister&nbsp;Pack | 0.51 |
| IPTp | IPTp (SP) | IPTp (SP) Distribution | Distribution | IPTp&nbsp;Blister&nbsp;Pack | 0.13 |
| PMC & SMC | PMC (SP) | PMC (SP) Procurement | Procurement | SP&nbsp;Tablet&nbsp;0-1 | 0.20 |
| PMC & SMC | PMC (SP) | PMC (SP) Procurement | Procurement | SP&nbsp;Tablet&nbsp;1-2 | 0.20 |
| PMC & SMC | PMC (SP) | PMC (SP) Operational | Operational | Each | 0.08 |
| PMC & SMC | SMC (SP+AQ) | SMC (SP+AQ) Procurement | Procurement | SP&nbsp;Tablet&nbsp;0-1 | 0.24 |
| PMC & SMC | SMC (SP+AQ) | SMC (SP+AQ) Procurement | Procurement | SP&nbsp;Tablet&nbsp;1-2 | 0.27 |
| PMC & SMC | SMC (SP+AQ) | SMC (SP+AQ) Operational | Operational | Each | 1.33 |
| ITN Campaign | Dual AI | Dual AI Procurement | Procurement | Net | 3.49 |
| ITN Campaign | Dual AI | Dual AI Distribution | Distribution | Bale | 6.25 |
| ITN Campaign | PBO | PBO Procurement | Procurement | Net | 3.49 |
| ITN Campaign | PBO | PBO Distribution | Distribution | Bale | 6.25 |
| ITN Campaign | Standard Pyrethroid | Standard Pyrethroid Procurement | Procurement | Net | 0.87 |
| ITN Campaign | Standard Pyrethroid | Standard Pyrethroid Distribution | Distribution | Bale | 6.25 |
| ITN Routine | Dual AI | Dual AI Procurement | Procurement | Net | 3.49 |
| ITN Routine | Dual AI | Dual AI Operational | Operational | Net | 0.36 |
| ITN Routine | PBO | PBO Procurement | Procurement | Net | 0.87 |
| ITN Routine | PBO | PBO Operational | Operational | Net | 0.36 |
| ITN Routine | Standard Pyrethroid | Standard Pyrethroid Procurement | Procurement | Net | 3.49 |
| ITN Routine | Standard Pyrethroid | Standard Pyrethroid Operational | Operational | Net | 0.36 |
| ITN School | Dual AI | Dual AI Procurement | Procurement | Net | 3.49 |
| ITN School | Dual AI | Dual AI Distribution | Distribution | Bale | 6.25 |
| ITN School | PBO | PBO Procurement | Procurement | Net | 3.49 |
| ITN School | PBO | PBO Distribution | Distribution | Bale | 6.25 |
| ITN School | Standard Pyrethroid | Standard Pyrethroid Procurement | Procurement | Net | 0.87 |
| ITN School | Standard Pyrethroid | Standard Pyrethroid Distribution | Distribution | Bale | 6.25 |
| Vaccination | R21 | R21 Procurement | Procurement | Vaccine&nbsp;dose | 4.00 |
| Vaccination | R21 | R21 Operational | Operational | Each | 1.00 |