### PR TITLE
SNT-487 Update demo account configuration with new budget entities

### DIFF
--- a/management/commands/fixtures/BFA_dummy_metadata.csv
+++ b/management/commands/fixtures/BFA_dummy_metadata.csv
@@ -1,12 +1,12 @@
-VARIABLE,LABEL,DESCRIPTION,SOURCE,UNITS,TYPE,SCALE,CATEGORY,ORDER,UNIT_SYMBOL,PERIOD,IS_UTILITY
-POPULATION,Population totale (WorldPop),Nombre total de personnes vivant dans une zone spécifique.,WorldPop,Nombre de personnes,Threshold,"[50000,100000,200000,300000,400000,500000]",Variables de population et de santé,1,,2024,
-POP_UNDER_5,Population aged 0-5 years,Number of children aged 0 to 5 years.,WorldPop,Number of people,Threshold,"[10000, 25000, 50000, 75000, 100000, 150000]",Population variables,2,,2024,True
-POP_0_1_Y,Population aged 0-1 years,Number of children aged 0 to 1 year.,WorldPop,Number of people,Threshold,"[5000, 10000, 15000, 20000, 25000, 30000]",Population variables,3,,2024,True
-POP_1_2_Y,Population aged 1-2 years,Number of children aged 1 to 2 years.,WorldPop,Number of people,Threshold,"[5000, 10000, 15000, 20000, 25000, 30000]",Population variables,4,,2024,True
-POP_5_36_M,Vaccine-eligible population (5-36 months),Number of children aged 5 to 36 months eligible for vaccination.,WorldPop,Number of people,Threshold,"[5000, 10000, 15000, 20000, 25000, 30000]",Population variables,5,,2024,True
-POP_PREGNANT_WOMAN,Pregnant women population,Estimated number of pregnant women.,WorldPop,Number of people,Threshold,"[2500, 5000, 7500, 10000, 15000, 20000]",Population variables,6,,2024,True
-POP_5_10_Y,Population aged 5-10 years,Number of children aged 5 to 10 years.,WorldPop,Number of people,Threshold,"[10000, 25000, 50000, 75000, 100000, 150000]",Population variables,7,,2024,True
-POP_URBAN,Urban population,Number of people living in urban areas.,WorldPop,Number of people,Threshold,"[10000, 50000, 100000, 200000, 300000, 500000]",Population variables,8,,2024,True
+VARIABLE,LABEL,DESCRIPTION,SOURCE,UNITS,TYPE,SCALE,CATEGORY,ORDER,UNIT_SYMBOL,PERIOD,IS_UTILITY,IS_POPULATION
+POPULATION,Population totale (WorldPop),Nombre total de personnes vivant dans une zone spécifique.,WorldPop,Nombre de personnes,Threshold,"[50000,100000,200000,300000,400000,500000]",Variables de population et de santé,1,,2024,,True
+POP_UNDER_5,Population aged 0-5 years,Number of children aged 0 to 5 years.,WorldPop,Number of people,Threshold,"[10000, 25000, 50000, 75000, 100000, 150000]",Population variables,2,,2024,True,True
+POP_0_1_Y,Population aged 0-1 years,Number of children aged 0 to 1 year.,WorldPop,Number of people,Threshold,"[5000, 10000, 15000, 20000, 25000, 30000]",Population variables,3,,2024,True,True
+POP_1_2_Y,Population aged 1-2 years,Number of children aged 1 to 2 years.,WorldPop,Number of people,Threshold,"[5000, 10000, 15000, 20000, 25000, 30000]",Population variables,4,,2024,True,True
+POP_5_36_M,Vaccine-eligible population (5-36 months),Number of children aged 5 to 36 months eligible for vaccination.,WorldPop,Number of people,Threshold,"[5000, 10000, 15000, 20000, 25000, 30000]",Population variables,5,,2024,True,True
+POP_PREGNANT_WOMAN,Pregnant women population,Estimated number of pregnant women.,WorldPop,Number of people,Threshold,"[2500, 5000, 7500, 10000, 15000, 20000]",Population variables,6,,2024,True,True
+POP_5_10_Y,Population aged 5-10 years,Number of children aged 5 to 10 years.,WorldPop,Number of people,Threshold,"[10000, 25000, 50000, 75000, 100000, 150000]",Population variables,7,,2024,True,True
+POP_URBAN,Urban population,Number of people living in urban areas.,WorldPop,Number of people,Threshold,"[10000, 50000, 100000, 200000, 300000, 500000]",Population variables,8,,2024,True,True
 SEASONALITY_PRECIPITATION,Seasonal by Rainfall (ERA5),"Classification of seasonal malaria transmission based on rainfall trends, used to identify areas eligible for seasonal interventions such as SMC.",ERA5,"Not Seasonal (0), Seasonal (1)",Ordinal,"[not-seasonal, seasonal]",Environmental Indicators,5,,,
 SEASONAL_BLOCK_DURATION_PRECIPITATION,Length of Transmission Season by Rainfall (ERA5),Estimated number of consecutive months per year with elevated malaria transmission based on rainfall patterns.,ERA5,Number of months,Ordinal,"[3, 4, 5]",Environmental Indicators,5,,,
 PF_PR_RATE,Prévalence du Pf chez les enfants de 2 à 10 ans (MAP),Pourcentage des enfants de 2 à 10 ans étant infectés de Plasmodium falciparum.,MAP,Pour 100 enfants,Threshold,"[0, 20, 40, 60, 80, 100]",Indicateurs épidémiologiques,4,%,2025,

--- a/management/commands/recreate_demo_account.py
+++ b/management/commands/recreate_demo_account.py
@@ -34,6 +34,29 @@ from .support.metrics_importer import MetricsImporter
 
 
 DEMO_ACCOUNT_NAME = "Burkina Faso (demo)"
+
+# Maps (intervention.code, unit_type.name) to the population MetricType code that
+# drives that cost line. Only needed for population-driven lines; NULL lines are left unchanged.
+COST_LINE_POPULATION_CODES = {
+    ("iptp", "IPTp Blister Pack"): "POP_PREGNANT_WOMAN",
+    ("pmc", "SP Tablet 0-1"): "POP_0_1_Y",
+    ("pmc", "SP Tablet 1-2"): "POP_1_2_Y",
+    ("pmc", "Each"): "POP_UNDER_5",
+    ("smc", "SP Tablet 0-1"): "POP_UNDER_5",
+    ("smc", "SP Tablet 1-2"): "POP_UNDER_5",
+    ("smc", "Each"): "POP_UNDER_5",
+    ("smc_3", "SMC 3 cycles"): "POP_UNDER_5",
+    ("smc_4", "SMC 4 cycles"): "POP_UNDER_5",
+    ("smc_5", "SMC 5 cycles"): "POP_UNDER_5",
+    ("itn_campaign", "Net"): "POPULATION",
+    ("itn_campaign", "Bale"): "POPULATION",
+    ("itn_routine", "Net"): "POPULATION",
+    ("itn_school", "Net"): "POP_5_10_Y",
+    ("itn_school", "Bale"): "POP_5_10_Y",
+    ("vacc", "Vaccine dose"): "POP_5_36_M",
+    ("vacc", "Each"): "POP_5_36_M",
+    ("lsm", "Days"): "POPULATION",
+}
 DEMO_USER_USERNAME = "demo"
 DEMO_USER_PASSWORD = "demo"
 
@@ -205,6 +228,9 @@ class Command(BaseCommand):
             # Seed interventions and intervention costs
             InterventionSeeder(account, self.stdout.write).create_interventions()
 
+            # Link population metric types to cost breakdown lines (demo-specific mapping)
+            self._link_cost_line_population_layers(account)
+
             # Randomly assign impact ref to interventions
             interventions = Intervention.objects_include_deleted.filter(intervention_category__account=account)
             for intervention in interventions:
@@ -235,3 +261,34 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS("\nDemo user created with credentials:"))
             self.stdout.write(self.style.SUCCESS(f"\tUsername: {DEMO_USER_USERNAME}"))
             self.stdout.write(self.style.SUCCESS(f"\tPassword: {DEMO_USER_PASSWORD}"))
+
+    def _link_cost_line_population_layers(self, account):
+        """Set population_layer on InterventionCostBreakdownLines using COST_LINE_POPULATION_CODES.
+
+        This is a demo-account-specific step: intervention_seeder leaves population_layer=None
+        so it stays reusable across accounts, and we fill in the links here.
+        """
+        metric_types = {
+            mt.code: mt
+            for mt in MetricType.objects.filter(
+                account=account,
+                metric_kind=MetricType.MetricKind.POPULATION,
+            )
+        }
+
+        lines = InterventionCostBreakdownLine.objects.filter(
+            intervention__intervention_category__account=account
+        ).select_related("intervention", "unit_type")
+
+        updated = 0
+        for line in lines:
+            key = (line.intervention.code, line.unit_type.name)
+            pop_code = COST_LINE_POPULATION_CODES.get(key)
+            if pop_code:
+                metric_type = metric_types.get(pop_code)
+                if metric_type and line.population_layer_id != metric_type.id:
+                    line.population_layer = metric_type
+                    line.save(update_fields=["population_layer"])
+                    updated += 1
+
+        self.stdout.write(f"Linked population layers on {updated} cost breakdown lines")

--- a/management/commands/support/demo_scenario_seeder.py
+++ b/management/commands/support/demo_scenario_seeder.py
@@ -3,14 +3,36 @@ Create a demo scenario with intervention assignments for Burkina Faso
 """
 
 from datetime import date
+from decimal import Decimal
 
 from iaso.models import OrgUnitType, User
 from iaso.models.data_store import JsonDataStore
-from iaso.models.metric import MetricType
+from iaso.models.metric import MetricType, MetricValue
 
 # from plugins.snt_malaria.models.budget import Budget
+from plugins.snt_malaria.models.cost_breakdown import InterventionCostBreakdownLine
 from plugins.snt_malaria.models.intervention import Intervention
 from plugins.snt_malaria.models.scenario import Scenario, ScenarioRule
+from plugins.snt_malaria.models.scenario_yearly_cost_assignment import ScenarioYearlyCostAssignment
+from plugins.snt_malaria.services.budget.budget_calculation import BudgetCalculationService
+
+
+# Coverage ratios stored in ScenarioYearlyCostAssignment.value for population-driven lines.
+# Keyed by intervention.code; unrecognised codes fall back to DEFAULT_YEARLY_COVERAGE.
+YEARLY_COVERAGE_BY_CODE = {
+    "iptp": Decimal("0.85"),
+    "pmc": Decimal("0.80"),
+    "smc": Decimal("0.90"),
+    "smc_3": Decimal("0.90"),
+    "smc_4": Decimal("0.90"),
+    "smc_5": Decimal("0.90"),
+    "itn_campaign": Decimal("0.75"),
+    "itn_routine": Decimal("0.80"),
+    "itn_school": Decimal("0.75"),
+    "vacc": Decimal("0.70"),
+    "lsm": Decimal("0.80"),
+}
+DEFAULT_YEARLY_COVERAGE = Decimal("1.00")
 
 
 class DemoScenarioSeeder:
@@ -51,17 +73,12 @@ class DemoScenarioSeeder:
         pf_rate_metric_type = metric_types.filter(code="PF_PR_RATE").first()
         seasonality_precipitation_metric_type = metric_types.filter(code="SEASONALITY_PRECIPITATION").first()
 
-        scenario_1 = self._create_scenario_(
+        self._create_scenario_(
             "NSP 1", created_by, interventions, seasonality_precipitation_metric_type, pf_rate_metric_type, rate=60
         )
-        scenario_2 = self._create_scenario_(
+        self._create_scenario_(
             "NSP 2", created_by, interventions, seasonality_precipitation_metric_type, pf_rate_metric_type, rate=80
         )
-
-        # Create a budget for the scenario
-        # self.stdout_write("\nCreating budget for scenario...")
-        # budget = self._create_budget_for_scenario(scenario, created_by)
-        # self.stdout_write(f"Created budget: {budget.name}")
 
         # Create an SNT config
         country_out_id = OrgUnitType.objects.get(projects=self.project, short_name="Country").id
@@ -76,69 +93,6 @@ class DemoScenarioSeeder:
         )
 
         self.stdout_write("Done creating demo scenario.")
-
-    def _create_budget_for_scenario(self, scenario, created_by):
-        """
-        Create a budget for the given scenario using the budget calculator.
-        """
-        start_year = scenario.start_year
-        end_year = scenario.end_year
-
-        # Build cost and population dataframes and format the intervention plan
-        # cost_df = build_cost_dataframe(self.account, start_year, end_year)
-        # population_df = build_population_dataframe(self.account, start_year, end_year)
-        # interventions_input = build_interventions_input(scenario)
-
-        # Build a quick lookup map ((code, type) -> id) for fast id retrieval
-        interventions = Intervention.objects.filter(intervention_category__account=self.account)
-        interventions_map = {(iv.code, iv.name): iv.id for iv in interventions}
-
-        # Use default cost assumptions
-        # settings = DEFAULT_COST_ASSUMPTIONS
-
-        # budgets = []
-        # budget_calculator = BudgetCalculator(
-        #     interventions_input=interventions_input,
-        #     settings=settings,
-        #     cost_df=cost_df,
-        #     population_df=population_df,
-        #     local_currency="USD",
-        #     budget_currency="USD",
-        #     spatial_planning_unit="org_unit_id",
-        # )
-
-        # Calculate budget for each year
-        # for year in range(start_year, end_year + 1):
-        #     interventions_costs = budget_calculator.get_interventions_costs(year)
-        #     places_costs = budget_calculator.get_places_costs(year)
-
-        #     # Adjust cost breakdown category field name
-        #     for intervention in interventions_costs:
-        #         for cost_breakdown in intervention["cost_breakdown"]:
-        #             cost_breakdown["category"] = cost_breakdown.pop("cost_class", None)
-
-        #     # Adjust place costs field names and attach intervention IDs
-        #     for place_cost in places_costs:
-        #         place_cost["org_unit_id"] = place_cost.pop("place")
-
-        #         for place_cost_intervention in place_cost.get("interventions", []):
-        #             code = place_cost_intervention["code"]
-        #             type_ = place_cost_intervention["type"]
-        #             intervention_id = interventions_map.get((code, type_))
-        #             place_cost_intervention["id"] = intervention_id
-
-        #     budgets.append({"year": year, "interventions": interventions_costs, "org_units_costs": places_costs})
-
-        # Create the budget object
-        # budget = Budget.objects.create(
-        #     scenario=scenario,
-        #     name=f"Budget for {scenario.name}",
-        #     results=budgets,
-        #     created_by=created_by,
-        #     updated_by=created_by,
-        # )
-
-        # return budget
 
     def _create_scenario_(
         self, scenario_name, user, interventions, seasonality_precipitation_metric_type, pf_rate_metric_type, rate
@@ -234,3 +188,74 @@ class DemoScenarioSeeder:
         scenario.refresh_assignments(user=user)
         assignment_count = scenario.intervention_assignments.count()
         self.stdout_write(f"Assigned {assignment_count} interventions to scenario")
+
+        self._create_yearly_cost_assignments(scenario)
+
+        self._ensure_population_for_scenario_years(scenario)
+
+        self.stdout_write(f"Calculating budget for '{scenario.name}'...")
+        budget = BudgetCalculationService(scenario).calculate_and_save_all_years(user)
+        self.stdout_write(f"Created budget '{budget.name}' (ID: {budget.id})")
+
+        return scenario
+
+    def _create_yearly_cost_assignments(self, scenario):
+        """Create ScenarioYearlyCostAssignment rows for all cost breakdown lines of
+        the interventions assigned to the scenario, one row per (line, year)."""
+        intervention_ids = list(scenario.intervention_assignments.values_list("intervention_id", flat=True).distinct())
+
+        cost_lines = InterventionCostBreakdownLine.objects.filter(intervention_id__in=intervention_ids).select_related(
+            "intervention"
+        )
+
+        to_create = []
+        for year in range(scenario.start_year, scenario.end_year + 1):
+            for line in cost_lines:
+                if line.cost_driver == InterventionCostBreakdownLine.CostDriver.POPULATION:
+                    value = YEARLY_COVERAGE_BY_CODE.get(line.intervention.code, DEFAULT_YEARLY_COVERAGE)
+                else:
+                    # Fixed-cost lines default to 0 in the budget calculator; seed an explicit 0
+                    value = Decimal("0.00")
+                to_create.append(
+                    ScenarioYearlyCostAssignment(
+                        scenario=scenario,
+                        cost_line=line,
+                        year=year,
+                        value=value,
+                    )
+                )
+
+        ScenarioYearlyCostAssignment.objects.bulk_create(to_create, ignore_conflicts=True)
+        self.stdout_write(f"Created {len(to_create)} yearly cost assignments for '{scenario.name}'")
+
+    def _ensure_population_for_scenario_years(self, scenario):
+        """The metrics dataset has no YEAR column so MetricValues are imported with year=0.
+        The budget calculator queries by exact year, so copy the year=0 baseline values to
+        every year in the scenario range so the calculation produces non-zero results."""
+        pop_metric_types = MetricType.objects.filter(
+            account=scenario.account,
+            metric_kind=MetricType.MetricKind.POPULATION,
+        )
+
+        base_values = list(MetricValue.objects.filter(metric_type__in=pop_metric_types, year=0))
+        if not base_values:
+            self.stdout_write("WARNING: no year=0 population values found; budget may be empty")
+            return
+
+        to_create = []
+        for year in range(scenario.start_year, scenario.end_year + 1):
+            for v in base_values:
+                to_create.append(
+                    MetricValue(
+                        metric_type_id=v.metric_type_id,
+                        org_unit_id=v.org_unit_id,
+                        value=v.value,
+                        string_value=v.string_value,
+                        year=year,
+                    )
+                )
+
+        MetricValue.objects.bulk_create(to_create, ignore_conflicts=True)
+        self.stdout_write(
+            f"Extended {len(base_values)} population baseline values to {scenario.end_year - scenario.start_year + 1} scenario years"
+        )

--- a/management/commands/support/metrics_importer.py
+++ b/management/commands/support/metrics_importer.py
@@ -146,6 +146,8 @@ class MetricsImporter:
         for row in metareader:
             try:
                 metric_type = existing_metric_types.get(row["VARIABLE"])
+                is_population = (row.get("IS_POPULATION") or "False").lower() == "true"
+                metric_kind = MetricType.MetricKind.POPULATION if is_population else MetricType.MetricKind.ANY
                 if metric_type:
                     metric_type.name = row["LABEL"]
                     metric_type.description = row["DESCRIPTION"]
@@ -154,8 +156,8 @@ class MetricsImporter:
                     metric_type.category = row["CATEGORY"]
                     metric_type.unit_symbol = row["UNIT_SYMBOL"]
                     metric_type.legend_type = row["TYPE"].lower()
-                    metric_type.is_utility = row.get("IS_UTILITY", "False").lower() == "true"
-                    metric_type.metric_kind = MetricType.MetricKind.ANY
+                    metric_type.is_utility = (row.get("IS_UTILITY") or "False").lower() == "true"
+                    metric_type.metric_kind = metric_kind
                     metric_type.origin = MetricType.MetricTypeOrigin.OPENHEXA
                     to_update.append(metric_type)
                     self.stdout_write(
@@ -172,8 +174,8 @@ class MetricsImporter:
                         category=row["CATEGORY"],
                         unit_symbol=row["UNIT_SYMBOL"],
                         legend_type=row["TYPE"].lower(),
-                        is_utility=row.get("IS_UTILITY", "False").lower() == "true",
-                        metric_kind=MetricType.MetricKind.ANY,
+                        is_utility=(row.get("IS_UTILITY") or "False").lower() == "true",
+                        metric_kind=metric_kind,
                         origin=MetricType.MetricTypeOrigin.OPENHEXA,
                     )
                     to_create.append(metric_type)


### PR DESCRIPTION
## What problem is this PR solving?

Update demo account configuration with new budget entities

### Related JIRA tickets

SNT-489

## Changes

- Add `IS_POPULATION` flag on population metric types for demo account
- Link population layers to cost lines
- Clean up old budget properties which have been removed
- Set cost units
- Set yearly costs

## How to test

run: `docker-compose run --rm iaso manage recreate_demo_account`
It should work properly.
Now go to snt and login to the demo account and verify that:
- Cost lines have a population target
- cost units are defined
- Budget is already calculated
- There are yearly cost assignment on the scenario

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
