### PR TITLE
SNT-494 Duplicate yearly costs and calculate budget on scenario duplicate

### DIFF
--- a/api/scenarios/utils.py
+++ b/api/scenarios/utils.py
@@ -207,3 +207,13 @@ def duplicate_rules(scenario_from: Scenario, scenario_to: Scenario, user: User):
             ip.pk = None
             ip.scenario_rule = rule
             ip.save()
+
+
+def duplicate_scenario_yearly_cost_assignment(scenario_from: Scenario, scenario_to: Scenario, user: User):
+    for cost_assignment in scenario_from.yearly_cost_assignments.all():
+        initial_cost_assignment = deepcopy(cost_assignment)
+        initial_cost_assignment.pk = None
+        initial_cost_assignment.scenario = scenario_to
+        initial_cost_assignment.created_by = user
+        initial_cost_assignment.update_by = None
+        initial_cost_assignment.save()

--- a/api/scenarios/utils.py
+++ b/api/scenarios/utils.py
@@ -214,6 +214,4 @@ def duplicate_scenario_yearly_cost_assignment(scenario_from: Scenario, scenario_
         initial_cost_assignment = deepcopy(cost_assignment)
         initial_cost_assignment.pk = None
         initial_cost_assignment.scenario = scenario_to
-        initial_cost_assignment.created_by = user
-        initial_cost_assignment.update_by = None
         initial_cost_assignment.save()

--- a/api/scenarios/views.py
+++ b/api/scenarios/views.py
@@ -17,6 +17,7 @@ from iaso.api.common import CONTENT_TYPE_CSV
 from plugins.snt_malaria.api.scenarios.utils import (
     create_rules_from_import,
     duplicate_rules,
+    duplicate_scenario_yearly_cost_assignment,
     get_csv_headers,
     get_csv_row,
     get_scenario,
@@ -24,6 +25,7 @@ from plugins.snt_malaria.api.scenarios.utils import (
 from plugins.snt_malaria.models import InterventionAssignment, Scenario, ScenarioRule
 from plugins.snt_malaria.models.account_settings import get_intervention_org_units
 from plugins.snt_malaria.models.intervention import Intervention
+from plugins.snt_malaria.services import BudgetCalculationService
 
 from .permissions import ScenarioPermission
 from .serializers import (
@@ -99,8 +101,12 @@ class ScenarioViewSet(viewsets.ModelViewSet):
             raise ValidationError(f"Error saving scenario: {e}")
 
         duplicate_rules(initial_scenario, new_scenario, request.user)
+        duplicate_scenario_yearly_cost_assignment(initial_scenario, new_scenario, request.user)
 
         new_scenario.refresh_assignments(request.user)
+
+        budget_service = BudgetCalculationService(new_scenario)
+        budget_service.calculate_and_save_all_years(request.user)
 
         serializer = ScenarioSerializer(new_scenario)
         return Response(serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
## What problem is this PR solving?

Duplicate yearly costs and calculate budget on scenario duplicate

### Related JIRA tickets

SNT-494

## Changes

Duplicate scenario yearly cost assignments when duplicating scenario
Calculate budget when duplicating scenario

## How to test

Go to a scenario with modified cost assignments. 
Duplicate it, then verify that budget is there for the new scenario and that cost assignments is also the same.
Try to change it and verify that it didn't modify original scenario.

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
