### PR TITLE
Feature SNT-517: Constrained settings layout with max width and more

### DIFF
--- a/js/src/components/styledComponents.tsx
+++ b/js/src/components/styledComponents.tsx
@@ -59,3 +59,11 @@ export const CardScrollable = styled(Card)(({}) => ({
     flexDirection: 'column',
     overflow: 'hidden',
 }));
+
+// Wraps a settings form inside its card, adding top spacing so it doesn't sit
+// flush against the card header. Page-level width capping/centering is done in
+// the settings index, so the form just fills the available width here.
+export const SettingsFormContainer = styled(Box)(({ theme }) => ({
+    width: '100%',
+    paddingTop: theme.spacing(3),
+}));

--- a/js/src/domains/settings/costUnits/components/CostUnitFormWrapper.tsx
+++ b/js/src/domains/settings/costUnits/components/CostUnitFormWrapper.tsx
@@ -5,6 +5,7 @@ import { Button, Stack, Typography } from '@mui/material';
 import { makeFullModal, useSafeIntl } from 'bluesquare-components';
 import { DeleteRestoreModal } from 'Iaso/components/DeleteRestoreModals/DeleteRestoreModal';
 import { CardStyled } from '../../../../components/CardStyled';
+import { SettingsFormContainer } from '../../../../components/styledComponents';
 import { ExtendedFormikProvider } from '../../../../hooks/useGetExtendedFormikContext';
 import { MESSAGES } from '../../../messages';
 import { useCostUnitFormState } from '../hooks/useCostUnitFormState';
@@ -17,6 +18,7 @@ type Props = {
     costUnit?: CostUnitType | null;
     onSaved: (savedId?: number) => void;
     onDeleted: () => void;
+    onCancel: () => void;
 };
 
 const DeleteTriggerButton: FC<{
@@ -44,6 +46,7 @@ export const CostUnitFormWrapper: FC<Props> = ({
     costUnit,
     onSaved,
     onDeleted,
+    onCancel,
 }) => {
     const { formatMessage } = useSafeIntl();
 
@@ -122,6 +125,11 @@ export const CostUnitFormWrapper: FC<Props> = ({
                                 )}
                             </DeleteCostUnitModal>
                         )}
+                        {isNew && (
+                            <Button onClick={onCancel} color="primary">
+                                {formatMessage(MESSAGES.cancel)}
+                            </Button>
+                        )}
                         <Button
                             onClick={() => formik.handleSubmit()}
                             variant="contained"
@@ -136,7 +144,9 @@ export const CostUnitFormWrapper: FC<Props> = ({
             }
         >
             <ExtendedFormikProvider formik={formik}>
-                <CostUnitForm />
+                <SettingsFormContainer>
+                    <CostUnitForm />
+                </SettingsFormContainer>
             </ExtendedFormikProvider>
         </CardStyled>
     );

--- a/js/src/domains/settings/costUnits/index.tsx
+++ b/js/src/domains/settings/costUnits/index.tsx
@@ -47,6 +47,16 @@ export const CostUnitSettings: FC = () => {
         });
     }, [costUnitTypes]);
 
+    // Cancelling creation falls back to the first unit in the list, if any.
+    const handleCancelCreate = useCallback(() => {
+        setIsCreating(false);
+        setSelectedId(
+            costUnitTypes && costUnitTypes.length > 0
+                ? costUnitTypes[0].id
+                : null,
+        );
+    }, [costUnitTypes]);
+
     useEffect(() => {
         if (
             costUnitTypes &&
@@ -116,6 +126,7 @@ export const CostUnitSettings: FC = () => {
                                 }
                             }}
                             onDeleted={handleDeleted}
+                            onCancel={handleCancelCreate}
                         />
                     )}
                 </CardScrollable>

--- a/js/src/domains/settings/index.tsx
+++ b/js/src/domains/settings/index.tsx
@@ -47,7 +47,14 @@ export const Settings: FC = () => {
                 sx={{
                     display: 'flex',
                     flexDirection: 'column',
+                    alignItems: 'center',
                     gap: theme => theme.spacing(2),
+                    // Cap and center the whole settings content (tab bar and
+                    // panels) instead of constraining each form individually.
+                    '& > *': {
+                        width: '100%',
+                        maxWidth: 1440,
+                    },
                 }}
             >
                 <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>

--- a/js/src/domains/settings/interventions/components/InterventionCostBreakdownLineForm.tsx
+++ b/js/src/domains/settings/interventions/components/InterventionCostBreakdownLineForm.tsx
@@ -1,19 +1,12 @@
 import React, { FC } from 'react';
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
-import { Grid, Stack } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { IconButton } from 'bluesquare-components';
 import InputComponent from 'Iaso/components/forms/InputComponent';
-import { SxStyles } from 'Iaso/types/general';
 import { noOp } from 'Iaso/utils';
 import { MESSAGES } from '../../../messages';
 import { useInterventionContext } from '../contexts/InterventionContext';
 import { InterventionCostBreakdownLine } from '../../../interventions/types';
-
-const styles = {
-    inputGrow: {
-        flexGrow: 1,
-    },
-} satisfies SxStyles;
 
 type Props = {
     costBreakdownLine: InterventionCostBreakdownLine;
@@ -36,88 +29,79 @@ export const InterventionCostBreakdownLineForm: FC<Props> = ({
     } = useInterventionContext();
 
     return (
-        <Grid container spacing={1}>
-            <Grid item xs={3}>
-                <InputComponent
-                    keyValue="name"
-                    onChange={onUpdateField}
-                    value={costBreakdownLine.name}
-                    type="text"
-                    label={MESSAGES.detailedCostLabel}
-                    required
-                    errors={getErrors('name')}
-                    withMarginTop={false}
-                    wrapperSx={styles.inputGrow}
-                />
-            </Grid>
-            <Grid item xs={2}>
-                <InputComponent
-                    type="select"
-                    keyValue="category"
-                    multi={false}
-                    withMarginTop={false}
-                    clearable={false}
-                    options={costCategoryOptions}
-                    value={costBreakdownLine.category}
-                    onChange={onUpdateField}
-                    label={MESSAGES.detailedCostCategoryLabel}
-                    errors={getErrors('category')}
-                    wrapperSx={styles.inputGrow}
-                />
-            </Grid>
-            <Grid item xs={1}>
-                <InputComponent
-                    type="number"
-                    keyValue="unit_cost"
-                    onChange={onUpdateField}
-                    required
-                    withMarginTop={false}
-                    label={MESSAGES.detailedCostUnitLabel}
-                    value={costBreakdownLine.unit_cost}
-                    errors={getErrors('unit_cost')}
-                    numberInputOptions={{
-                        decimalScale: 2,
-                        prefix: currencySymbol,
-                    }}
-                    wrapperSx={styles.inputGrow}
-                />
-            </Grid>
-            <Grid item xs={2}>
-                <InputComponent
-                    type="select"
-                    keyValue="unit_type"
-                    multi={false}
-                    withMarginTop={false}
-                    clearable={false}
-                    options={costUnitTypeOptions}
-                    value={costBreakdownLine.unit_type}
-                    onChange={onUpdateField}
-                    label={MESSAGES.unit}
-                    errors={getErrors('unit')}
-                    wrapperSx={styles.inputGrow}
-                />
-            </Grid>
-            <Grid item xs={3} spacing={1}>
-                <InputComponent
-                    type="select"
-                    keyValue="population_layer"
-                    multi={false}
-                    withMarginTop={false}
-                    clearable
-                    options={populationOptions}
-                    value={costBreakdownLine.population_layer || ''}
-                    onChange={onUpdateField}
-                    label={MESSAGES.targetPopulationLabel}
-                    errors={getErrors('population_layer')}
-                    wrapperSx={styles.inputGrow}
-                />
-            </Grid>
-            <Grid
-                item
-                xs={1}
-                display="flex"
-                alignItems="center"
-                justifyContent="flex-start"
+        <Stack direction="row" spacing={1} alignItems="flex-start">
+            <InputComponent
+                keyValue="name"
+                onChange={onUpdateField}
+                value={costBreakdownLine.name}
+                type="text"
+                label={MESSAGES.detailedCostLabel}
+                required
+                errors={getErrors('name')}
+                withMarginTop={false}
+                wrapperSx={{ flex: 3, minWidth: 0 }}
+            />
+            <InputComponent
+                type="select"
+                keyValue="category"
+                multi={false}
+                withMarginTop={false}
+                clearable={false}
+                options={costCategoryOptions}
+                value={costBreakdownLine.category}
+                onChange={onUpdateField}
+                label={MESSAGES.detailedCostCategoryLabel}
+                errors={getErrors('category')}
+                wrapperSx={{ flex: 2, minWidth: 0 }}
+            />
+            <InputComponent
+                type="number"
+                keyValue="unit_cost"
+                onChange={onUpdateField}
+                required
+                withMarginTop={false}
+                label={MESSAGES.detailedCostUnitLabel}
+                value={costBreakdownLine.unit_cost}
+                errors={getErrors('unit_cost')}
+                numberInputOptions={{
+                    decimalScale: 2,
+                    prefix: currencySymbol,
+                }}
+                wrapperSx={{ flex: 1.5, minWidth: 0 }}
+            />
+            <InputComponent
+                type="select"
+                keyValue="unit_type"
+                multi={false}
+                withMarginTop={false}
+                clearable={false}
+                options={costUnitTypeOptions}
+                value={costBreakdownLine.unit_type}
+                onChange={onUpdateField}
+                label={MESSAGES.unit}
+                errors={getErrors('unit')}
+                wrapperSx={{ flex: 2, minWidth: 0 }}
+            />
+            <InputComponent
+                type="select"
+                keyValue="population_layer"
+                multi={false}
+                withMarginTop={false}
+                clearable
+                options={populationOptions}
+                value={costBreakdownLine.population_layer || ''}
+                onChange={onUpdateField}
+                label={MESSAGES.targetPopulationLabel}
+                errors={getErrors('population_layer')}
+                wrapperSx={{ flex: 3, minWidth: 0 }}
+            />
+            <Box
+                sx={{
+                    flexShrink: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    height: 40,
+                }}
             >
                 <IconButton
                     onClick={() => onRemove()}
@@ -126,7 +110,7 @@ export const InterventionCostBreakdownLineForm: FC<Props> = ({
                         MESSAGES.removeInterventionCostBreakdownLine
                     }
                 ></IconButton>
-            </Grid>
-        </Grid>
+            </Box>
+        </Stack>
     );
 };

--- a/js/src/domains/settings/interventions/components/InterventionFormWrapper.tsx
+++ b/js/src/domains/settings/interventions/components/InterventionFormWrapper.tsx
@@ -3,6 +3,7 @@ import CheckIcon from '@mui/icons-material/Check';
 import { Button, Stack, Typography } from '@mui/material';
 import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
 import { CardStyled } from '../../../../components/CardStyled';
+import { SettingsFormContainer } from '../../../../components/styledComponents';
 import { ExtendedFormikProvider } from '../../../../hooks/useGetExtendedFormikContext';
 import { useGetMetricTypes } from '../../../dataLayers/hooks/useGetMetrics';
 import { useGetInterventionCostBreakdownLineCategories } from '../../../interventions/hooks/useGetInterventionCostBreakdownLineCategories';
@@ -95,7 +96,9 @@ export const InterventionFormWrapper: FC<Props> = ({ interventionId }) => {
                 )}
 
                 <ExtendedFormikProvider formik={formik}>
-                    <InterventionForm />
+                    <SettingsFormContainer>
+                        <InterventionForm />
+                    </SettingsFormContainer>
                 </ExtendedFormikProvider>
             </CardStyled>
         </InterventionProvider>


### PR DESCRIPTION
## What problem is this PR solving?

* Max width for the settings
* Cancel adding new cost units
* other fixes  

### Related JIRA tickets

SNT-517, SNT-498

## Changes

Settings pages are now width-constrained to 1440px, so the forms don't stretch over a hole screen anymore. Adding of new items have a cancel flow (return to top item in the list). Also the alignment of cost lines has been fixed in the intervention settings.

Max width on a large screen:
<img width="3008" height="1603" alt="image" src="https://github.com/user-attachments/assets/1dc8f86b-a0bb-4c12-bb6d-92d668d551c9" />


Cancel adding:
<img width="684" height="153" alt="image" src="https://github.com/user-attachments/assets/892749cb-2d38-455a-99ac-7f2dcfb11858" />