### PR TITLE
SNT-426 Only show trash icon on hover and remove edit button

### DIFF
--- a/js/src/domains/planning/components/scenarioRule/scenarioRuleList/ScenarioRuleLine.tsx
+++ b/js/src/domains/planning/components/scenarioRule/scenarioRuleList/ScenarioRuleLine.tsx
@@ -1,8 +1,6 @@
-import React, { FC, useMemo } from 'react';
-import EditIcon from '@mui/icons-material/Edit';
+import React, { FC, useMemo, useState } from 'react';
 import { Box, Grid, Typography } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
-import { EditIconButton } from 'Iaso/components/Buttons/EditIconButton';
 import { DeleteModal } from 'Iaso/components/DeleteRestoreModals/DeleteModal';
 import { SxStyles } from 'Iaso/types/general';
 import { noOp } from 'Iaso/utils';
@@ -15,9 +13,18 @@ import { ScenarioRule } from '../../../types/scenarioRule';
 const styles: SxStyles = {
     colorBox: {
         width: 16,
+        minWidth: 16,
         height: 16,
         mr: 2,
         borderRadius: '5px',
+    },
+    contentBox: {
+        width: '100%',
+    },
+    deleteAction: {
+        display: 'flex',
+        alignItems: 'center',
+        ml: 'auto',
     },
     rulesText: {
         ml: 4,
@@ -37,6 +44,7 @@ type Props = {
 
 export const ScenarioRuleLine: FC<Props> = ({ scenarioId, rule, onEdit }) => {
     const { formatMessage } = useSafeIntl();
+    const [hovered, setHovered] = useState(false);
     const { mutateAsync: deleteScenarioRule } =
         useDeleteScenarioRule(scenarioId);
 
@@ -75,53 +83,73 @@ export const ScenarioRuleLine: FC<Props> = ({ scenarioId, rule, onEdit }) => {
     }, [rule, metricTypeNames, formatMessage]);
 
     return (
-        <React.Fragment key={rule.id}>
-            <Grid container direction="row" alignItems="center" mb={1}>
-                <Box
-                    sx={{
-                        ...styles.colorBox,
-                        bgcolor: rule.color,
-                    }}
-                />
-                <Typography
-                    variant="body1"
-                    fontWeight="medium"
-                    sx={{ flexGrow: 1 }}
+        <Grid
+            container
+            direction="row"
+            justifyContent="space-between"
+            key={rule.id}
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+            onClick={isScenarioEditable ? () => onEdit(rule) : undefined}
+            sx={{
+                cursor: isScenarioEditable ? 'pointer' : 'default',
+            }}
+        >
+            <Box sx={styles.contentBox}>
+                <Grid
+                    container
+                    direction="row"
+                    alignItems="center"
+                    mb={1}
+                    flexWrap="nowrap"
                 >
-                    {rule.name ||
-                        generateRuleName(
-                            rule.interventions,
-                            interventionCategories,
-                        )}
-                </Typography>
-                {isScenarioEditable && (
-                    <>
-                        <EditIconButton
-                            onClick={() => onEdit(rule)}
-                            overrideIcon={EditIcon}
-                        />
-                        <DeleteModal
-                            type="icon"
-                            onConfirm={() => deleteScenarioRule(rule.id)}
-                            onCancel={noOp}
-                            titleMessage={MESSAGES.deleteScenarioRule}
-                            iconProps={{}}
-                            backdropClick={true}
-                        >
-                            {formatMessage(
-                                MESSAGES.deleteScenarioRuleConfirmMessage,
+                    <Box
+                        sx={{
+                            ...styles.colorBox,
+                            bgcolor: rule.color,
+                        }}
+                    />
+                    <Typography
+                        variant="body1"
+                        fontWeight="medium"
+                        flexGrow={1}
+                        my={1}
+                        noWrap
+                    >
+                        {rule.name ||
+                            generateRuleName(
+                                rule.interventions,
+                                interventionCategories,
                             )}
-                        </DeleteModal>
-                    </>
-                )}
-            </Grid>
-            <Typography
-                variant="body2"
-                color="textSecondary"
-                sx={styles.rulesText}
-            >
-                {metricTypeCriterionLabel}
-            </Typography>
-        </React.Fragment>
+                    </Typography>
+                    {isScenarioEditable && hovered && (
+                        <Box
+                            onClick={e => e.stopPropagation()}
+                            sx={styles.deleteAction}
+                        >
+                            <DeleteModal
+                                type="icon"
+                                onConfirm={() => deleteScenarioRule(rule.id)}
+                                onCancel={noOp}
+                                titleMessage={MESSAGES.deleteScenarioRule}
+                                iconProps={{}}
+                                backdropClick={true}
+                            >
+                                {formatMessage(
+                                    MESSAGES.deleteScenarioRuleConfirmMessage,
+                                )}
+                            </DeleteModal>
+                        </Box>
+                    )}
+                </Grid>
+                <Typography
+                    variant="body2"
+                    color="textSecondary"
+                    sx={styles.rulesText}
+                >
+                    {metricTypeCriterionLabel}
+                </Typography>
+            </Box>
+        </Grid>
     );
 };

--- a/js/src/domains/planning/components/scenarioRule/scenarioRuleList/ScenarioRuleLine.tsx
+++ b/js/src/domains/planning/components/scenarioRule/scenarioRuleList/ScenarioRuleLine.tsx
@@ -93,6 +93,7 @@ export const ScenarioRuleLine: FC<Props> = ({ scenarioId, rule, onEdit }) => {
             onClick={isScenarioEditable ? () => onEdit(rule) : undefined}
             sx={{
                 cursor: isScenarioEditable ? 'pointer' : 'default',
+                p: 2,
             }}
         >
             <Box sx={styles.contentBox}>
@@ -130,7 +131,7 @@ export const ScenarioRuleLine: FC<Props> = ({ scenarioId, rule, onEdit }) => {
                             <DeleteModal
                                 type="icon"
                                 onConfirm={() => deleteScenarioRule(rule.id)}
-                                onCancel={noOp}
+                                onCancel={() => setHovered(false)}
                                 titleMessage={MESSAGES.deleteScenarioRule}
                                 iconProps={{}}
                                 backdropClick={true}

--- a/js/src/domains/planning/components/scenarioRule/scenarioRuleList/ScenarioRulesContainer.tsx
+++ b/js/src/domains/planning/components/scenarioRule/scenarioRuleList/ScenarioRulesContainer.tsx
@@ -2,11 +2,11 @@ import React, { FC, Ref, useCallback } from 'react';
 import { AsyncSortableList } from 'bluesquare-components';
 import { SxStyles } from 'Iaso/types/general';
 import { CardStyled } from '../../../../../components/CardStyled';
+import { usePlanningContext } from '../../../contexts/PlanningContext';
 import { useReorderScenarioRules } from '../../../hooks/useReorderScenarioRules';
 import { ScenarioRule } from '../../../types/scenarioRule';
 import { ScenarioRuleLine } from './ScenarioRuleLine';
 import { ScenarioRulesHeader } from './ScenarioRulesHeader';
-import { usePlanningContext } from '../../../contexts/PlanningContext';
 
 const styles: SxStyles = {
     rulesContainer: {
@@ -14,7 +14,7 @@ const styles: SxStyles = {
     },
     ruleBox: {
         mb: 2,
-        p: 2,
+        p: 0,
         border: 1,
         borderColor: 'grey.300',
         borderRadius: 2,


### PR DESCRIPTION
## What problem is this PR solving?

Only show trash icon on hover and remove edit button

### Related JIRA tickets

SNT-526

## Changes

Rule list: 
- remove edit button and handle rule box click.
- Show delete button on hover of a rule box.

## How to test

Go to SNT, Scenario, in rule list, no action should be visible by default.
By hovering it, delete button should be shown and working.
By clicking on a rule, it should open the edit form.
Test the rule name overflow too.

## Print screen / video

<img width="918" height="674" alt="image" src="https://github.com/user-attachments/assets/74d4d9bd-7d5b-4bc4-9b22-888165529e7e" />

<img width="910" height="684" alt="image" src="https://github.com/user-attachments/assets/081d5867-19e5-4465-bdef-38732064017d" />


## Notes


## Doc

