### PR TITLE
SNT-526 add buffer to general settings

### DIFF
--- a/js/src/constants/translations/en.json
+++ b/js/src/constants/translations/en.json
@@ -338,6 +338,7 @@
     "iaso.snt_malaria.settings.intervention.grant": "Grant",
     "iaso.snt_malaria.settings.general.title": "General",
     "iaso.snt_malaria.settings.budget.title": "Budget",
+    "iaso.snt_malaria.settings.budget.warning": "Changing these settings will not automatically recalculate existing budgets. Re-run the budget calculation on each scenario to apply the new values.",
     "iaso.snt_malaria.settings.budget.subtitle": "Set the currency and rates used to compute intervention costs and projections.",
     "iaso.snt_malaria.settings.budget.localCurrency": "Local currency (ISO code)",
     "iaso.snt_malaria.settings.budget.localCurrencyHelp": "Three-letter code, e.g. USD, EUR, XOF.",

--- a/js/src/constants/translations/en.json
+++ b/js/src/constants/translations/en.json
@@ -345,5 +345,7 @@
     "iaso.snt_malaria.settings.budget.inflationRate": "Annual inflation rate",
     "iaso.snt_malaria.settings.budget.inflationRateHelp": "Decimal value, e.g. 0.03 for 3%.",
     "iaso.snt_malaria.settings.budget.invalidNumber": "Please enter a valid number.",
-    "iaso.snt_malaria.settings.budget.invalidCurrencyCode": "Enter a 3-letter currency code."
+    "iaso.snt_malaria.settings.budget.invalidCurrencyCode": "Enter a 3-letter currency code.",
+    "iaso.snt_malaria.settings.budget.buffer": "Buffer multiplier",
+    "iaso.snt_malaria.settings.budget.bufferHelp": "Multiplier applied to all costs, e.g. 1.1 for a 10% buffer."
 }

--- a/js/src/constants/translations/fr.json
+++ b/js/src/constants/translations/fr.json
@@ -337,6 +337,7 @@
     "iaso.snt_malaria.settings.intervention.grant": "Subvention",
     "iaso.snt_malaria.settings.general.title": "Général",
     "iaso.snt_malaria.settings.budget.title": "Budget",
+    "iaso.snt_malaria.settings.budget.warning": "Modifier ces paramètres ne recalculera pas automatiquement les budgets existants. Relancez le calcul du budget sur chaque scénario pour appliquer les nouvelles valeurs.",
     "iaso.snt_malaria.settings.budget.subtitle": "Définissez la devise et les taux utilisés pour calculer les coûts des interventions et les projections.",
     "iaso.snt_malaria.settings.budget.localCurrency": "Devise locale (code ISO)",
     "iaso.snt_malaria.settings.budget.localCurrencyHelp": "Code à trois lettres, ex. USD, EUR, XOF.",

--- a/js/src/constants/translations/fr.json
+++ b/js/src/constants/translations/fr.json
@@ -344,5 +344,7 @@
     "iaso.snt_malaria.settings.budget.inflationRate": "Taux d'inflation annuel",
     "iaso.snt_malaria.settings.budget.inflationRateHelp": "Valeur décimale, ex. 0,03 pour 3 %.",
     "iaso.snt_malaria.settings.budget.invalidNumber": "Veuillez saisir un nombre valide.",
-    "iaso.snt_malaria.settings.budget.invalidCurrencyCode": "Saisissez un code de devise à 3 lettres."
+    "iaso.snt_malaria.settings.budget.invalidCurrencyCode": "Saisissez un code de devise à 3 lettres.",
+    "iaso.snt_malaria.settings.budget.buffer": "Multiplicateur de marge",
+    "iaso.snt_malaria.settings.budget.bufferHelp": "Multiplicateur appliqué à tous les coûts, ex. 1,1 pour une marge de 10 %."
 }

--- a/js/src/domains/messages.ts
+++ b/js/src/domains/messages.ts
@@ -1008,6 +1008,11 @@ export const MESSAGES = defineMessages({
         defaultMessage:
             'Set the currency and rates used to compute intervention costs and projections.',
     },
+    budgetSettingsWarning: {
+        id: 'iaso.snt_malaria.settings.budget.warning',
+        defaultMessage:
+            'Changing these settings will not automatically recalculate existing budgets. Re-run the budget calculation on each scenario to apply the new values.',
+    },
     budgetLocalCurrency: {
         id: 'iaso.snt_malaria.settings.budget.localCurrency',
         defaultMessage: 'Local currency (ISO code)',

--- a/js/src/domains/messages.ts
+++ b/js/src/domains/messages.ts
@@ -1036,4 +1036,13 @@ export const MESSAGES = defineMessages({
         id: 'iaso.snt_malaria.settings.budget.invalidCurrencyCode',
         defaultMessage: 'Enter a 3-letter currency code.',
     },
+    budgetBuffer: {
+        id: 'iaso.snt_malaria.settings.budget.buffer',
+        defaultMessage: 'Buffer multiplier',
+    },
+    budgetBufferHelp: {
+        id: 'iaso.snt_malaria.settings.budget.bufferHelp',
+        defaultMessage:
+            'Multiplier applied to all costs, e.g. 1.1 for a 10% buffer.',
+    },
 });

--- a/js/src/domains/settings/budget/hooks/useBudgetSettingsFormState.tsx
+++ b/js/src/domains/settings/budget/hooks/useBudgetSettingsFormState.tsx
@@ -31,6 +31,10 @@ const useValidation = () => {
                     .typeError(formatMessage(MESSAGES.budgetInvalidNumber))
                     .min(0, formatMessage(MESSAGES.negativeValueNotAllowed))
                     .required(formatMessage(MESSAGES.required)),
+                buffer: Yup.number()
+                    .typeError(formatMessage(MESSAGES.budgetInvalidNumber))
+                    .min(0, formatMessage(MESSAGES.negativeValueNotAllowed))
+                    .required(formatMessage(MESSAGES.required)),
             }),
         [formatMessage],
     );

--- a/js/src/domains/settings/budget/index.tsx
+++ b/js/src/domains/settings/budget/index.tsx
@@ -31,6 +31,7 @@ export const BudgetSettingsTab: FC = () => {
             local_currency: budgetSettings?.local_currency ?? '',
             exchange_rate: budgetSettings?.exchange_rate ?? '1',
             inflation_rate: budgetSettings?.inflation_rate ?? '0',
+            buffer: budgetSettings?.buffer ?? '1.1',
         }),
         [budgetSettings],
     );
@@ -45,6 +46,7 @@ export const BudgetSettingsTab: FC = () => {
                 local_currency: values.local_currency.toUpperCase(),
                 exchange_rate: values.exchange_rate,
                 inflation_rate: values.inflation_rate,
+                buffer: values.buffer,
             });
         },
         [saveBudgetSettings],
@@ -142,6 +144,19 @@ export const BudgetSettingsTab: FC = () => {
                             )}
                             helperText={formatMessage(
                                 MESSAGES.budgetInflationRateHelp,
+                            )}
+                            withMarginTop={false}
+                        />
+                        <InputComponent
+                            keyValue="buffer"
+                            type="number"
+                            required
+                            value={values.buffer}
+                            onChange={onChange}
+                            errors={getErrors('buffer')}
+                            labelString={formatMessage(MESSAGES.budgetBuffer)}
+                            helperText={formatMessage(
+                                MESSAGES.budgetBufferHelp,
                             )}
                             withMarginTop={false}
                         />

--- a/js/src/domains/settings/budget/index.tsx
+++ b/js/src/domains/settings/budget/index.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useCallback, useMemo } from 'react';
 import { TollOutlined } from '@mui/icons-material';
 import CheckIcon from '@mui/icons-material/Check';
-import { Stack, Typography } from '@mui/material';
+import { Alert, Stack, Typography } from '@mui/material';
 import { Button } from '@mui/material';
 import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
 import InputComponent from 'Iaso/components/forms/InputComponent';
@@ -101,6 +101,9 @@ export const BudgetSettingsTab: FC = () => {
                 }
             >
                 {isLoading && <LoadingSpinner absolute />}
+                <Alert severity="warning">
+                    {formatMessage(MESSAGES.budgetSettingsWarning)}
+                </Alert>
                 <SettingsFormContainer>
                     <Stack spacing={2}>
                         <Typography variant="caption" color="textSecondary">

--- a/js/src/domains/settings/budget/types.ts
+++ b/js/src/domains/settings/budget/types.ts
@@ -3,6 +3,7 @@ export type BudgetSettings = {
     local_currency: string;
     exchange_rate: string;
     inflation_rate: string;
+    buffer: string;
 };
 
 export type BudgetSettingsPayload = {
@@ -10,6 +11,7 @@ export type BudgetSettingsPayload = {
     local_currency: string;
     exchange_rate: string | number;
     inflation_rate: string | number;
+    buffer: string | number;
 };
 
 export type BudgetSettingsFormValues = {
@@ -17,4 +19,5 @@ export type BudgetSettingsFormValues = {
     local_currency: string;
     exchange_rate: string | number;
     inflation_rate: string | number;
+    buffer: string | number;
 };


### PR DESCRIPTION
## What problem is this PR solving?

Add buffer to general settings

### Related JIRA tickets

SNT-526

## Changes

Add buffer to general settings tab.
Add a warning to let user know that budget are not auto matically refreshed.

## How to test

Go to settings, general tab and modify the buffer.
Go to a scenario with a budget, save a rule or change a coverage to recalculate the budget and verify on the tooltip that it is using your new value.

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
