### PR TITLE
Feature SNT-518: Add budget settings through "General" tab

### DIFF
--- a/js/src/constants/translations/en.json
+++ b/js/src/constants/translations/en.json
@@ -320,5 +320,15 @@
     "iaso.snt_malaria.settings.grants.amount": "Amount",
     "iaso.snt_malaria.settings.grants.donor": "Donor",
     "iaso.snt_malaria.settings.grants.donorHelp": "Pick an existing donor or type a new name; new donors are created when the grant is saved.",
-    "iaso.snt_malaria.settings.intervention.grant": "Grant"
+    "iaso.snt_malaria.settings.intervention.grant": "Grant",
+    "iaso.snt_malaria.settings.general.title": "General",
+    "iaso.snt_malaria.settings.budget.title": "Budget",
+    "iaso.snt_malaria.settings.budget.subtitle": "Set the currency and rates used to compute intervention costs and projections.",
+    "iaso.snt_malaria.settings.budget.localCurrency": "Local currency (ISO code)",
+    "iaso.snt_malaria.settings.budget.localCurrencyHelp": "Three-letter code, e.g. USD, EUR, XOF.",
+    "iaso.snt_malaria.settings.budget.exchangeRate": "Exchange rate (local per USD)",
+    "iaso.snt_malaria.settings.budget.inflationRate": "Annual inflation rate",
+    "iaso.snt_malaria.settings.budget.inflationRateHelp": "Decimal value, e.g. 0.03 for 3%.",
+    "iaso.snt_malaria.settings.budget.invalidNumber": "Please enter a valid number.",
+    "iaso.snt_malaria.settings.budget.invalidCurrencyCode": "Enter a 3-letter currency code."
 }

--- a/js/src/constants/translations/fr.json
+++ b/js/src/constants/translations/fr.json
@@ -319,5 +319,15 @@
     "iaso.snt_malaria.settings.grants.amount": "Montant",
     "iaso.snt_malaria.settings.grants.donor": "Bailleur",
     "iaso.snt_malaria.settings.grants.donorHelp": "Choisissez un bailleur existant ou saisissez un nouveau nom ; les nouveaux bailleurs sont créés lors de l'enregistrement de la subvention.",
-    "iaso.snt_malaria.settings.intervention.grant": "Subvention"
+    "iaso.snt_malaria.settings.intervention.grant": "Subvention",
+    "iaso.snt_malaria.settings.general.title": "Général",
+    "iaso.snt_malaria.settings.budget.title": "Budget",
+    "iaso.snt_malaria.settings.budget.subtitle": "Définissez la devise et les taux utilisés pour calculer les coûts des interventions et les projections.",
+    "iaso.snt_malaria.settings.budget.localCurrency": "Devise locale (code ISO)",
+    "iaso.snt_malaria.settings.budget.localCurrencyHelp": "Code à trois lettres, ex. USD, EUR, XOF.",
+    "iaso.snt_malaria.settings.budget.exchangeRate": "Taux de change (local par USD)",
+    "iaso.snt_malaria.settings.budget.inflationRate": "Taux d'inflation annuel",
+    "iaso.snt_malaria.settings.budget.inflationRateHelp": "Valeur décimale, ex. 0,03 pour 3 %.",
+    "iaso.snt_malaria.settings.budget.invalidNumber": "Veuillez saisir un nombre valide.",
+    "iaso.snt_malaria.settings.budget.invalidCurrencyCode": "Saisissez un code de devise à 3 lettres."
 }

--- a/js/src/domains/messages.ts
+++ b/js/src/domains/messages.ts
@@ -934,4 +934,45 @@ export const MESSAGES = defineMessages({
         id: 'iaso.snt_malaria.settings.intervention.grant',
         defaultMessage: 'Grant',
     },
+    generalTitle: {
+        id: 'iaso.snt_malaria.settings.general.title',
+        defaultMessage: 'General',
+    },
+    budgetSettingsTitle: {
+        id: 'iaso.snt_malaria.settings.budget.title',
+        defaultMessage: 'Budget',
+    },
+    budgetSettingsSubtitle: {
+        id: 'iaso.snt_malaria.settings.budget.subtitle',
+        defaultMessage:
+            'Set the currency and rates used to compute intervention costs and projections.',
+    },
+    budgetLocalCurrency: {
+        id: 'iaso.snt_malaria.settings.budget.localCurrency',
+        defaultMessage: 'Local currency (ISO code)',
+    },
+    budgetLocalCurrencyHelp: {
+        id: 'iaso.snt_malaria.settings.budget.localCurrencyHelp',
+        defaultMessage: 'Three-letter code, e.g. USD, EUR, XOF.',
+    },
+    budgetExchangeRate: {
+        id: 'iaso.snt_malaria.settings.budget.exchangeRate',
+        defaultMessage: 'Exchange rate (local per USD)',
+    },
+    budgetInflationRate: {
+        id: 'iaso.snt_malaria.settings.budget.inflationRate',
+        defaultMessage: 'Annual inflation rate',
+    },
+    budgetInflationRateHelp: {
+        id: 'iaso.snt_malaria.settings.budget.inflationRateHelp',
+        defaultMessage: 'Decimal value, e.g. 0.03 for 3%.',
+    },
+    budgetInvalidNumber: {
+        id: 'iaso.snt_malaria.settings.budget.invalidNumber',
+        defaultMessage: 'Please enter a valid number.',
+    },
+    budgetInvalidCurrencyCode: {
+        id: 'iaso.snt_malaria.settings.budget.invalidCurrencyCode',
+        defaultMessage: 'Enter a 3-letter currency code.',
+    },
 });

--- a/js/src/domains/settings/budget/hooks/useBudgetSettingsFormState.tsx
+++ b/js/src/domains/settings/budget/hooks/useBudgetSettingsFormState.tsx
@@ -3,9 +3,12 @@ import { useSafeIntl } from 'bluesquare-components';
 import { FormikHelpers, useFormik } from 'formik';
 import * as Yup from 'yup';
 import { MESSAGES } from '../../../messages';
+import { BudgetSettingsFormValues } from '../types';
 
-const emptyToNull = (value: unknown, originalValue: unknown) =>
-    originalValue === '' ? null : value;
+const emptyToNull = (
+    value: string | null,
+    originalValue: string,
+): string | null => (originalValue === '' ? null : value);
 
 const useValidation = () => {
     const { formatMessage } = useSafeIntl();
@@ -37,8 +40,11 @@ export const useBudgetSettingsFormState = ({
     onSubmit,
     initialValues,
 }: {
-    onSubmit: (values: any, formikHelpers?: FormikHelpers<any>) => void;
-    initialValues: any;
+    onSubmit: (
+        values: BudgetSettingsFormValues,
+        formikHelpers?: FormikHelpers<BudgetSettingsFormValues>,
+    ) => void;
+    initialValues: BudgetSettingsFormValues;
 }) => {
     const validationSchema = useValidation();
     const formik = useFormik({

--- a/js/src/domains/settings/budget/hooks/useBudgetSettingsFormState.tsx
+++ b/js/src/domains/settings/budget/hooks/useBudgetSettingsFormState.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+import { useSafeIntl } from 'bluesquare-components';
+import { FormikHelpers, useFormik } from 'formik';
+import * as Yup from 'yup';
+import { MESSAGES } from '../../../messages';
+
+const emptyToNull = (value: unknown, originalValue: unknown) =>
+    originalValue === '' ? null : value;
+
+const useValidation = () => {
+    const { formatMessage } = useSafeIntl();
+
+    return useMemo(
+        () =>
+            Yup.object().shape({
+                local_currency: Yup.string()
+                    .nullable()
+                    .transform(emptyToNull)
+                    .matches(
+                        /^[A-Za-z]{3}$/,
+                        formatMessage(MESSAGES.budgetInvalidCurrencyCode),
+                    ),
+                exchange_rate: Yup.number()
+                    .typeError(formatMessage(MESSAGES.budgetInvalidNumber))
+                    .min(0, formatMessage(MESSAGES.negativeValueNotAllowed))
+                    .required(formatMessage(MESSAGES.required)),
+                inflation_rate: Yup.number()
+                    .typeError(formatMessage(MESSAGES.budgetInvalidNumber))
+                    .min(0, formatMessage(MESSAGES.negativeValueNotAllowed))
+                    .required(formatMessage(MESSAGES.required)),
+            }),
+        [formatMessage],
+    );
+};
+
+export const useBudgetSettingsFormState = ({
+    onSubmit,
+    initialValues,
+}: {
+    onSubmit: (values: any, formikHelpers?: FormikHelpers<any>) => void;
+    initialValues: any;
+}) => {
+    const validationSchema = useValidation();
+    const formik = useFormik({
+        initialValues,
+        validationSchema,
+        enableReinitialize: true,
+        onSubmit,
+    });
+
+    return formik;
+};

--- a/js/src/domains/settings/budget/hooks/useGetBudgetSettings.ts
+++ b/js/src/domains/settings/budget/hooks/useGetBudgetSettings.ts
@@ -1,0 +1,18 @@
+import { getRequest } from 'Iaso/libs/Api';
+import { useSnackQuery } from 'Iaso/libs/apiHooks';
+import { UseQueryResult } from 'react-query';
+import { BudgetSettings } from '../types';
+
+export const useGetBudgetSettings = (): UseQueryResult<
+    BudgetSettings | undefined,
+    Error
+> =>
+    useSnackQuery({
+        queryKey: ['budgetSettings'],
+        queryFn: () => getRequest('/api/snt_malaria/budget_settings/'),
+        options: {
+            // BudgetSettings has a OneToOneField to Account, so there's at
+            // most one row per account; the API returns a list.
+            select: (data: BudgetSettings[]) => (data ? data[0] : undefined),
+        },
+    });

--- a/js/src/domains/settings/budget/hooks/useSaveBudgetSettings.ts
+++ b/js/src/domains/settings/budget/hooks/useSaveBudgetSettings.ts
@@ -1,0 +1,16 @@
+import { patchRequest } from 'Iaso/libs/Api';
+import { useSnackMutation } from 'Iaso/libs/apiHooks';
+import { UseMutationResult } from 'react-query';
+import { BudgetSettingsPayload } from '../types';
+
+export const useSaveBudgetSettings = (): UseMutationResult =>
+    useSnackMutation({
+        mutationFn: ({ id, ...body }: BudgetSettingsPayload) =>
+            patchRequest(`/api/snt_malaria/budget_settings/${id}/`, body),
+        // Also refresh the copies used by intervention settings and the
+        // account configuration wizard.
+        invalidateQueryKey: [
+            'budgetSettings',
+            'snt_malaria_configureAccount_budget_settings',
+        ],
+    });

--- a/js/src/domains/settings/budget/index.tsx
+++ b/js/src/domains/settings/budget/index.tsx
@@ -16,7 +16,7 @@ import { MESSAGES } from '../../messages';
 import { useBudgetSettingsFormState } from './hooks/useBudgetSettingsFormState';
 import { useGetBudgetSettings } from './hooks/useGetBudgetSettings';
 import { useSaveBudgetSettings } from './hooks/useSaveBudgetSettings';
-import { BudgetSettingsPayload } from './types';
+import { BudgetSettingsFormValues } from './types';
 
 export const BudgetSettingsTab: FC = () => {
     const { formatMessage } = useSafeIntl();
@@ -36,7 +36,7 @@ export const BudgetSettingsTab: FC = () => {
     );
 
     const onSubmit = useCallback(
-        (values: BudgetSettingsPayload) => {
+        (values: BudgetSettingsFormValues) => {
             if (!values.id) {
                 return;
             }

--- a/js/src/domains/settings/budget/index.tsx
+++ b/js/src/domains/settings/budget/index.tsx
@@ -1,0 +1,153 @@
+import React, { FC, useCallback, useMemo } from 'react';
+import { TollOutlined } from '@mui/icons-material';
+import CheckIcon from '@mui/icons-material/Check';
+import { Stack, Typography } from '@mui/material';
+import { Button } from '@mui/material';
+import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
+import InputComponent from 'Iaso/components/forms/InputComponent';
+import { useTranslatedErrors } from 'Iaso/libs/validation';
+import { CardStyled } from '../../../components/CardStyled';
+import { IconBoxed } from '../../../components/IconBoxed';
+import {
+    CardScrollable,
+    SettingsFormContainer,
+} from '../../../components/styledComponents';
+import { MESSAGES } from '../../messages';
+import { useBudgetSettingsFormState } from './hooks/useBudgetSettingsFormState';
+import { useGetBudgetSettings } from './hooks/useGetBudgetSettings';
+import { useSaveBudgetSettings } from './hooks/useSaveBudgetSettings';
+import { BudgetSettingsPayload } from './types';
+
+export const BudgetSettingsTab: FC = () => {
+    const { formatMessage } = useSafeIntl();
+
+    const { data: budgetSettings, isLoading } = useGetBudgetSettings();
+    const { mutate: saveBudgetSettings, isLoading: isSaving } =
+        useSaveBudgetSettings();
+
+    const initialValues = useMemo(
+        () => ({
+            id: budgetSettings?.id,
+            local_currency: budgetSettings?.local_currency ?? '',
+            exchange_rate: budgetSettings?.exchange_rate ?? '1',
+            inflation_rate: budgetSettings?.inflation_rate ?? '0',
+        }),
+        [budgetSettings],
+    );
+
+    const onSubmit = useCallback(
+        (values: BudgetSettingsPayload) => {
+            if (!values.id) {
+                return;
+            }
+            saveBudgetSettings({
+                id: values.id,
+                local_currency: values.local_currency.toUpperCase(),
+                exchange_rate: values.exchange_rate,
+                inflation_rate: values.inflation_rate,
+            });
+        },
+        [saveBudgetSettings],
+    );
+
+    const formik = useBudgetSettingsFormState({ onSubmit, initialValues });
+    const { values, errors, touched, setFieldValue, setFieldTouched } = formik;
+
+    const onChange = useCallback(
+        (keyValue: string | null, value: unknown) => {
+            if (!keyValue) {
+                return;
+            }
+            setFieldTouched(keyValue, true);
+            setFieldValue(keyValue, value ?? '');
+        },
+        [setFieldTouched, setFieldValue],
+    );
+
+    const getErrors = useTranslatedErrors({
+        errors,
+        touched,
+        formatMessage,
+        messages: MESSAGES,
+    });
+
+    return (
+        <CardScrollable>
+            <CardStyled
+                header={
+                    <Stack
+                        direction="row"
+                        justifyContent="space-between"
+                        alignItems="center"
+                    >
+                        <Stack direction="row" alignItems="center" spacing={1}>
+                            <IconBoxed Icon={TollOutlined} />
+                            <Typography variant="h6">
+                                {formatMessage(MESSAGES.budgetSettingsTitle)}
+                            </Typography>
+                        </Stack>
+                        <Button
+                            onClick={() => formik.handleSubmit()}
+                            variant="contained"
+                            color="primary"
+                            startIcon={<CheckIcon />}
+                            disabled={isSaving || !budgetSettings?.id}
+                        >
+                            {formatMessage(MESSAGES.save)}
+                        </Button>
+                    </Stack>
+                }
+            >
+                {isLoading && <LoadingSpinner absolute />}
+                <SettingsFormContainer>
+                    <Stack spacing={2}>
+                        <Typography variant="caption" color="textSecondary">
+                            {formatMessage(MESSAGES.budgetSettingsSubtitle)}
+                        </Typography>
+                        <InputComponent
+                            keyValue="local_currency"
+                            type="text"
+                            value={values.local_currency}
+                            onChange={onChange}
+                            errors={getErrors('local_currency')}
+                            labelString={formatMessage(
+                                MESSAGES.budgetLocalCurrency,
+                            )}
+                            helperText={formatMessage(
+                                MESSAGES.budgetLocalCurrencyHelp,
+                            )}
+                            withMarginTop={false}
+                        />
+                        <InputComponent
+                            keyValue="exchange_rate"
+                            type="number"
+                            required
+                            value={values.exchange_rate}
+                            onChange={onChange}
+                            errors={getErrors('exchange_rate')}
+                            labelString={formatMessage(
+                                MESSAGES.budgetExchangeRate,
+                            )}
+                            withMarginTop={false}
+                        />
+                        <InputComponent
+                            keyValue="inflation_rate"
+                            type="number"
+                            required
+                            value={values.inflation_rate}
+                            onChange={onChange}
+                            errors={getErrors('inflation_rate')}
+                            labelString={formatMessage(
+                                MESSAGES.budgetInflationRate,
+                            )}
+                            helperText={formatMessage(
+                                MESSAGES.budgetInflationRateHelp,
+                            )}
+                            withMarginTop={false}
+                        />
+                    </Stack>
+                </SettingsFormContainer>
+            </CardStyled>
+        </CardScrollable>
+    );
+};

--- a/js/src/domains/settings/budget/types.ts
+++ b/js/src/domains/settings/budget/types.ts
@@ -11,3 +11,10 @@ export type BudgetSettingsPayload = {
     exchange_rate: string | number;
     inflation_rate: string | number;
 };
+
+export type BudgetSettingsFormValues = {
+    id?: number;
+    local_currency: string;
+    exchange_rate: string | number;
+    inflation_rate: string | number;
+};

--- a/js/src/domains/settings/budget/types.ts
+++ b/js/src/domains/settings/budget/types.ts
@@ -1,0 +1,13 @@
+export type BudgetSettings = {
+    id: number;
+    local_currency: string;
+    exchange_rate: string;
+    inflation_rate: string;
+};
+
+export type BudgetSettingsPayload = {
+    id: number;
+    local_currency: string;
+    exchange_rate: string | number;
+    inflation_rate: string | number;
+};

--- a/js/src/domains/settings/general/index.tsx
+++ b/js/src/domains/settings/general/index.tsx
@@ -25,13 +25,13 @@ const styles = {
     listItem: {
         cursor: 'pointer',
         borderRadius: 2,
-        paddingX: (theme: Theme) => theme.spacing(1),
+        padding: (theme: Theme) => theme.spacing(0, 1),
     },
     activeListItem: {
         cursor: 'pointer',
         backgroundColor: (theme: Theme) => theme.palette.primary.light,
         borderRadius: 2,
-        paddingX: (theme: Theme) => theme.spacing(1),
+        padding: (theme: Theme) => theme.spacing(0, 1),
     },
     listItemIcon: {
         minWidth: 36,
@@ -93,8 +93,6 @@ export const GeneralSettings: FC = () => {
                                 return (
                                     <ListItem
                                         key={section.key}
-                                        disableGutters
-                                        disablePadding
                                         onClick={() =>
                                             setActiveKey(section.key)
                                         }

--- a/js/src/domains/settings/general/index.tsx
+++ b/js/src/domains/settings/general/index.tsx
@@ -1,0 +1,121 @@
+import React, { FC, ReactNode, useMemo, useState } from 'react';
+import { SettingsOutlined, TollOutlined } from '@mui/icons-material';
+import {
+    List,
+    ListItem,
+    ListItemIcon,
+    ListItemText,
+    Stack,
+    Theme,
+    Typography,
+} from '@mui/material';
+import { useSafeIntl } from 'bluesquare-components';
+import { CardStyled } from '../../../components/CardStyled';
+import { IconBoxed } from '../../../components/IconBoxed';
+import {
+    CardScrollable,
+    MainColumn,
+    SidebarColumn,
+    SidebarLayout,
+} from '../../../components/styledComponents';
+import { MESSAGES } from '../../messages';
+import { BudgetSettingsTab } from '../budget';
+
+const styles = {
+    listItem: {
+        cursor: 'pointer',
+        borderRadius: 2,
+        paddingX: (theme: Theme) => theme.spacing(1),
+    },
+    activeListItem: {
+        cursor: 'pointer',
+        backgroundColor: (theme: Theme) => theme.palette.primary.light,
+        borderRadius: 2,
+        paddingX: (theme: Theme) => theme.spacing(1),
+    },
+    listItemIcon: {
+        minWidth: 36,
+    },
+};
+
+type GeneralSection = {
+    key: string;
+    label: string;
+    icon: React.ElementType;
+    content: ReactNode;
+};
+
+export const GeneralSettings: FC = () => {
+    const { formatMessage } = useSafeIntl();
+
+    // Sub-entries of the "General" tab. Add more here as other singleton
+    // settings move under General; the sidebar acts as their navigation menu.
+    const sections: GeneralSection[] = useMemo(
+        () => [
+            {
+                key: 'budget',
+                label: formatMessage(MESSAGES.budgetSettingsTitle),
+                icon: TollOutlined,
+                content: <BudgetSettingsTab />,
+            },
+        ],
+        [formatMessage],
+    );
+
+    const [activeKey, setActiveKey] = useState(sections[0].key);
+    const activeSection =
+        sections.find(section => section.key === activeKey) ?? sections[0];
+
+    return (
+        <SidebarLayout>
+            <SidebarColumn>
+                <CardScrollable>
+                    <CardStyled
+                        header={
+                            <Stack
+                                direction="row"
+                                alignItems="center"
+                                spacing={1}
+                            >
+                                <IconBoxed Icon={SettingsOutlined} />
+                                <Typography
+                                    variant="h6"
+                                    sx={{ flexGrow: 1, mb: 0 }}
+                                >
+                                    {formatMessage(MESSAGES.generalTitle)}
+                                </Typography>
+                            </Stack>
+                        }
+                    >
+                        <List>
+                            {sections.map(section => {
+                                const Icon = section.icon;
+                                return (
+                                    <ListItem
+                                        key={section.key}
+                                        disableGutters
+                                        disablePadding
+                                        onClick={() =>
+                                            setActiveKey(section.key)
+                                        }
+                                        sx={
+                                            section.key === activeKey
+                                                ? styles.activeListItem
+                                                : styles.listItem
+                                        }
+                                    >
+                                        <ListItemIcon sx={styles.listItemIcon}>
+                                            <Icon fontSize="small" />
+                                        </ListItemIcon>
+                                        <ListItemText primary={section.label} />
+                                    </ListItem>
+                                );
+                            })}
+                        </List>
+                    </CardStyled>
+                </CardScrollable>
+            </SidebarColumn>
+            <MainColumn>{activeSection.content}</MainColumn>
+        </SidebarLayout>
+    );
+};

--- a/js/src/domains/settings/index.tsx
+++ b/js/src/domains/settings/index.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useCallback, useEffect } from 'react';
 import {
     AccountBalanceOutlined,
+    SettingsOutlined,
     StraightenOutlined,
     VaccinesOutlined,
 } from '@mui/icons-material';
@@ -11,12 +12,18 @@ import { useSearchParams } from 'react-router-dom';
 import { PageContainer } from '../../components/styledComponents';
 import { MESSAGES } from '../messages';
 import { CostUnitSettings } from './costUnits';
+import { GeneralSettings } from './general';
 import { GrantSettings } from './grants';
 import { InterventionSettings } from './interventions';
 
-type SettingsTab = 'interventions' | 'costUnits' | 'grants';
+type SettingsTab = 'interventions' | 'costUnits' | 'grants' | 'general';
 
-const SETTINGS_TABS: SettingsTab[] = ['interventions', 'costUnits', 'grants'];
+const SETTINGS_TABS: SettingsTab[] = [
+    'interventions',
+    'costUnits',
+    'grants',
+    'general',
+];
 
 const DEFAULT_TAB: SettingsTab = 'interventions';
 
@@ -24,7 +31,8 @@ export const Settings: FC = () => {
     const { formatMessage } = useSafeIntl();
     const [searchParams, setSearchParams] = useSearchParams();
     const tabParam = searchParams.get('tab') as SettingsTab | null;
-    // Fall back to the default for missing/unknown tabs.
+    // Fall back to the default for missing/unknown tabs (e.g. the legacy
+    // "budget" tab, now a sub-entry of "general").
     const tab =
         tabParam && SETTINGS_TABS.includes(tabParam) ? tabParam : DEFAULT_TAB;
 
@@ -38,8 +46,8 @@ export const Settings: FC = () => {
     );
 
     // Reflect the active tab in the URL as a query param when it is missing or
-    // unknown (e.g. on first load), so the tab is always valid and
-    // shareable/bookmarkable.
+    // unknown (e.g. on first load, or the legacy "budget" tab), so the tab is
+    // always valid and shareable/bookmarkable.
     useEffect(() => {
         if (searchParams.get('tab') !== tab) {
             const next = new URLSearchParams(searchParams);
@@ -96,12 +104,20 @@ export const Settings: FC = () => {
                             label={formatMessage(MESSAGES.grantsTitle)}
                             sx={{ textTransform: 'none', minHeight: 48 }}
                         />
+                        <Tab
+                            value="general"
+                            icon={<SettingsOutlined fontSize="small" />}
+                            iconPosition="start"
+                            label={formatMessage(MESSAGES.generalTitle)}
+                            sx={{ textTransform: 'none', minHeight: 48 }}
+                        />
                     </Tabs>
                 </Box>
                 <Box sx={{ flex: 1, minHeight: 0 }}>
                     {tab === 'interventions' && <InterventionSettings />}
                     {tab === 'costUnits' && <CostUnitSettings />}
                     {tab === 'grants' && <GrantSettings />}
+                    {tab === 'general' && <GeneralSettings />}
                 </Box>
             </PageContainer>
         </>


### PR DESCRIPTION
## What problem is this PR solving?

Adds a new "General" settings tab and Budget settings under it

### Related JIRA tickets

SNT-518, SNT-498

## Changes

This is only historically related to the grant work but since it was done I'm adding it because it is useful to have budget settings.

<img width="1626" height="468" alt="image" src="https://github.com/user-attachments/assets/85475986-80bf-4a7a-b14c-c7387bf1dd96" />
