### PR TITLE
SNT-531 Multi map support in data layer

### DIFF
--- a/js/src/components/CardStyled.tsx
+++ b/js/src/components/CardStyled.tsx
@@ -1,12 +1,16 @@
-import React, { FC, ReactNode } from 'react';
-import { CardContent, CardHeader } from '@mui/material';
+import React, { FC, ReactNode, useMemo } from 'react';
+import { CardContent, CardHeader, SxProps } from '@mui/material';
 import { LoadingSpinner } from 'bluesquare-components';
 import { SxStyles } from 'Iaso/types/general';
 
-const styles: SxStyles = {
+const styles = {
     cardHeader: {
         pb: 0,
         minHeight: '65px',
+        '& .MuiCardHeader-content': {
+            overflow: 'hidden',
+            minWidth: 0,
+        },
     },
     cardContent: {
         overflow: 'auto',
@@ -16,18 +20,31 @@ const styles: SxStyles = {
             paddingBottom: 2,
         },
     },
-};
+} satisfies SxStyles;
 
 type Props = {
     header?: ReactNode;
     isLoading?: boolean;
+    headerSx?: SxProps;
     children: ReactNode;
 };
 
-export const CardStyled: FC<Props> = ({ header, isLoading, children }) => {
+export const CardStyled: FC<Props> = ({
+    header,
+    isLoading,
+    headerSx,
+    children,
+}) => {
+    const headerStyles = useMemo(
+        () =>
+            headerSx
+                ? { ...styles.cardHeader, ...headerSx }
+                : styles.cardHeader,
+        [headerSx],
+    );
     return (
         <>
-            <CardHeader sx={styles.cardHeader} title={header} />
+            <CardHeader sx={headerStyles} title={header} />
 
             <CardContent sx={styles.cardContent}>
                 {isLoading ? <LoadingSpinner absolute={true} /> : children}

--- a/js/src/components/OrgUnitSelect.tsx
+++ b/js/src/components/OrgUnitSelect.tsx
@@ -8,7 +8,7 @@ import { useGetOrgUnits } from '../domains/planning/hooks/useGetOrgUnits';
 
 const styles = {
     select: {
-        minWidth: '225px',
+        minWidth: '175px',
     },
 } satisfies SxStyles;
 

--- a/js/src/constants/translations/en.json
+++ b/js/src/constants/translations/en.json
@@ -106,6 +106,7 @@
     "iaso.snt_malaria.settings.dataLayers.scale": "Scale",
     "iaso.snt_malaria.settings.dataLayers.legendType": "Legend Type",
     "iaso.snt_malaria.settings.dataLayers.editLayer": "Edit Layer",
+    "ias.snt_malaria.settings.dataLayers.addToComparison": "Add to comparison maps",
     "iaso.snt_malaria.settings.dataLayers.deleteLayer": "Delete Layer",
     "iaso.snt_malaria.settings.dataLayers.deleteLayerConfirmMessage": "Are you sure you want to delete this layer?",
     "iaso.snt_malaria.settings.dataLayers.downloadCSVTemplate": "Download CSV Template",

--- a/js/src/constants/translations/fr.json
+++ b/js/src/constants/translations/fr.json
@@ -105,6 +105,7 @@
     "iaso.snt_malaria.settings.dataLayers.scale": "Echelle",
     "iaso.snt_malaria.settings.dataLayers.legendType": "Type de légende",
     "iaso.snt_malaria.settings.dataLayers.editLayer": "Modifier la couche",
+    "ias.snt_malaria.settings.dataLayers.addToComparison": "Ajouter aux cartes de comparaison",
     "iaso.snt_malaria.settings.dataLayers.deleteLayer": "Supprimer la couche",
     "iaso.snt_malaria.settings.dataLayers.deleteLayerConfirmMessage": "Êtes-vous sûr de vouloir supprimer ce type de métrique ?",
     "iaso.snt_malaria.settings.dataLayers.downloadCSVTemplate": "Télécharger le Template CSV",

--- a/js/src/domains/dataLayers/contexts/DataLayerComparisonContext.tsx
+++ b/js/src/domains/dataLayers/contexts/DataLayerComparisonContext.tsx
@@ -1,0 +1,78 @@
+import React, {
+    createContext,
+    useCallback,
+    useContext,
+    useState,
+} from 'react';
+import { OrgUnit } from 'Iaso/domains/orgUnits/types/orgUnit';
+import { MetricType } from '../types/metrics';
+
+const MAX_METRICS = 4;
+
+type DataLayerComparisonContextType = {
+    maxMetricsCountReached: boolean;
+    comparisonMetricTypes: MetricType[];
+    addMetricToComparison: (metricType: MetricType) => void;
+    // We need the index here as we can have multiple time the same metric on state.
+    removeMetricFromComparison: (metricType: number, index: number) => void;
+    orgUnits: OrgUnit[];
+};
+
+const DataLayerComparisonContext =
+    createContext<DataLayerComparisonContextType>({
+        maxMetricsCountReached: false,
+        comparisonMetricTypes: [],
+        orgUnits: [],
+        addMetricToComparison: () => {},
+        removeMetricFromComparison: () => {},
+    });
+
+export const useDataLayerComparisonContext = () =>
+    useContext(DataLayerComparisonContext);
+
+export const DataLayerComparisonProvider = ({
+    orgUnits,
+    children,
+}: {
+    orgUnits: OrgUnit[];
+    children: React.ReactNode;
+}) => {
+    const [comparisonMetricTypes, setComparisonMetricTypes] = useState<
+        MetricType[]
+    >([]);
+
+    const maxMetricsCountReached = comparisonMetricTypes.length >= MAX_METRICS;
+    const addMetricToComparison = useCallback(
+        (metricType: MetricType) => {
+            if (maxMetricsCountReached) return;
+
+            setComparisonMetricTypes([...comparisonMetricTypes, metricType]);
+        },
+        [comparisonMetricTypes, maxMetricsCountReached],
+    );
+
+    const removeMetricFromComparison = useCallback(
+        (metricType: number, index: number) => {
+            if (comparisonMetricTypes?.[index].id !== metricType) return;
+
+            const newValue = [...comparisonMetricTypes];
+            newValue.splice(index, 1);
+            setComparisonMetricTypes(newValue);
+        },
+        [comparisonMetricTypes],
+    );
+
+    return (
+        <DataLayerComparisonContext.Provider
+            value={{
+                maxMetricsCountReached,
+                addMetricToComparison,
+                removeMetricFromComparison,
+                orgUnits,
+                comparisonMetricTypes,
+            }}
+        >
+            {children}
+        </DataLayerComparisonContext.Provider>
+    );
+};

--- a/js/src/domains/dataLayers/dataLayerComparison/dataLayerComparisonContainer.tsx
+++ b/js/src/domains/dataLayers/dataLayerComparison/dataLayerComparisonContainer.tsx
@@ -1,0 +1,45 @@
+import React, { FC } from 'react';
+import { Box, Stack } from '@mui/material';
+import { SxStyles } from 'Iaso/types/general';
+import { useDataLayerComparisonContext } from '../contexts/DataLayerComparisonContext';
+import { DataLayerMapWrapper } from '../dataLayerMap/DataLayerMapWrapper';
+
+const styles = {
+    stack: {
+        maxHeight: '100%',
+        overflow: 'auto',
+        scrollbarWidth: 'none',
+        '&::-webkit-scrollbar': { display: 'none' },
+        width: '33%',
+    },
+    items: {
+        minHeight: '50%',
+        height: '50%',
+    },
+} satisfies SxStyles;
+
+export const DataLayerComparisonContainer: FC = ({}) => {
+    const { orgUnits, comparisonMetricTypes, removeMetricFromComparison } =
+        useDataLayerComparisonContext();
+    return comparisonMetricTypes?.length <= 0 ? null : (
+        <Stack direction="column" sx={styles.stack} gap={2}>
+            {React.Children.toArray(
+                comparisonMetricTypes.map((metricType, index) => (
+                    <Box sx={styles.items}>
+                        <DataLayerMapWrapper
+                            orgUnits={orgUnits}
+                            metricType={metricType}
+                            small={true}
+                            onRemove={() =>
+                                removeMetricFromComparison(
+                                    metricType?.id,
+                                    index,
+                                )
+                            }
+                        />
+                    </Box>
+                )),
+            )}
+        </Stack>
+    );
+};

--- a/js/src/domains/dataLayers/dataLayerComparison/dataLayerComparisonContainer.tsx
+++ b/js/src/domains/dataLayers/dataLayerComparison/dataLayerComparisonContainer.tsx
@@ -13,8 +13,8 @@ const styles = {
         width: '33%',
     },
     items: {
-        minHeight: '50%',
-        height: '50%',
+        minHeight: 'calc(50% - .25rem)',
+        height: 'calc(50% - .25rem)',
     },
 } satisfies SxStyles;
 
@@ -22,7 +22,7 @@ export const DataLayerComparisonContainer: FC = ({}) => {
     const { orgUnits, comparisonMetricTypes, removeMetricFromComparison } =
         useDataLayerComparisonContext();
     return comparisonMetricTypes?.length <= 0 ? null : (
-        <Stack direction="column" sx={styles.stack} gap={2}>
+        <Stack direction="column" sx={styles.stack} gap={1}>
             {React.Children.toArray(
                 comparisonMetricTypes.map((metricType, index) => (
                     <Box sx={styles.items}>

--- a/js/src/domains/dataLayers/dataLayerList/DataLayerLine.tsx
+++ b/js/src/domains/dataLayers/dataLayerList/DataLayerLine.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useCallback } from 'react';
+import AddCircleOutlineOutlinedIcon from '@mui/icons-material/AddCircleOutlineOutlined';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import {
     Box,
@@ -15,6 +16,7 @@ import { DeleteModal } from 'Iaso/components/DeleteRestoreModals/DeleteModal';
 import { DisplayIfUserHasPerm } from 'Iaso/components/DisplayIfUserHasPerm';
 import { SxStyles } from 'Iaso/types/general';
 import * as CorePermission from 'Iaso/utils/permissions';
+import { useDataLayerComparisonContext } from '../contexts/DataLayerComparisonContext';
 import { MESSAGES } from '../messages';
 import { MetricType } from '../types/metrics';
 
@@ -29,14 +31,15 @@ type Props = {
 const styles: SxStyles = {
     metricType: {
         borderRadius: 2,
+        py: 0,
         border: '1px solid transparent',
         cursor: 'pointer',
-        ' .MuiListItemSecondaryAction-root': {
+        ' .action-box, .MuiListItemSecondaryAction-root': {
             visibility: 'hidden',
         },
         '&:hover': {
             bgcolor: 'action.hover',
-            ' .MuiListItemSecondaryAction-root': {
+            ' .action-box, .MuiListItemSecondaryAction-root': {
                 visibility: 'visible',
             },
         },
@@ -53,6 +56,7 @@ const styles: SxStyles = {
         display: 'flex',
         justifyContent: 'space-between',
         marginRight: 4,
+        py: 2,
     },
 };
 
@@ -69,6 +73,15 @@ export const DataLayerLine: FC<Props> = ({
     const toggleMoreActions = useCallback(() => {
         setShowMoreActions(!showMoreActions);
     }, [showMoreActions]);
+    const { addMetricToComparison, maxMetricsCountReached } =
+        useDataLayerComparisonContext();
+    const onAddMetricToComparison = useCallback(
+        (e: Event) => {
+            e.stopPropagation();
+            addMetricToComparison(metricType);
+        },
+        [addMetricToComparison, metricType],
+    );
 
     return (
         <ListItem
@@ -97,40 +110,53 @@ export const DataLayerLine: FC<Props> = ({
             <Box sx={styles.metricTypeDetails}>
                 <Typography variant="body2">{metricType.name}</Typography>
             </Box>
-            <Popover
-                id="metric_type_line_actions"
-                open={showMoreActions}
-                anchorEl={anchorRef.current}
-                anchorOrigin={{
-                    vertical: 'bottom',
-                    horizontal: 'right',
-                }}
-                transformOrigin={{
-                    vertical: 'top',
-                    horizontal: 'right',
-                }}
-            >
-                <ClickAwayListener
-                    onClickAway={() => setShowMoreActions(false)}
+            <Box className="action-box">
+                {maxMetricsCountReached ? undefined : (
+                    <IconButton
+                        aria-label="add-to-comparison"
+                        tooltipMessage={MESSAGES.addToComparison}
+                        overrideIcon={AddCircleOutlineOutlinedIcon}
+                        disabled={maxMetricsCountReached}
+                        onClick={onAddMetricToComparison}
+                    ></IconButton>
+                )}
+                <Popover
+                    id="metric_type_line_actions"
+                    open={showMoreActions}
+                    anchorEl={anchorRef.current}
+                    anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'right',
+                    }}
+                    transformOrigin={{
+                        vertical: 'top',
+                        horizontal: 'right',
+                    }}
                 >
-                    <MenuList>
-                        <MenuItem onClick={() => onEdit(metricType)}>
-                            {formatMessage(MESSAGES.editLayer)}
-                        </MenuItem>
-                        <DeleteModal
-                            type="menuItem"
-                            onConfirm={() => onDelete(metricType.id)}
-                            onCancel={() => setShowMoreActions(false)}
-                            titleMessage={MESSAGES.deleteLayer}
-                            iconProps={{}}
-                            key={`delete-layer-${metricType.id}`}
-                            backdropClick={true}
-                        >
-                            {formatMessage(MESSAGES.deleteLayerConfirmMessage)}
-                        </DeleteModal>
-                    </MenuList>
-                </ClickAwayListener>
-            </Popover>
+                    <ClickAwayListener
+                        onClickAway={() => setShowMoreActions(false)}
+                    >
+                        <MenuList>
+                            <MenuItem onClick={() => onEdit(metricType)}>
+                                {formatMessage(MESSAGES.editLayer)}
+                            </MenuItem>
+                            <DeleteModal
+                                type="menuItem"
+                                onConfirm={() => onDelete(metricType.id)}
+                                onCancel={() => setShowMoreActions(false)}
+                                titleMessage={MESSAGES.deleteLayer}
+                                iconProps={{}}
+                                key={`delete-layer-${metricType.id}`}
+                                backdropClick={true}
+                            >
+                                {formatMessage(
+                                    MESSAGES.deleteLayerConfirmMessage,
+                                )}
+                            </DeleteModal>
+                        </MenuList>
+                    </ClickAwayListener>
+                </Popover>
+            </Box>
         </ListItem>
     );
 };

--- a/js/src/domains/dataLayers/dataLayerMap/DataLayerMapWrapper.tsx
+++ b/js/src/domains/dataLayers/dataLayerMap/DataLayerMapWrapper.tsx
@@ -1,19 +1,36 @@
 import React, { FC, useCallback, useEffect, useState } from 'react';
-import { Card, MenuItem, Select, Stack, Typography } from '@mui/material';
-import { LoadingSpinner, useRedirectToReplace } from 'bluesquare-components';
+import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined';
+import {
+    Card,
+    MenuItem,
+    Select,
+    Stack,
+    Tooltip,
+    Typography,
+} from '@mui/material';
+import {
+    IconButton,
+    LoadingSpinner,
+    useRedirectToReplace,
+} from 'bluesquare-components';
 import { OrgUnit } from 'Iaso/domains/orgUnits/types/orgUnit';
 import { CardStyled } from '../../../components/CardStyled';
 import { OrgUnitSelect } from '../../../components/OrgUnitSelect';
 import { baseUrls } from '../../../constants/urls';
+import { MESSAGES } from '../../messages';
 import { useGetMetricValues } from '../hooks/useGetMetrics';
 import { MetricType, MetricValue } from '../types/metrics';
 import { DataLayerMap } from './DataLayerMap';
 
 const styles = {
     card: {
+        flexGrow: 1,
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
+    },
+    smallHeader: {
+        minHeight: '36px',
     },
 };
 
@@ -21,12 +38,16 @@ type Props = {
     metricType?: MetricType;
     orgUnits?: OrgUnit[];
     displayOrgUnitId?: number;
+    small?: boolean;
+    onRemove?: () => void;
 };
 
 export const DataLayerMapWrapper: FC<Props> = ({
     metricType,
     orgUnits,
     displayOrgUnitId,
+    small = false,
+    onRemove,
 }) => {
     const { data: metricValues, isLoading: loadingMetricValues } =
         useGetMetricValues({
@@ -83,16 +104,29 @@ export const DataLayerMapWrapper: FC<Props> = ({
     return (
         <Card sx={styles.card}>
             <CardStyled
+                headerSx={small ? styles.smallHeader : undefined}
                 header={
                     <Stack
                         direction="row"
                         justifyContent="space-between"
                         alignItems="center"
+                        overflow="hidden"
                     >
-                        <Typography variant="h6">
-                            {metricType?.name || ''}
-                        </Typography>
-                        <Stack direction="row" spacing={2} alignItems="end">
+                        <Tooltip title={metricType?.name || ''}>
+                            <Typography
+                                variant={small ? 'body2' : 'h6'}
+                                noWrap
+                                sx={{ flex: 1, minWidth: 0, paddingRight: 1 }}
+                            >
+                                {metricType?.name || ''}
+                            </Typography>
+                        </Tooltip>
+                        <Stack
+                            direction="row"
+                            spacing={2}
+                            alignItems="end"
+                            sx={{ flexShrink: 0 }}
+                        >
                             {metricType?.metric_kind === 'population' && (
                                 <Select
                                     value={year}
@@ -110,11 +144,20 @@ export const DataLayerMapWrapper: FC<Props> = ({
                                     ))}
                                 </Select>
                             )}
-
-                            <OrgUnitSelect
-                                onOrgUnitChange={handleDisplayOrgUnitChange}
-                                selectedOrgUnitId={displayOrgUnitId}
-                            />
+                            {small ? null : (
+                                <OrgUnitSelect
+                                    onOrgUnitChange={handleDisplayOrgUnitChange}
+                                    selectedOrgUnitId={displayOrgUnitId}
+                                />
+                            )}
+                            {(onRemove && (
+                                <IconButton
+                                    overrideIcon={CancelOutlinedIcon}
+                                    tooltipMessage={MESSAGES.remove}
+                                    onClick={onRemove}
+                                ></IconButton>
+                            )) ||
+                                null}
                         </Stack>
                     </Stack>
                 }

--- a/js/src/domains/dataLayers/index.tsx
+++ b/js/src/domains/dataLayers/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback, useMemo, useState } from 'react';
-import { Card } from '@mui/material';
+import { Card, Stack } from '@mui/material';
 import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
 import TopBar from 'Iaso/components/nav/TopBarComponent';
 import { useParamsObject } from 'Iaso/routing/hooks/useParamsObject';
@@ -17,6 +17,8 @@ import { baseUrls } from '../../constants/urls';
 import { useOnboarding } from '../../hooks/useOnboarding';
 import { useGetAccountSettings } from '../planning/hooks/useGetAccountSettings';
 import { useGetOrgUnits } from '../planning/hooks/useGetOrgUnits';
+import { DataLayerComparisonProvider } from './contexts/DataLayerComparisonContext';
+import { DataLayerComparisonContainer } from './dataLayerComparison/dataLayerComparisonContainer';
 import { DataLayerDialog } from './dataLayerForm/DataLayerDialog';
 import { DataLayerList } from './dataLayerList/DataLayerList';
 import { DataLayerListHeader } from './dataLayerList/DataLayerListHeader';
@@ -125,7 +127,7 @@ export const DataLayers: FC = () => {
     });
 
     return (
-        <>
+        <DataLayerComparisonProvider orgUnits={orgUnits ?? []}>
             {isLoadingMetricLayers && <LoadingSpinner />}
             <TopBar
                 title={formatMessage(MESSAGES.dataLayersTitle)}
@@ -166,10 +168,17 @@ export const DataLayers: FC = () => {
                     </SidebarColumn>
                     <MainColumn>
                         <PaperFullHeight>
-                            <DataLayerMapWrapper
-                                metricType={displayedMetricType}
-                                orgUnits={orgUnits || []}
-                            />
+                            <Stack
+                                direction="row"
+                                gap={2}
+                                sx={{ height: '100%' }}
+                            >
+                                <DataLayerMapWrapper
+                                    metricType={displayedMetricType}
+                                    orgUnits={orgUnits || []}
+                                />
+                                <DataLayerComparisonContainer />
+                            </Stack>
                         </PaperFullHeight>
                     </MainColumn>
                 </SidebarLayout>
@@ -183,6 +192,6 @@ export const DataLayers: FC = () => {
                 )}
             </PageContainer>
             {onboarding.element}
-        </>
+        </DataLayerComparisonProvider>
     );
 };

--- a/js/src/domains/dataLayers/index.tsx
+++ b/js/src/domains/dataLayers/index.tsx
@@ -170,7 +170,7 @@ export const DataLayers: FC = () => {
                         <PaperFullHeight>
                             <Stack
                                 direction="row"
-                                gap={2}
+                                gap={1}
                                 sx={{ height: '100%' }}
                             >
                                 <DataLayerMapWrapper

--- a/js/src/domains/dataLayers/messages.ts
+++ b/js/src/domains/dataLayers/messages.ts
@@ -45,6 +45,10 @@ export const MESSAGES = defineMessages({
         id: 'iaso.snt_malaria.settings.dataLayers.editLayer',
         defaultMessage: 'Edit Layer',
     },
+    addToComparison: {
+        id: 'ias.snt_malaria.settings.dataLayers.addToComparison',
+        defaultMessage: 'Add to comparison maps',
+    },
     codeImmutableErrorHeadline: {
         id: 'iaso.snt_malaria.settings.dataLayers.errors.codeImmutableHeadline',
         defaultMessage: 'Layer code is immutable.',


### PR DESCRIPTION
## What problem is this PR solving?

Multi map support in data layer

### Related JIRA tickets

SNT-531

## Changes

- Add data layer comparis context
- Add an action to add a layer to the comparison list
- Add styles for small maps
- Add an action to remove layer from the comparison list

## How to test

Go to data layer, hover one of them, you should see a "+" button. 
Clicking on the line, should select the layer as main layer.
Clicking on the "+" should only add it to the comparison list.
Comparison list should be smaller.
No org unit selection should be available on small maps.
Verify that you can add a maximum of 4 map to the comparison panel.
Try to add twice the same map, then removing one should remove the one in the correct index.

## Print screen / video

https://github.com/user-attachments/assets/655718f5-452f-4e12-9cfb-de4d0277deaa

## Notes

N/A

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
