### PR TITLE
Fix: Add missing deepcopy import on scenario utils

### DIFF
--- a/api/scenarios/utils.py
+++ b/api/scenarios/utils.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from copy import deepcopy
 from datetime import datetime
 
 import pandas as pd


### PR DESCRIPTION
## What problem is this PR solving?

Add missing import when duplicating scenario
