### PR TITLE
SNT-506 Don't allow tab deselection

### DIFF
--- a/js/src/domains/planning/index.tsx
+++ b/js/src/domains/planning/index.tsx
@@ -5,10 +5,10 @@ import {
     useRedirectToReplace,
     useSafeIntl,
 } from 'bluesquare-components';
+import { useNavigate } from 'react-router';
 import TopBar from 'Iaso/components/nav/TopBarComponent';
 import { useParamsObject } from 'Iaso/routing/hooks/useParamsObject';
 import { SxStyles } from 'Iaso/types/general';
-import { useNavigate } from 'react-router';
 import { CardStyled } from '../../components/CardStyled';
 import {
     MainColumn,
@@ -128,6 +128,11 @@ export const Planning: FC = () => {
     const { mutate: previewScenarioRule, isLoading: isLoadingPreview } =
         usePreviewScenarioRule();
 
+    const onSetTab = useCallback(
+        (tab: string) => tab && setActiveTab(tab),
+        [setActiveTab],
+    );
+
     const onPreviewScenarioRule = useCallback(
         (rule?: Partial<ScenarioRule>) => {
             setPreviewRule(rule);
@@ -215,7 +220,7 @@ export const Planning: FC = () => {
                                 <CardStyled
                                     header={
                                         <InterventionPlanHeader
-                                            onTabChange={setActiveTab}
+                                            onTabChange={onSetTab}
                                             activeTab={activeTab}
                                             onDeleteScenario={
                                                 handleDeleteScenario


### PR DESCRIPTION
## What problem is this PR solving?

Don't allow tab deselection on planning

### Related JIRA tickets

SNT-506

## Changes

Don't update activate tab on setTab.

## How to test

Go to snt, scenario, on the right, try to click on selected tab, it should not be deselected.

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A