### PR TITLE
SNT-533 generate flume by claude

### DIFF
--- a/api/account_settings/serializers.py
+++ b/api/account_settings/serializers.py
@@ -26,6 +26,9 @@ class AccountSettingsSerializer(serializers.ModelSerializer):
         required=False,
         allow_null=True,
     )
+    # Lets the frontend decide whether to show AI-powered features (e.g. the composite layer chat
+    # panel) without ever exposing the key itself.
+    has_ai_api_key = serializers.SerializerMethodField()
 
     class Meta:
         model = AccountSettings
@@ -35,11 +38,16 @@ class AccountSettingsSerializer(serializers.ModelSerializer):
             "focus_org_unit_type_id",
             "intervention_org_unit_type_id",
             "default_population_id",
+            "has_ai_api_key",
         ]
         read_only_fields = [
             "id",
             "account",
+            "has_ai_api_key",
         ]
+
+    def get_has_ai_api_key(self, obj: AccountSettings) -> bool:
+        return bool(obj.account.anthropic_api_key)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/api/composite_layer_ai/agent.py
+++ b/api/composite_layer_ai/agent.py
@@ -1,0 +1,187 @@
+import json
+import logging
+
+from typing import Optional
+
+import anthropic
+
+from django.conf import settings
+from pydantic import BaseModel
+
+
+logger = logging.getLogger(__name__)
+
+
+COMPOSITE_LAYER_SYSTEM_PROMPT_TEMPLATE = """You are an expert at building composite malaria data layers with a visual node graph editor.
+
+A composite layer is a small directed graph of nodes, evaluated per org unit:
+- `dataLayer`: reads an existing data layer (metric type), unmodified.
+- `formula`: evaluates an infix math expression over one or more inputs. Inputs are referenced
+  inside the formula as `a`, `b`, `c`, ... in the same order as the node's `inputs` list. An input
+  is usually numeric, but it can also be the categorical text label produced by a `classify` node -
+  in that case only compare it against a string literal (e.g. `a == "High"`), don't use it in
+  arithmetic. Supported: + - * / ^, comparisons, and the functions abs/min/max/round.
+- `classify`: maps a single numeric input to a category label using an ordered list of threshold
+  rules (e.g. "< 100" -> "Low"), with a `default` label used when no rule matches. A `classify`
+  node's own output is categorical (text). It CAN feed a `formula` node (e.g. to compare it against
+  a string literal, like `a == "High"`), but it CANNOT feed another `classify` node, since `classify`
+  requires a numeric input.
+- The graph has exactly one final output: it references the node whose result becomes the composite
+  layer (`source`), a `name`, and a `legend_type` (one of "auto", "linear", "threshold", "ordinal";
+  "auto" picks a sensible default based on the result - use it unless the user asks for a specific one).
+
+## Available data layers for this account
+{metric_types_catalog}
+
+When the user asks you to create or modify a composite layer, you MUST respond with valid JSON
+matching this schema, and no text outside the JSON block:
+{{
+  "graph": {{
+    "nodes": [
+      {{"id": "<unique id you choose, e.g. \\"rainfall\\">", "type": "dataLayer", "metric_type_id": "<id from the catalog above, as a string>"}},
+      {{"id": "<unique id>", "type": "formula", "inputs": ["<id of another node>", ...], "formula": "<infix expression using a, b, c, ...>"}},
+      {{"id": "<unique id>", "type": "classify", "input": "<id of a numeric-producing node>", "rules": [{{"op": "<", "value": 100, "label": "Low"}}], "default": "<label for anything matching no rule>"}}
+    ],
+    "output": {{"source": "<id of the node producing the final result>", "name": "<human readable name>", "legend_type": "auto"}}
+  }},
+  "message": "<your explanation to the user of what you created or changed>"
+}}
+
+## Rules
+- Only reference data layer ids that appear in the catalog above.
+- Every node needs a unique `id`; reference nodes by that id from `inputs`/`input`/`source`.
+- A graph can mix any number of `dataLayer`, `formula` and `classify` nodes - chain them as needed
+  (e.g. combine two layers with a formula, then reclassify the result into categories).
+- `formula` nodes need at least one input.
+- `classify` nodes need at least one rule, a default, or both.
+- When the user asks to modify a previously generated composite layer, return the COMPLETE updated
+  graph, not just the change and ask if it should be applied on the data layer editor directly.
+- If the request is ambiguous or no matching data layer exists, respond with plain text asking a
+  clarifying question instead of JSON.
+- Prefer a `classify` node over emulating one with a `formula` ternary/if-else whenever the goal is
+  to bucket a numeric layer into labels (e.g. "Low"/"Medium"/"High") - do this even when the
+  categorized result is NOT the final output and needs further processing. Chain `classify` into a
+  downstream `formula` (comparing its label, e.g. `a == "High"`) rather than reimplementing the same
+  thresholds as comparisons inside one big formula. A categorical (text) result is a normal, valid
+  output on its own and does not need to be summable to be useful, so do not avoid `classify` just
+  because its output is text or because more nodes follow it. 
+  
+"""
+
+
+class GraphNodeSpec(BaseModel, extra="allow"):
+    id: str
+    type: str
+    # dataLayer
+    metric_type_id: Optional[str] = None
+    # formula
+    inputs: Optional[list[str]] = None
+    formula: Optional[str] = None
+    # classify
+    input: Optional[str] = None
+    rules: Optional[list[dict]] = None
+    default: Optional[str] = None
+
+
+class GraphOutputSpec(BaseModel):
+    source: str
+    name: str
+    legend_type: str = "auto"
+
+
+class GeneratedGraph(BaseModel):
+    nodes: list[GraphNodeSpec]
+    output: GraphOutputSpec
+
+
+class GeneratedCompositeLayerGraphResponse(BaseModel):
+    graph: GeneratedGraph
+    message: str
+
+
+def _build_metric_types_catalog(metric_types: list[dict]) -> str:
+    if not metric_types:
+        return "(no data layers available for this account)"
+
+    lines = []
+    for metric_type in metric_types:
+        line = f'- id={metric_type["id"]}, name="{metric_type["name"]}"'
+        if metric_type.get("description"):
+            line += f', description="{metric_type["description"]}"'
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def call_claude(
+    message: str,
+    conversation_history: list[dict],
+    metric_types: list[dict],
+    api_key: Optional[str] = None,
+) -> str:
+    """Call Claude API with the conversation and return the raw response text."""
+    client = anthropic.Anthropic(api_key=api_key)
+
+    system_prompt = COMPOSITE_LAYER_SYSTEM_PROMPT_TEMPLATE.format(
+        metric_types_catalog=_build_metric_types_catalog(metric_types),
+    )
+
+    messages = [{"role": entry["role"], "content": entry["content"]} for entry in conversation_history]
+    messages.append({"role": "user", "content": message})
+
+    response = client.messages.create(
+        model=settings.COMPOSITE_LAYER_AI_MODEL,
+        max_tokens=4096,
+        system=system_prompt,
+        messages=messages,
+    )
+
+    return response.content[0].text
+
+
+def parse_composite_layer_graph_response(response_text: str) -> GeneratedCompositeLayerGraphResponse:
+    """Parse Claude's response into a GeneratedCompositeLayerGraphResponse."""
+    text = response_text.strip()
+
+    if "```json" in text:
+        text = text.split("```json")[1].split("```")[0].strip()
+    elif "```" in text:
+        text = text.split("```")[1].split("```")[0].strip()
+
+    data = json.loads(text)
+    return GeneratedCompositeLayerGraphResponse(**data)
+
+
+def generate_composite_layer_graph(
+    message: str,
+    conversation_history: list[dict],
+    metric_types: list[dict],
+    api_key: Optional[str] = None,
+) -> dict:
+    """Call the AI and return the parsed graph spec plus updated conversation history.
+
+    Returns a dict with:
+    - assistant_message: The agent's response text
+    - graph: the generated graph spec (None if the response was conversational)
+    - conversation_history: Updated conversation history
+    """
+    response_text = call_claude(message, conversation_history, metric_types, api_key=api_key)
+
+    new_history = list(conversation_history) + [
+        {"role": "user", "content": message},
+        {"role": "assistant", "content": response_text},
+    ]
+
+    try:
+        parsed = parse_composite_layer_graph_response(response_text)
+        return {
+            "assistant_message": parsed.message,
+            "graph": parsed.graph.model_dump(),
+            "conversation_history": new_history,
+        }
+    except (json.JSONDecodeError, Exception) as e:
+        logger.info("Response was not a composite layer graph (might be conversational): %s", e)
+        return {
+            "assistant_message": response_text,
+            "graph": None,
+            "conversation_history": new_history,
+        }

--- a/api/composite_layer_ai/agent.py
+++ b/api/composite_layer_ai/agent.py
@@ -21,6 +21,15 @@ A composite layer is a small directed graph of nodes, evaluated per org unit:
   is usually numeric, but it can also be the categorical text label produced by a `classify` node -
   in that case only compare it against a string literal (e.g. `a == "High"`), don't use it in
   arithmetic. Supported: + - * / ^, comparisons, and the functions abs/min/max/round.
+- `combine`: reduces one or more numeric inputs (`inputs`, same convention as `formula`) into one
+  value per org unit with a single symmetric operation, given as `operation`: "mean", "sum", "min",
+  or "max". Prefer `combine` over a `formula` that just adds/averages/min/maxes its inputs (e.g.
+  `(a+b+c)/3`, `a+b`, `min(a,b)`) - it says what it does and needs no formula syntax. Only fall back
+  to `formula` for arithmetic `combine` can't express (weights, non-symmetric operations, conditionals).
+- `normalize`: min-max rescales a single numeric input (`input`) to a 0-`scale` range (`scale` is 1
+  or 100), independently per year - i.e. it re-expresses each org unit's value as its relative
+  position between the layer's min and max. This CANNOT be reproduced with a `formula`, since a
+  formula only ever sees one org unit's inputs at a time and has no access to the layer's min/max.
 - `classify`: maps a single numeric input to a category label using an ordered list of threshold
   rules (e.g. "< 100" -> "Low"), with a `default` label used when no rule matches. A `classify`
   node's own output is categorical (text). It CAN feed a `formula` node (e.g. to compare it against
@@ -40,6 +49,8 @@ matching this schema, and no text outside the JSON block:
     "nodes": [
       {{"id": "<unique id you choose, e.g. \\"rainfall\\">", "type": "dataLayer", "metric_type_id": "<id from the catalog above, as a string>"}},
       {{"id": "<unique id>", "type": "formula", "inputs": ["<id of another node>", ...], "formula": "<infix expression using a, b, c, ...>"}},
+      {{"id": "<unique id>", "type": "combine", "inputs": ["<id of another node>", ...], "operation": "<mean|sum|min|max>"}},
+      {{"id": "<unique id>", "type": "normalize", "input": "<id of a numeric-producing node>", "scale": 1}},
       {{"id": "<unique id>", "type": "classify", "input": "<id of a numeric-producing node>", "rules": [{{"op": "<", "value": 100, "label": "Low"}}], "default": "<label for anything matching no rule>"}}
     ],
     "output": {{"source": "<id of the node producing the final result>", "name": "<human readable name>", "legend_type": "auto"}}
@@ -50,9 +61,10 @@ matching this schema, and no text outside the JSON block:
 ## Rules
 - Only reference data layer ids that appear in the catalog above.
 - Every node needs a unique `id`; reference nodes by that id from `inputs`/`input`/`source`.
-- A graph can mix any number of `dataLayer`, `formula` and `classify` nodes - chain them as needed
-  (e.g. combine two layers with a formula, then reclassify the result into categories).
-- `formula` nodes need at least one input.
+- A graph can mix any number of `dataLayer`, `formula`, `combine`, `normalize` and `classify` nodes -
+  chain them as needed (e.g. combine three layers with `combine`, then reclassify the result into
+  categories).
+- `formula` and `combine` nodes need at least one input; `normalize` and `classify` need exactly one.
 - `classify` nodes need at least one rule, a default, or both.
 - When the user asks to modify a previously generated composite layer, return the COMPLETE updated
   graph, not just the change and ask if it should be applied on the data layer editor directly.
@@ -64,8 +76,9 @@ matching this schema, and no text outside the JSON block:
   downstream `formula` (comparing its label, e.g. `a == "High"`) rather than reimplementing the same
   thresholds as comparisons inside one big formula. A categorical (text) result is a normal, valid
   output on its own and does not need to be summable to be useful, so do not avoid `classify` just
-  because its output is text or because more nodes follow it. 
-  
+  because its output is text or because more nodes follow it.
+- Prefer `combine` over `formula` whenever the goal is a plain mean/sum/min/max across two or more
+  layers, for the same reason: it says what it does and needs no formula syntax to read or write.
 """
 
 
@@ -74,13 +87,18 @@ class GraphNodeSpec(BaseModel, extra="allow"):
     type: str
     # dataLayer
     metric_type_id: Optional[str] = None
-    # formula
+    # formula, combine
     inputs: Optional[list[str]] = None
     formula: Optional[str] = None
-    # classify
+    # combine
+    operation: Optional[str] = None
+    # classify, normalize
     input: Optional[str] = None
+    # classify
     rules: Optional[list[dict]] = None
     default: Optional[str] = None
+    # normalize
+    scale: Optional[float] = None
 
 
 class GraphOutputSpec(BaseModel):

--- a/api/composite_layer_ai/serializers.py
+++ b/api/composite_layer_ai/serializers.py
@@ -1,0 +1,17 @@
+from rest_framework import serializers
+
+
+class CompositeLayerAIRequestSerializer(serializers.Serializer):
+    message = serializers.CharField(help_text="User message describing the composite layer to create or modify")
+    conversation_history = serializers.ListField(
+        child=serializers.DictField(),
+        required=False,
+        default=list,
+        help_text="Previous conversation messages",
+    )
+
+
+class CompositeLayerAIResponseSerializer(serializers.Serializer):
+    assistant_message = serializers.CharField()
+    graph = serializers.DictField(allow_null=True)
+    conversation_history = serializers.ListField(child=serializers.DictField())

--- a/api/composite_layer_ai/views.py
+++ b/api/composite_layer_ai/views.py
@@ -1,0 +1,78 @@
+import logging
+
+import anthropic
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import status, viewsets
+from rest_framework.response import Response
+
+from iaso.models import MetricType
+from plugins.snt_malaria.api.composite_layers.permissions import CompositeLayerPermission
+
+from .agent import generate_composite_layer_graph
+from .serializers import (
+    CompositeLayerAIRequestSerializer,
+    CompositeLayerAIResponseSerializer,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@extend_schema(tags=["SNT Malaria"])
+class CompositeLayerAIViewSet(viewsets.ViewSet):
+    """AI-powered composite layer generation.
+
+    Send a natural language message describing the desired composite data layer. Returns a
+    generated node graph spec (dataLayer/formula/classify nodes plus an output) that the frontend
+    converts into Flume graph nodes for the composite layer editor.
+    """
+
+    permission_classes = [CompositeLayerPermission]
+
+    @extend_schema(
+        request=CompositeLayerAIRequestSerializer,
+        responses={200: CompositeLayerAIResponseSerializer},
+    )
+    def create(self, request):
+        serializer = CompositeLayerAIRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        message = serializer.validated_data["message"]
+        conversation_history = serializer.validated_data.get("conversation_history", [])
+
+        account = request.user.iaso_profile.account
+        api_key = account.anthropic_api_key or None
+        if not api_key:
+            return Response(
+                {
+                    "error": "Composite Layer AI API key is not configured for this account. Please contact your administrator."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        metric_types = list(
+            MetricType.objects.filter(account=account, is_utility=False).values("id", "name", "description")
+        )
+
+        try:
+            result = generate_composite_layer_graph(message, conversation_history, metric_types, api_key=api_key)
+            return Response(result, status=status.HTTP_200_OK)
+        except anthropic.APIStatusError as e:
+            if e.status_code == 503:
+                logger.warning("Claude API returned 503")
+                return Response(
+                    {"error": "The AI service is temporarily unavailable. Please try again later."},
+                    status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                )
+            logger.exception("Composite Layer AI error")
+            return Response(
+                {"error": "Failed to generate composite layer. Please try again."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except Exception:
+            logger.exception("Composite Layer AI error")
+            return Response(
+                {"error": "Failed to generate composite layer. Please try again."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )

--- a/api/urls.py
+++ b/api/urls.py
@@ -3,6 +3,7 @@ from rest_framework import routers
 from plugins.snt_malaria.api.account_settings.views import AccountSettingsViewSet
 from plugins.snt_malaria.api.budget.views import BudgetViewSet
 from plugins.snt_malaria.api.budget_settings.views import BudgetSettingsViewSet
+from plugins.snt_malaria.api.composite_layer_ai.views import CompositeLayerAIViewSet
 from plugins.snt_malaria.api.impact.views import ImpactAgeGroupsViewSet, ImpactViewSet, ImpactYearRangeViewSet
 from plugins.snt_malaria.api.scenario_yearly_cost_assignment.views import ScenarioYearlyCostAssignmentViewSet
 
@@ -52,3 +53,4 @@ router.register(r"snt_malaria/impact_age_groups", ImpactAgeGroupsViewSet, basena
 router.register(r"snt_malaria/account_settings", AccountSettingsViewSet, basename="account_settings")
 router.register(r"snt_malaria/account_setup", SNTAccountSetupViewSet, basename="account_setup")
 router.register(r"snt_malaria/composite_layers", CompositeLayerViewSet, basename="composite_layers")
+router.register(r"snt_malaria/composite_layer_ai", CompositeLayerAIViewSet, basename="composite_layer_ai")

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,5 +2,6 @@ services:
     iaso:
       image: blsq/snt_malaria:${PROD_IMAGE_TAG:-develop}
       environment:
+        - COMPOSITE_LAYER_AI_MODEL
         - ENABLE_PUBLIC_ACCOUNT_SETUP
         - PUBLIC_ACCOUNT_THROTTLE_RATE

--- a/js/src/constants/translations/en.json
+++ b/js/src/constants/translations/en.json
@@ -419,5 +419,10 @@
     "iaso.snt_malaria.settings.account.interventionOrgUnitType": "Intervention org unit type",
     "iaso.snt_malaria.settings.account.focusOrgUnitType": "Focus org unit type",
     "iaso.snt_malaria.settings.account.defaultPopulation": "Default population",
-    "iaso.snt_malaria.settings.account.defaultPopulationHelp": "Metric type automatically shown as the population layer whenever one is needed for display (e.g. totals on the rule panel)."
+    "iaso.snt_malaria.settings.account.defaultPopulationHelp": "Metric type automatically shown as the population layer whenever one is needed for display (e.g. totals on the rule panel).",
+    "iaso.snt_malaria.compositeLayerEditor.ai.title": "Generate with AI",
+    "iaso.snt_malaria.compositeLayerEditor.ai.placeholder": "Describe the composite layer you want to create...",
+    "iaso.snt_malaria.compositeLayerEditor.ai.error": "Error generating composite layer. Please try again.",
+    "iaso.snt_malaria.compositeLayerEditor.ai.emptyStateTitle": "Describe the composite layer you want to create",
+    "iaso.snt_malaria.compositeLayerEditor.ai.emptyStateDescription": "Describe the metrics, formulas and thresholds you want to combine — the AI builds the graph for you."
 }

--- a/js/src/constants/translations/fr.json
+++ b/js/src/constants/translations/fr.json
@@ -418,5 +418,10 @@
     "iaso.snt_malaria.settings.account.interventionOrgUnitType": "Type d'unité d'organisation d'intervention",
     "iaso.snt_malaria.settings.account.focusOrgUnitType": "Type d'unité d'organisation de focus",
     "iaso.snt_malaria.settings.account.defaultPopulation": "Population par défaut",
-    "iaso.snt_malaria.settings.account.defaultPopulationHelp": "Type de métrique affiché automatiquement comme couche de population chaque fois qu'une est nécessaire (ex. : totaux sur le panneau de règles)."
+    "iaso.snt_malaria.settings.account.defaultPopulationHelp": "Type de métrique affiché automatiquement comme couche de population chaque fois qu'une est nécessaire (ex. : totaux sur le panneau de règles).",
+    "iaso.snt_malaria.compositeLayerEditor.ai.title": "Générer avec l'IA",
+    "iaso.snt_malaria.compositeLayerEditor.ai.placeholder": "Décrivez la couche composite que vous souhaitez créer...",
+    "iaso.snt_malaria.compositeLayerEditor.ai.error": "Erreur lors de la génération de la couche composite. Veuillez réessayer.",
+    "iaso.snt_malaria.compositeLayerEditor.ai.emptyStateTitle": "Décrivez la couche composite que vous souhaitez créer",
+    "iaso.snt_malaria.compositeLayerEditor.ai.emptyStateDescription": "Décrivez les métriques, formules et seuils que vous souhaitez combiner — l'IA construit le graphe pour vous."
 }

--- a/js/src/domains/compositeLayerEditor/compositeLayerChatBot/CompositeLayerAIChat.tsx
+++ b/js/src/domains/compositeLayerEditor/compositeLayerChatBot/CompositeLayerAIChat.tsx
@@ -1,8 +1,9 @@
 import React, { FC, useCallback, useState } from 'react';
-import { Card } from '@mui/material';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import { Box, Card, Typography } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
-import { ChatMessage, ChatPanel } from 'Iaso/components/chat/ChatPanel';
-import { CardStyled } from '../../../components/CardStyled';
+import { ChatMessage, ChatPanel } from 'Iaso/components/ChatPanel/ChatPanel';
+import { SxStyles } from 'Iaso/types/general';
 import { MESSAGES } from '../messages';
 import { ConversationEntry, GeneratedGraph } from './types';
 import { useSendCompositeLayerAIMessage } from './useSendCompositeLayerAIMessage';
@@ -10,6 +11,17 @@ import { useSendCompositeLayerAIMessage } from './useSendCompositeLayerAIMessage
 type Props = {
     onGenerate: (graph: GeneratedGraph) => void;
 };
+
+const chatStyles = {
+    header: {
+        pb: 0,
+        minHeight: '65px',
+        display: 'flex',
+        alignContent: 'center',
+        border: 'none',
+        ' p': { fontSize: '1.25rem', ml: 0.5 },
+    },
+} satisfies SxStyles;
 
 export const CompositeLayerAIChat: FC<Props> = ({ onGenerate }) => {
     const { formatMessage } = useSafeIntl();
@@ -70,16 +82,32 @@ export const CompositeLayerAIChat: FC<Props> = ({ onGenerate }) => {
                 flexDirection: 'column',
             }}
         >
-            <CardStyled header={formatMessage(MESSAGES.compositeLayerAITitle)}>
-                <ChatPanel
-                    messages={messages}
-                    isLoading={isLoading}
-                    placeholder={formatMessage(
-                        MESSAGES.compositeLayerAIPlaceholder,
-                    )}
-                    onSendMessage={handleSendMessage}
-                />
-            </CardStyled>
+            <ChatPanel
+                messages={messages}
+                isLoading={isLoading}
+                title={formatMessage(MESSAGES.compositeLayerAITitle)}
+                titleIcon={<AutoAwesomeIcon color="primary" fontSize="small" />}
+                placeholder={formatMessage(
+                    MESSAGES.compositeLayerAIPlaceholder,
+                )}
+                sx={chatStyles}
+                emptyState={
+                    <Box>
+                        <Typography variant="body1" sx={{ fontWeight: 700 }}>
+                            {formatMessage(
+                                MESSAGES.compositeLayerAIEmptyStateTitle,
+                            )}
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                            {formatMessage(
+                                MESSAGES.compositeLayerAIEmptyStateDescription,
+                            )}
+                        </Typography>
+                    </Box>
+                }
+                onSendMessage={handleSendMessage}
+                interpretMarkdown={true}
+            />
         </Card>
     );
 };

--- a/js/src/domains/compositeLayerEditor/compositeLayerChatBot/CompositeLayerAIChat.tsx
+++ b/js/src/domains/compositeLayerEditor/compositeLayerChatBot/CompositeLayerAIChat.tsx
@@ -1,0 +1,85 @@
+import React, { FC, useCallback, useState } from 'react';
+import { Card } from '@mui/material';
+import { useSafeIntl } from 'bluesquare-components';
+import { ChatMessage, ChatPanel } from 'Iaso/components/chat/ChatPanel';
+import { CardStyled } from '../../../components/CardStyled';
+import { MESSAGES } from '../messages';
+import { ConversationEntry, GeneratedGraph } from './types';
+import { useSendCompositeLayerAIMessage } from './useSendCompositeLayerAIMessage';
+
+type Props = {
+    onGenerate: (graph: GeneratedGraph) => void;
+};
+
+export const CompositeLayerAIChat: FC<Props> = ({ onGenerate }) => {
+    const { formatMessage } = useSafeIntl();
+    const [messages, setMessages] = useState<ChatMessage[]>([]);
+    const [conversationHistory, setConversationHistory] = useState<
+        ConversationEntry[]
+    >([]);
+    const { mutate: sendMessage, isLoading } = useSendCompositeLayerAIMessage();
+
+    const handleSendMessage = useCallback(
+        (message: string) => {
+            setMessages(prev => [
+                ...prev,
+                { role: 'user', content: message, id: crypto.randomUUID() },
+            ]);
+
+            sendMessage(
+                { message, conversation_history: conversationHistory },
+                {
+                    onSuccess: data => {
+                        setMessages(prev => [
+                            ...prev,
+                            {
+                                role: 'assistant',
+                                content: data.assistant_message,
+                                id: crypto.randomUUID(),
+                            },
+                        ]);
+                        setConversationHistory(data.conversation_history);
+                        if (data.graph) {
+                            onGenerate(data.graph);
+                        }
+                    },
+                    onError: () => {
+                        setMessages(prev => [
+                            ...prev,
+                            {
+                                role: 'assistant',
+                                content: formatMessage(
+                                    MESSAGES.compositeLayerAIError,
+                                ),
+                                id: crypto.randomUUID(),
+                            },
+                        ]);
+                    },
+                },
+            );
+        },
+        [conversationHistory, sendMessage, onGenerate, formatMessage],
+    );
+
+    return (
+        <Card
+            sx={{
+                height: '100%',
+                flexGrow: 1,
+                display: 'flex',
+                flexDirection: 'column',
+            }}
+        >
+            <CardStyled header={formatMessage(MESSAGES.compositeLayerAITitle)}>
+                <ChatPanel
+                    messages={messages}
+                    isLoading={isLoading}
+                    placeholder={formatMessage(
+                        MESSAGES.compositeLayerAIPlaceholder,
+                    )}
+                    onSendMessage={handleSendMessage}
+                />
+            </CardStyled>
+        </Card>
+    );
+};

--- a/js/src/domains/compositeLayerEditor/compositeLayerChatBot/buildFlumeGraph.ts
+++ b/js/src/domains/compositeLayerEditor/compositeLayerChatBot/buildFlumeGraph.ts
@@ -10,6 +10,8 @@ const ROW_HEIGHT = 180;
 const NODE_WIDTH: Record<GraphNodeType | 'output', number> = {
     dataLayer: 330,
     formula: 260,
+    combine: 260,
+    normalize: 260,
     classify: 320,
     output: 330,
 };
@@ -18,16 +20,20 @@ const NODE_WIDTH: Record<GraphNodeType | 'output', number> = {
 const OUTPUT_PORT_NAME: Record<GraphNodeType, string> = {
     dataLayer: 'values',
     formula: 'result',
+    combine: 'result',
+    normalize: 'result',
     classify: 'result',
 };
 
-// Names given to a formula node's value inputs, in order: a, b, c, … (see flumeConfig.ts).
+// Names given to a formula/combine node's value inputs, in order: a, b, c, … (see flumeConfig.ts).
 const formulaInputName = (index: number): string =>
     String.fromCharCode('a'.charCodeAt(0) + index);
 
 const upstreamIds = (node: GeneratedGraphNode): string[] => {
-    if (node.type === 'formula') return node.inputs ?? [];
-    if (node.type === 'classify') return node.input ? [node.input] : [];
+    if (node.type === 'formula' || node.type === 'combine')
+        return node.inputs ?? [];
+    if (node.type === 'classify' || node.type === 'normalize')
+        return node.input ? [node.input] : [];
     return [];
 };
 
@@ -77,8 +83,8 @@ const addConnection = (
 
 /**
  * Converts the AI's abstract graph spec into a Flume-compatible node map matching the composite
- * layer editor's real node types (`dataLayer` / `formula` / `classify` / `output`, see
- * flumeConfig.ts). Node ids from the spec are reused verbatim as Flume node ids.
+ * layer editor's real node types (`dataLayer` / `formula` / `combine` / `normalize` / `classify` /
+ * `output`, see flumeConfig.ts). Node ids from the spec are reused verbatim as Flume node ids.
  */
 export const buildFlumeGraphFromSpec = (graph: GeneratedGraph): FlumeNodes => {
     const nodes: FlumeNodes = {};
@@ -122,6 +128,29 @@ export const buildFlumeGraphFromSpec = (graph: GeneratedGraph): FlumeNodes => {
                 inputData: { formula: { formula: node.formula ?? '' } },
                 connections: { inputs: {}, outputs: {} },
             };
+        } else if (node.type === 'combine') {
+            nodes[node.id] = {
+                id: node.id,
+                type: 'combine',
+                width: NODE_WIDTH.combine,
+                x,
+                y,
+                inputData: {
+                    operation: { operation: node.operation ?? 'mean' },
+                },
+                connections: { inputs: {}, outputs: {} },
+            };
+        } else if (node.type === 'normalize') {
+            nodes[node.id] = {
+                id: node.id,
+                type: 'normalize',
+                width: NODE_WIDTH.normalize,
+                x,
+                y,
+                // The scale control's options carry string values ('1'/'100'), see flumeConfig.ts.
+                inputData: { scale: { scale: String(node.scale ?? 1) } },
+                connections: { inputs: {}, outputs: {} },
+            };
         } else if (node.type === 'classify') {
             nodes[node.id] = {
                 id: node.id,
@@ -148,7 +177,7 @@ export const buildFlumeGraphFromSpec = (graph: GeneratedGraph): FlumeNodes => {
 
     // Wire connections now that every node exists (so both endpoints can be updated together).
     graph.nodes.forEach(node => {
-        if (node.type === 'formula') {
+        if (node.type === 'formula' || node.type === 'combine') {
             (node.inputs ?? []).forEach((sourceId, index) => {
                 const sourceType = nodes[sourceId]?.type as
                     | GraphNodeType
@@ -163,7 +192,10 @@ export const buildFlumeGraphFromSpec = (graph: GeneratedGraph): FlumeNodes => {
                     { nodeId: node.id, portName: formulaInputName(index) },
                 );
             });
-        } else if (node.type === 'classify' && node.input) {
+        } else if (
+            (node.type === 'classify' || node.type === 'normalize') &&
+            node.input
+        ) {
             const sourceType = nodes[node.input]?.type as
                 | GraphNodeType
                 | undefined;

--- a/js/src/domains/compositeLayerEditor/compositeLayerChatBot/buildFlumeGraph.ts
+++ b/js/src/domains/compositeLayerEditor/compositeLayerChatBot/buildFlumeGraph.ts
@@ -1,0 +1,218 @@
+import { FlumeNodes } from 'flume';
+import { GeneratedGraph, GeneratedGraphNode, GraphNodeType } from './types';
+
+// Layout constants: nodes are placed in columns by graph depth (dataLayer nodes at depth 0),
+// stacked top-to-bottom within a column in the order the AI listed them. The output node always
+// sits one column past the deepest node.
+const COLUMN_WIDTH = 360;
+const ROW_HEIGHT = 180;
+
+const NODE_WIDTH: Record<GraphNodeType | 'output', number> = {
+    dataLayer: 330,
+    formula: 260,
+    classify: 320,
+    output: 330,
+};
+
+// Port name a node's result is exposed under, keyed by node type - matches flumeConfig.ts.
+const OUTPUT_PORT_NAME: Record<GraphNodeType, string> = {
+    dataLayer: 'values',
+    formula: 'result',
+    classify: 'result',
+};
+
+// Names given to a formula node's value inputs, in order: a, b, c, … (see flumeConfig.ts).
+const formulaInputName = (index: number): string =>
+    String.fromCharCode('a'.charCodeAt(0) + index);
+
+const upstreamIds = (node: GeneratedGraphNode): string[] => {
+    if (node.type === 'formula') return node.inputs ?? [];
+    if (node.type === 'classify') return node.input ? [node.input] : [];
+    return [];
+};
+
+// Depth = longest path back to a dataLayer node, used purely to lay the graph out left-to-right.
+// Guards against a malformed (cyclic or self-referencing) AI response by treating any node caught
+// mid-traversal as depth 0 rather than recursing forever.
+const computeDepths = (nodes: GeneratedGraphNode[]): Map<string, number> => {
+    const byId = new Map(nodes.map(node => [node.id, node]));
+    const depths = new Map<string, number>();
+    const visiting = new Set<string>();
+
+    const depthOf = (id: string): number => {
+        if (depths.has(id)) return depths.get(id) as number;
+        if (visiting.has(id)) return 0;
+        const node = byId.get(id);
+        if (!node) return 0;
+        visiting.add(id);
+        const upstream = upstreamIds(node);
+        const depth = upstream.length
+            ? 1 + Math.max(...upstream.map(depthOf))
+            : 0;
+        visiting.delete(id);
+        depths.set(id, depth);
+        return depth;
+    };
+
+    nodes.forEach(node => depthOf(node.id));
+    return depths;
+};
+
+const addConnection = (
+    nodes: FlumeNodes,
+    from: { nodeId: string; portName: string },
+    to: { nodeId: string; portName: string },
+) => {
+    const targetInputs = nodes[to.nodeId].connections.inputs;
+    targetInputs[to.portName] = [
+        ...(targetInputs[to.portName] ?? []),
+        { nodeId: from.nodeId, portName: from.portName },
+    ];
+    const sourceOutputs = nodes[from.nodeId].connections.outputs;
+    sourceOutputs[from.portName] = [
+        ...(sourceOutputs[from.portName] ?? []),
+        { nodeId: to.nodeId, portName: to.portName },
+    ];
+};
+
+/**
+ * Converts the AI's abstract graph spec into a Flume-compatible node map matching the composite
+ * layer editor's real node types (`dataLayer` / `formula` / `classify` / `output`, see
+ * flumeConfig.ts). Node ids from the spec are reused verbatim as Flume node ids.
+ */
+export const buildFlumeGraphFromSpec = (graph: GeneratedGraph): FlumeNodes => {
+    const nodes: FlumeNodes = {};
+    const depths = computeDepths(graph.nodes);
+    const rowByDepth = new Map<number, number>();
+
+    const placeAt = (depth: number): { x: number; y: number } => {
+        const row = rowByDepth.get(depth) ?? 0;
+        rowByDepth.set(depth, row + 1);
+        return { x: depth * COLUMN_WIDTH, y: row * ROW_HEIGHT };
+    };
+
+    graph.nodes.forEach(node => {
+        const { x, y } = placeAt(depths.get(node.id) ?? 0);
+
+        if (node.type === 'dataLayer') {
+            nodes[node.id] = {
+                id: node.id,
+                type: 'dataLayer',
+                width: NODE_WIDTH.dataLayer,
+                x,
+                y,
+                inputData: {
+                    // The select's options carry a numeric `value` (see MetricOption in
+                    // flumeConfig.ts) and Flume's Select matches the current value against them
+                    // with `===`, so this must be a number - a string id would render as neither
+                    // the picked label nor the placeholder.
+                    metricType: {
+                        metricTypeId: Number(node.metric_type_id),
+                    },
+                },
+                connections: { inputs: {}, outputs: {} },
+            };
+        } else if (node.type === 'formula') {
+            nodes[node.id] = {
+                id: node.id,
+                type: 'formula',
+                width: NODE_WIDTH.formula,
+                x,
+                y,
+                inputData: { formula: { formula: node.formula ?? '' } },
+                connections: { inputs: {}, outputs: {} },
+            };
+        } else if (node.type === 'classify') {
+            nodes[node.id] = {
+                id: node.id,
+                type: 'classify',
+                width: NODE_WIDTH.classify,
+                x,
+                y,
+                inputData: {
+                    config: {
+                        rules: {
+                            rules: (node.rules ?? []).map(rule => ({
+                                op: rule.op,
+                                value: rule.value,
+                                label: rule.label,
+                            })),
+                            default: node.default ?? '',
+                        },
+                    },
+                },
+                connections: { inputs: {}, outputs: {} },
+            };
+        }
+    });
+
+    // Wire connections now that every node exists (so both endpoints can be updated together).
+    graph.nodes.forEach(node => {
+        if (node.type === 'formula') {
+            (node.inputs ?? []).forEach((sourceId, index) => {
+                const sourceType = nodes[sourceId]?.type as
+                    | GraphNodeType
+                    | undefined;
+                if (!sourceType) return;
+                addConnection(
+                    nodes,
+                    {
+                        nodeId: sourceId,
+                        portName: OUTPUT_PORT_NAME[sourceType],
+                    },
+                    { nodeId: node.id, portName: formulaInputName(index) },
+                );
+            });
+        } else if (node.type === 'classify' && node.input) {
+            const sourceType = nodes[node.input]?.type as
+                | GraphNodeType
+                | undefined;
+            if (sourceType) {
+                addConnection(
+                    nodes,
+                    {
+                        nodeId: node.input,
+                        portName: OUTPUT_PORT_NAME[sourceType],
+                    },
+                    { nodeId: node.id, portName: 'a' },
+                );
+            }
+        }
+    });
+
+    // The output node: always exactly one, placed one column past the deepest node.
+    const maxDepth = graph.nodes.length
+        ? Math.max(...graph.nodes.map(node => depths.get(node.id) ?? 0))
+        : 0;
+    const { x: outputX, y: outputY } = placeAt(maxDepth + 1);
+    const outputId = 'output';
+
+    nodes[outputId] = {
+        id: outputId,
+        type: 'output',
+        width: NODE_WIDTH.output,
+        x: outputX,
+        y: outputY,
+        inputData: {
+            name: { name: graph.output.name },
+            legend: { legendType: graph.output.legend_type ?? 'auto' },
+        },
+        connections: { inputs: {}, outputs: {} },
+    };
+
+    const sourceType = nodes[graph.output.source]?.type as
+        | GraphNodeType
+        | undefined;
+    if (sourceType) {
+        addConnection(
+            nodes,
+            {
+                nodeId: graph.output.source,
+                portName: OUTPUT_PORT_NAME[sourceType],
+            },
+            { nodeId: outputId, portName: 'layer' },
+        );
+    }
+
+    return nodes;
+};

--- a/js/src/domains/compositeLayerEditor/compositeLayerChatBot/types.ts
+++ b/js/src/domains/compositeLayerEditor/compositeLayerChatBot/types.ts
@@ -1,0 +1,51 @@
+export type ConversationEntry = {
+    role: 'user' | 'assistant';
+    content: string;
+};
+
+export type ClassifyOperator = '<' | '<=' | '>' | '>=' | '==' | '!=';
+
+export type ClassifyRuleSpec = {
+    op: ClassifyOperator;
+    value: number;
+    label: string;
+};
+
+export type GraphNodeType = 'dataLayer' | 'formula' | 'classify';
+
+// A single abstract node in the AI-generated graph. Which fields are relevant depends on `type`:
+// dataLayer -> metric_type_id; formula -> inputs + formula; classify -> input + rules + default.
+export type GeneratedGraphNode = {
+    id: string;
+    type: GraphNodeType;
+    metric_type_id?: string;
+    inputs?: string[];
+    formula?: string;
+    input?: string;
+    rules?: ClassifyRuleSpec[];
+    default?: string;
+};
+
+export type LegendType = 'auto' | 'linear' | 'threshold' | 'ordinal';
+
+export type GeneratedGraphOutput = {
+    source: string;
+    name: string;
+    legend_type: LegendType;
+};
+
+export type GeneratedGraph = {
+    nodes: GeneratedGraphNode[];
+    output: GeneratedGraphOutput;
+};
+
+export type CompositeLayerAIRequest = {
+    message: string;
+    conversation_history: ConversationEntry[];
+};
+
+export type CompositeLayerAIResponse = {
+    assistant_message: string;
+    graph: GeneratedGraph | null;
+    conversation_history: ConversationEntry[];
+};

--- a/js/src/domains/compositeLayerEditor/compositeLayerChatBot/types.ts
+++ b/js/src/domains/compositeLayerEditor/compositeLayerChatBot/types.ts
@@ -11,19 +11,29 @@ export type ClassifyRuleSpec = {
     label: string;
 };
 
-export type GraphNodeType = 'dataLayer' | 'formula' | 'classify';
+export type CombineOperation = 'mean' | 'sum' | 'min' | 'max';
+
+export type GraphNodeType =
+    | 'dataLayer'
+    | 'formula'
+    | 'combine'
+    | 'normalize'
+    | 'classify';
 
 // A single abstract node in the AI-generated graph. Which fields are relevant depends on `type`:
-// dataLayer -> metric_type_id; formula -> inputs + formula; classify -> input + rules + default.
+// dataLayer -> metric_type_id; formula -> inputs + formula; combine -> inputs + operation;
+// normalize -> input + scale; classify -> input + rules + default.
 export type GeneratedGraphNode = {
     id: string;
     type: GraphNodeType;
     metric_type_id?: string;
     inputs?: string[];
     formula?: string;
+    operation?: CombineOperation;
     input?: string;
     rules?: ClassifyRuleSpec[];
     default?: string;
+    scale?: 1 | 100;
 };
 
 export type LegendType = 'auto' | 'linear' | 'threshold' | 'ordinal';

--- a/js/src/domains/compositeLayerEditor/compositeLayerChatBot/useSendCompositeLayerAIMessage.ts
+++ b/js/src/domains/compositeLayerEditor/compositeLayerChatBot/useSendCompositeLayerAIMessage.ts
@@ -1,0 +1,15 @@
+import { postRequest } from 'Iaso/libs/Api';
+import { useSnackMutation } from 'Iaso/libs/apiHooks';
+import { CompositeLayerAIRequest, CompositeLayerAIResponse } from './types';
+
+export const useSendCompositeLayerAIMessage = () => {
+    return useSnackMutation<
+        CompositeLayerAIResponse,
+        Error,
+        CompositeLayerAIRequest
+    >({
+        mutationFn: (data: CompositeLayerAIRequest) =>
+            postRequest('/api/snt_malaria/composite_layer_ai/', data),
+        showSuccessSnackBar: false,
+    });
+};

--- a/js/src/domains/compositeLayerEditor/compositeLayerChatBot/useSendCompositeLayerAIMessage.ts
+++ b/js/src/domains/compositeLayerEditor/compositeLayerChatBot/useSendCompositeLayerAIMessage.ts
@@ -1,15 +1,13 @@
+import { useMutation } from 'react-query';
 import { postRequest } from 'Iaso/libs/Api';
-import { useSnackMutation } from 'Iaso/libs/apiHooks';
 import { CompositeLayerAIRequest, CompositeLayerAIResponse } from './types';
 
 export const useSendCompositeLayerAIMessage = () => {
-    return useSnackMutation<
+    return useMutation<
         CompositeLayerAIResponse,
         Error,
         CompositeLayerAIRequest
-    >({
-        mutationFn: (data: CompositeLayerAIRequest) =>
-            postRequest('/api/snt_malaria/composite_layer_ai/', data),
-        showSuccessSnackBar: false,
-    });
+    >((data: CompositeLayerAIRequest) =>
+        postRequest('/api/snt_malaria/composite_layer_ai/', data),
+    );
 };

--- a/js/src/domains/compositeLayerEditor/index.tsx
+++ b/js/src/domains/compositeLayerEditor/index.tsx
@@ -1,7 +1,8 @@
 import React, {
-    FC,
+    forwardRef,
     useCallback,
     useEffect,
+    useImperativeHandle,
     useMemo,
     useRef,
     useState,
@@ -25,6 +26,7 @@ import { useGetOrgUnits } from '../planning/hooks/useGetOrgUnits';
 import { CanvasControls } from './components/CanvasControls';
 import { EditorHeader } from './components/EditorHeader';
 import { NodeHeaderContent } from './components/NodeHeaderContent';
+import { GeneratedGraph } from './compositeLayerChatBot/types';
 import {
     CompositeEditorContext,
     createCompositeFlumeConfig,
@@ -83,6 +85,13 @@ type Props = {
     onToggleSidebar?: () => void;
 };
 
+// Imperative handle so a sibling AI chat panel (rendered by the parent, outside this component's
+// tree) can push a generated graph in - see `applyGeneratedGraph` below for why this can't just be
+// a prop passed down.
+export type CompositeLayerEditorHandle = {
+    applyGeneratedGraph: (graph: GeneratedGraph) => void;
+};
+
 export const CompositeLayerEditor: FC<Props> = ({
     onClose,
     onSaved,
@@ -118,6 +127,10 @@ export const CompositeLayerEditor: FC<Props> = ({
     // Data layers wired into the output (even behind transformations), ordered; drives the
     // "based on a data layer" legend picker ordering.
     const [connectedLayerIds, setConnectedLayerIds] = useState<number[]>([]);
+    // An AI-generated graph, applied to the canvas by remounting NodeEditor (it only reads
+    // `nodes`/`comments` at mount time, so there's no other way to push a new graph in).
+    const [aiGraph, setAiGraph] = useState<FlumeNodes | undefined>();
+    const [editorGeneration, setEditorGeneration] = useState(0);
 
     const metricOptions: MetricOption[] = useMemo(() => {
         if (!metricCategories) return [];
@@ -184,13 +197,14 @@ export const CompositeLayerEditor: FC<Props> = ({
     };
 
     // Initial paint: existing graphs don't emit an onChange, so tag their ports once mounted.
+    // Also re-runs after an AI-generated graph forces a remount (`editorGeneration`).
     useEffect(() => {
         if (!isReady) return undefined;
         const frame = requestAnimationFrame(() =>
             syncPortConnections(nodesRef.current),
         );
         return () => cancelAnimationFrame(frame);
-    }, [isReady, existingLayer, syncPortConnections]);
+    }, [isReady, existingLayer, editorGeneration, syncPortConnections]);
 
     // Kick off a first preview once loaded (existing graphs don't emit an initial onChange).
     useEffect(() => {
@@ -225,6 +239,36 @@ export const CompositeLayerEditor: FC<Props> = ({
             </Wrapper>
         ),
         [],
+    );
+
+    // Applies an AI-generated graph to the canvas. NodeEditor only reads `nodes`/`comments` at
+    // mount time, so `editorGeneration` forces a remount (see the `key` below) with the new graph.
+    const handleGenerateGraph = useCallback(
+        (graph: GeneratedGraph) => {
+            const nodes = buildFlumeGraphFromSpec(graph);
+            nodesRef.current = nodes;
+            commentsRef.current = {};
+            setAiGraph(nodes);
+            setEditorGeneration(generation => generation + 1);
+            setConnectedLayerIds(getConnectedDataLayerIds(nodes));
+            if (previewTimer.current) clearTimeout(previewTimer.current);
+            if (isOutputConnected(nodes)) {
+                runPreview(nodes);
+            } else {
+                setPreview({
+                    status: 'error',
+                    data: null,
+                    error: DISCONNECTED_MESSAGE,
+                });
+            }
+        },
+        [runPreview],
+    );
+
+    useImperativeHandle(
+        ref,
+        () => ({ applyGeneratedGraph: handleGenerateGraph }),
+        [handleGenerateGraph],
     );
 
     const handleSave = () => {
@@ -312,4 +356,5 @@ export const CompositeLayerEditor: FC<Props> = ({
             </CardStyled>
         </Card>
     );
-};
+});
+CompositeLayerEditor.displayName = 'CompositeLayerEditor';

--- a/js/src/domains/compositeLayerEditor/index.tsx
+++ b/js/src/domains/compositeLayerEditor/index.tsx
@@ -1,11 +1,11 @@
 import React, {
-    forwardRef,
     useCallback,
     useEffect,
     useImperativeHandle,
     useMemo,
     useRef,
     useState,
+    forwardRef,
 } from 'react';
 import {
     Box,
@@ -16,7 +16,7 @@ import {
     useTheme,
 } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
-import { NodeEditor, FlumeCommentMap } from 'flume';
+import { NodeEditor, FlumeCommentMap, FlumeNodes } from 'flume';
 import { SxStyles } from 'Iaso/types/general';
 import { CardStyled } from '../../components/CardStyled';
 import { useGetMetricCategories } from '../dataLayers/hooks/useGetMetrics';
@@ -26,6 +26,7 @@ import { useGetOrgUnits } from '../planning/hooks/useGetOrgUnits';
 import { CanvasControls } from './components/CanvasControls';
 import { EditorHeader } from './components/EditorHeader';
 import { NodeHeaderContent } from './components/NodeHeaderContent';
+import { buildFlumeGraphFromSpec } from './compositeLayerChatBot/buildFlumeGraph';
 import { GeneratedGraph } from './compositeLayerChatBot/types';
 import {
     CompositeEditorContext,
@@ -92,269 +93,296 @@ export type CompositeLayerEditorHandle = {
     applyGeneratedGraph: (graph: GeneratedGraph) => void;
 };
 
-export const CompositeLayerEditor: FC<Props> = ({
-    onClose,
-    onSaved,
-    compositeLayerId,
-    sidebarCollapsed = false,
-    onToggleSidebar,
-}) => {
-    const { formatMessage } = useSafeIntl();
-    const theme = useTheme();
-
-    const { data: metricCategories, isLoading: isLoadingMetrics } =
-        useGetMetricCategories();
-    const { data: existingLayer, isLoading: isLoadingLayer } =
-        useGetCompositeLayer(compositeLayerId);
-    const { mutate: saveCompositeLayer, isLoading: isSaving } =
-        useSaveCompositeLayer();
-
-    const nodesRef = useRef<FlumeGraph>({});
-    const commentsRef = useRef<FlumeCommentMap>({});
-    const canvasRef = useRef<HTMLDivElement>(null);
-    const { preview, runPreview, schedulePreview, markDisconnected } =
-        useCompositePreview();
-    // Flume reads `nodes`/`comments`/`initialScale` only at mount, so dropping a data layer onto
-    // the canvas remounts the editor (bumping `mountNonce`) with the mutated graph. The mount refs
-    // carry the graph + scale to restore on that remount so the view stays put.
-    const {
-        mountNonce,
-        mountGraphRef,
-        mountCommentsRef,
-        mountScaleRef,
-        handleCanvasDrop,
-    } = useCanvasDrop({ canvasRef, nodesRef, commentsRef });
-    // Data layers wired into the output (even behind transformations), ordered; drives the
-    // "based on a data layer" legend picker ordering.
-    const [connectedLayerIds, setConnectedLayerIds] = useState<number[]>([]);
-    // An AI-generated graph, applied to the canvas by remounting NodeEditor (it only reads
-    // `nodes`/`comments` at mount time, so there's no other way to push a new graph in).
-    const [aiGraph, setAiGraph] = useState<FlumeNodes | undefined>();
-    const [editorGeneration, setEditorGeneration] = useState(0);
-
-    const metricOptions: MetricOption[] = useMemo(() => {
-        if (!metricCategories) return [];
-        return metricCategories.flatMap(category =>
-            category.items.map(item => ({
-                value: item.id,
-                label: item.name,
-            })),
-        );
-    }, [metricCategories]);
-
-    const config = useMemo(
-        () => createCompositeFlumeConfig(metricOptions, formatMessage),
-        [metricOptions, formatMessage],
-    );
-
-    // Org units + metric metadata needed by the in-node map preview, handed to Flume controls
-    // through the NodeEditor `context` prop.
-    const { data: accountSettings } = useGetAccountSettings();
-    const interventionTypeId = accountSettings?.intervention_org_unit_type_id;
-    const { data: orgUnits } = useGetOrgUnits({
-        orgUnitTypeId: interventionTypeId,
-        enabled: !!interventionTypeId,
-    });
-
-    const editorContext: CompositeEditorContext = useMemo(() => {
-        const metricTypeById = new Map<number, MetricType>();
-        (metricCategories ?? []).forEach(category => {
-            category.items.forEach(item => metricTypeById.set(item.id, item));
-        });
-        return {
-            orgUnits: orgUnits ?? [],
-            metricTypeById,
-            preview,
-            connectedLayerIds,
-        };
-    }, [metricCategories, orgUnits, preview, connectedLayerIds]);
-
-    // Seed the working graph + comments from the loaded layer (NodeEditor only reads these at mount).
-    useEffect(() => {
-        if (existingLayer?.graph) {
-            nodesRef.current = existingLayer.graph;
-        }
-        if (existingLayer?.comments) {
-            commentsRef.current = existingLayer.comments;
-        }
-    }, [existingLayer]);
-
-    const isReady = !isLoadingMetrics && (!compositeLayerId || !isLoadingLayer);
-
-    const syncPortConnections = usePortConnectionSync(canvasRef);
-
-    const handleChange = (nodes: FlumeGraph) => {
-        nodesRef.current = nodes;
-        // Wait a frame so ports added/removed by this change are in the DOM before we tag them.
-        requestAnimationFrame(() => syncPortConnections(nodes));
-        setConnectedLayerIds(getConnectedDataLayerIds(nodes));
-        // Clear the preview immediately on disconnect (don't wait out the debounce on a stale map).
-        if (!isOutputConnected(nodes)) {
-            markDisconnected();
-            return;
-        }
-        schedulePreview(nodes);
-    };
-
-    // Initial paint: existing graphs don't emit an onChange, so tag their ports once mounted.
-    // Also re-runs after an AI-generated graph forces a remount (`editorGeneration`).
-    useEffect(() => {
-        if (!isReady) return undefined;
-        const frame = requestAnimationFrame(() =>
-            syncPortConnections(nodesRef.current),
-        );
-        return () => cancelAnimationFrame(frame);
-    }, [isReady, existingLayer, editorGeneration, syncPortConnections]);
-
-    // Kick off a first preview once loaded (existing graphs don't emit an initial onChange).
-    useEffect(() => {
-        if (!isReady) return;
-        setConnectedLayerIds(getConnectedDataLayerIds(nodesRef.current));
-        runPreview(nodesRef.current);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isReady, existingLayer]);
-
-    const handleCommentsChange = (comments: FlumeCommentMap) => {
-        commentsRef.current = comments;
-    };
-
-    // After a drop-triggered remount, refresh the derived state the way an `onChange` normally would
-    // (the fresh NodeEditor doesn't emit one at mount).
-    useEffect(() => {
-        if (mountNonce === 0 || !isReady) return undefined;
-        const frame = requestAnimationFrame(() =>
-            syncPortConnections(nodesRef.current),
-        );
-        setConnectedLayerIds(getConnectedDataLayerIds(nodesRef.current));
-        runPreview(nodesRef.current);
-        return () => cancelAnimationFrame(frame);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [mountNonce]);
-
-    // Prefix every node's header with an icon and, for deletable nodes, a delete button.
-    const renderNodeHeader = useCallback(
-        (Wrapper: any, nodeType: any, actions: any) => (
-            <Wrapper>
-                <NodeHeaderContent nodeType={nodeType} actions={actions} />
-            </Wrapper>
-        ),
-        [],
-    );
-
-    // Applies an AI-generated graph to the canvas. NodeEditor only reads `nodes`/`comments` at
-    // mount time, so `editorGeneration` forces a remount (see the `key` below) with the new graph.
-    const handleGenerateGraph = useCallback(
-        (graph: GeneratedGraph) => {
-            const nodes = buildFlumeGraphFromSpec(graph);
-            nodesRef.current = nodes;
-            commentsRef.current = {};
-            setAiGraph(nodes);
-            setEditorGeneration(generation => generation + 1);
-            setConnectedLayerIds(getConnectedDataLayerIds(nodes));
-            if (previewTimer.current) clearTimeout(previewTimer.current);
-            if (isOutputConnected(nodes)) {
-                runPreview(nodes);
-            } else {
-                setPreview({
-                    status: 'error',
-                    data: null,
-                    error: DISCONNECTED_MESSAGE,
-                });
-            }
+export const CompositeLayerEditor = forwardRef<
+    CompositeLayerEditorHandle,
+    Props
+>(
+    (
+        {
+            onClose,
+            onSaved,
+            compositeLayerId,
+            sidebarCollapsed = false,
+            onToggleSidebar,
         },
-        [runPreview],
-    );
-
-    useImperativeHandle(
         ref,
-        () => ({ applyGeneratedGraph: handleGenerateGraph }),
-        [handleGenerateGraph],
-    );
+    ) => {
+        const { formatMessage } = useSafeIntl();
+        const theme = useTheme();
 
-    const handleSave = () => {
-        saveCompositeLayer(
-            {
-                graph: nodesRef.current,
-                comments: commentsRef.current,
-                id: compositeLayerId,
-            },
-            {
-                onSuccess: saved => {
-                    // Hand the resulting layer to the parent so it can be displayed on the map;
-                    // fall back to just closing if no handler is provided.
-                    if (onSaved) {
-                        onSaved(saved?.metric_type_detail ?? undefined);
-                    } else {
-                        onClose();
-                    }
-                },
-            },
+        const { data: metricCategories, isLoading: isLoadingMetrics } =
+            useGetMetricCategories();
+        const { data: existingLayer, isLoading: isLoadingLayer } =
+            useGetCompositeLayer(compositeLayerId);
+        const { mutate: saveCompositeLayer, isLoading: isSaving } =
+            useSaveCompositeLayer();
+
+        const nodesRef = useRef<FlumeGraph>({});
+        const commentsRef = useRef<FlumeCommentMap>({});
+        const canvasRef = useRef<HTMLDivElement>(null);
+        const previewTimer = useRef<ReturnType<typeof setTimeout>>();
+        const { preview, runPreview, schedulePreview, markDisconnected } =
+            useCompositePreview();
+
+        // Flume reads `nodes`/`comments`/`initialScale` only at mount, so dropping a data layer onto
+        // the canvas remounts the editor (bumping `mountNonce`) with the mutated graph. The mount refs
+        // carry the graph + scale to restore on that remount so the view stays put.
+        const {
+            mountNonce,
+            mountGraphRef,
+            mountCommentsRef,
+            mountScaleRef,
+            handleCanvasDrop,
+        } = useCanvasDrop({ canvasRef, nodesRef, commentsRef });
+
+        // Data layers wired into the output (even behind transformations), ordered; drives the
+        // "based on a data layer" legend picker ordering.
+        const [connectedLayerIds, setConnectedLayerIds] = useState<number[]>(
+            [],
         );
-    };
+        // An AI-generated graph, applied to the canvas by remounting NodeEditor (it only reads
+        // `nodes`/`comments` at mount time, so there's no other way to push a new graph in).
+        const [aiGraph, setAiGraph] = useState<FlumeNodes | undefined>();
+        const [editorGeneration, setEditorGeneration] = useState(0);
 
-    // Main-panel title: the edited layer's name, or "New composite layer" for a fresh one.
-    const headerTitle = compositeLayerId
-        ? existingLayer?.name || formatMessage(MESSAGES.title)
-        : formatMessage(MESSAGES.newCompositeLayer);
+        const metricOptions: MetricOption[] = useMemo(() => {
+            if (!metricCategories) return [];
+            return metricCategories.flatMap(category =>
+                category.items.map(item => ({
+                    value: item.id,
+                    label: item.name,
+                })),
+            );
+        }, [metricCategories]);
 
-    return (
-        <Card sx={styles.card}>
-            <GlobalStyles styles={flumeContextMenuStyles(theme)} />
-            <CardStyled
-                isLoading={!isReady}
-                header={
-                    <EditorHeader
-                        title={headerTitle}
-                        sidebarCollapsed={sidebarCollapsed}
-                        onToggleSidebar={onToggleSidebar}
-                        onCancel={onClose}
-                        onSave={handleSave}
-                        isSaving={isSaving}
-                    />
+        const config = useMemo(
+            () => createCompositeFlumeConfig(metricOptions, formatMessage),
+            [metricOptions, formatMessage],
+        );
+
+        // Org units + metric metadata needed by the in-node map preview, handed to Flume controls
+        // through the NodeEditor `context` prop.
+        const { data: accountSettings } = useGetAccountSettings();
+        const interventionTypeId =
+            accountSettings?.intervention_org_unit_type_id;
+        const { data: orgUnits } = useGetOrgUnits({
+            orgUnitTypeId: interventionTypeId,
+            enabled: !!interventionTypeId,
+        });
+
+        const editorContext: CompositeEditorContext = useMemo(() => {
+            const metricTypeById = new Map<number, MetricType>();
+            (metricCategories ?? []).forEach(category => {
+                category.items.forEach(item =>
+                    metricTypeById.set(item.id, item),
+                );
+            });
+            return {
+                orgUnits: orgUnits ?? [],
+                metricTypeById,
+                preview,
+                connectedLayerIds,
+            };
+        }, [metricCategories, orgUnits, preview, connectedLayerIds]);
+
+        // Seed the working graph + comments from the loaded layer (NodeEditor only reads these at mount).
+        useEffect(() => {
+            if (existingLayer?.graph) {
+                nodesRef.current = existingLayer.graph;
+            }
+            if (existingLayer?.comments) {
+                commentsRef.current = existingLayer.comments;
+            }
+        }, [existingLayer]);
+
+        const isReady =
+            !isLoadingMetrics && (!compositeLayerId || !isLoadingLayer);
+
+        const syncPortConnections = usePortConnectionSync(canvasRef);
+
+        const handleChange = (nodes: FlumeGraph) => {
+            nodesRef.current = nodes;
+            // Wait a frame so ports added/removed by this change are in the DOM before we tag them.
+            requestAnimationFrame(() => syncPortConnections(nodes));
+            setConnectedLayerIds(getConnectedDataLayerIds(nodes));
+            // Clear the preview immediately on disconnect (don't wait out the debounce on a stale map).
+            if (!isOutputConnected(nodes)) {
+                markDisconnected();
+                return;
+            }
+            schedulePreview(nodes);
+        };
+
+        // Initial paint: existing graphs don't emit an onChange, so tag their ports once mounted.
+        // Also re-runs after an AI-generated graph forces a remount (`editorGeneration`).
+        useEffect(() => {
+            if (!isReady) return undefined;
+            const frame = requestAnimationFrame(() =>
+                syncPortConnections(nodesRef.current),
+            );
+            return () => cancelAnimationFrame(frame);
+        }, [isReady, existingLayer, editorGeneration, syncPortConnections]);
+
+        // Kick off a first preview once loaded (existing graphs don't emit an initial onChange).
+        useEffect(() => {
+            if (!isReady) return;
+            setConnectedLayerIds(getConnectedDataLayerIds(nodesRef.current));
+            runPreview(nodesRef.current);
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [isReady, existingLayer]);
+
+        const handleCommentsChange = (comments: FlumeCommentMap) => {
+            commentsRef.current = comments;
+        };
+
+        // After a drop-triggered remount, refresh the derived state the way an `onChange` normally would
+        // (the fresh NodeEditor doesn't emit one at mount).
+        useEffect(() => {
+            if (mountNonce === 0 || !isReady) return undefined;
+            const frame = requestAnimationFrame(() =>
+                syncPortConnections(nodesRef.current),
+            );
+            setConnectedLayerIds(getConnectedDataLayerIds(nodesRef.current));
+            runPreview(nodesRef.current);
+            return () => cancelAnimationFrame(frame);
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [mountNonce]);
+
+        // Prefix every node's header with an icon and, for deletable nodes, a delete button.
+        const renderNodeHeader = useCallback(
+            (Wrapper: any, nodeType: any, actions: any) => (
+                <Wrapper>
+                    <NodeHeaderContent nodeType={nodeType} actions={actions} />
+                </Wrapper>
+            ),
+            [],
+        );
+
+        // Applies an AI-generated graph to the canvas. NodeEditor only reads `nodes`/`comments` at
+        // mount time, so `editorGeneration` forces a remount (see the `key` below) with the new graph.
+        const handleGenerateGraph = useCallback(
+            (graph: GeneratedGraph) => {
+                const nodes = buildFlumeGraphFromSpec(graph);
+                nodesRef.current = nodes;
+                commentsRef.current = {};
+                setAiGraph(nodes);
+                setEditorGeneration(generation => generation + 1);
+                setConnectedLayerIds(getConnectedDataLayerIds(nodes));
+                if (previewTimer.current) clearTimeout(previewTimer.current);
+                if (isOutputConnected(nodes)) {
+                    runPreview(nodes);
+                } else {
+                    markDisconnected();
                 }
-            >
-                <Box
-                    ref={canvasRef}
-                    sx={[styles.canvas, flumeThemeSx]}
-                    onDragOver={event => {
-                        event.preventDefault();
-                        event.dataTransfer.dropEffect = 'copy';
-                    }}
-                    onDrop={handleCanvasDrop}
+            },
+            [runPreview, markDisconnected],
+        );
+
+        useImperativeHandle(
+            ref,
+            () => ({ applyGeneratedGraph: handleGenerateGraph }),
+            [handleGenerateGraph],
+        );
+
+        const handleSave = () => {
+            saveCompositeLayer(
+                {
+                    graph: nodesRef.current,
+                    comments: commentsRef.current,
+                    id: compositeLayerId,
+                },
+                {
+                    onSuccess: saved => {
+                        // Hand the resulting layer to the parent so it can be displayed on the map;
+                        // fall back to just closing if no handler is provided.
+                        if (onSaved) {
+                            onSaved(saved?.metric_type_detail ?? undefined);
+                        } else {
+                            onClose();
+                        }
+                    },
+                },
+            );
+        };
+
+        // Main-panel title: the edited layer's name, or "New composite layer" for a fresh one.
+        const headerTitle = compositeLayerId
+            ? existingLayer?.name || formatMessage(MESSAGES.title)
+            : formatMessage(MESSAGES.newCompositeLayer);
+
+        const nodes = useMemo(
+            () =>
+                aiGraph ??
+                (mountNonce === 0
+                    ? existingLayer?.graph
+                    : mountGraphRef.current),
+            [aiGraph, mountNonce, existingLayer, mountGraphRef],
+        );
+
+        const comments = useMemo(
+            () =>
+                (aiGraph && {}) ||
+                (mountNonce === 0
+                    ? existingLayer?.comments
+                    : mountCommentsRef.current),
+            [aiGraph, mountNonce, existingLayer, mountCommentsRef],
+        );
+
+        return (
+            <Card sx={styles.card}>
+                <GlobalStyles styles={flumeContextMenuStyles(theme)} />
+                <CardStyled
+                    isLoading={!isReady}
+                    header={
+                        <EditorHeader
+                            title={headerTitle}
+                            sidebarCollapsed={sidebarCollapsed}
+                            onToggleSidebar={onToggleSidebar}
+                            onCancel={onClose}
+                            onSave={handleSave}
+                            isSaving={isSaving}
+                        />
+                    }
                 >
-                    <NodeEditor
-                        key={`${compositeLayerId ?? 'new'}-${mountNonce}`}
-                        portTypes={config.portTypes}
-                        nodeTypes={config.nodeTypes}
-                        nodes={
-                            mountNonce === 0
-                                ? existingLayer?.graph
-                                : mountGraphRef.current
-                        }
-                        comments={
-                            mountNonce === 0
-                                ? existingLayer?.comments
-                                : mountCommentsRef.current
-                        }
-                        initialScale={
-                            mountNonce === 0 ? undefined : mountScaleRef.current
-                        }
-                        defaultNodes={DEFAULT_NODES}
-                        context={editorContext}
-                        onChange={handleChange}
-                        onCommentsChange={handleCommentsChange}
-                        renderNodeHeader={renderNodeHeader}
-                    />
-                    <CanvasControls
-                        canvasRef={canvasRef}
-                        initialFitAlign={compositeLayerId ? 'center' : 'right'}
-                    />
-                    <Typography variant="caption" sx={styles.helper}>
-                        {formatMessage(MESSAGES.helper)}
-                    </Typography>
-                </Box>
-            </CardStyled>
-        </Card>
-    );
-});
+                    <Box
+                        ref={canvasRef}
+                        sx={[styles.canvas, flumeThemeSx]}
+                        onDragOver={event => {
+                            event.preventDefault();
+                            event.dataTransfer.dropEffect = 'copy';
+                        }}
+                        onDrop={handleCanvasDrop}
+                    >
+                        <NodeEditor
+                            key={`${compositeLayerId ?? 'new'}-${mountNonce}-${editorGeneration}`}
+                            portTypes={config.portTypes}
+                            nodeTypes={config.nodeTypes}
+                            nodes={nodes}
+                            comments={comments}
+                            initialScale={
+                                mountNonce === 0
+                                    ? undefined
+                                    : mountScaleRef.current
+                            }
+                            defaultNodes={DEFAULT_NODES}
+                            context={editorContext}
+                            onChange={handleChange}
+                            onCommentsChange={handleCommentsChange}
+                            renderNodeHeader={renderNodeHeader}
+                        />
+                        <CanvasControls
+                            canvasRef={canvasRef}
+                            initialFitAlign={
+                                compositeLayerId ? 'center' : 'right'
+                            }
+                        />
+                        <Typography variant="caption" sx={styles.helper}>
+                            {formatMessage(MESSAGES.helper)}
+                        </Typography>
+                    </Box>
+                </CardStyled>
+            </Card>
+        );
+    },
+);
 CompositeLayerEditor.displayName = 'CompositeLayerEditor';

--- a/js/src/domains/compositeLayerEditor/messages.ts
+++ b/js/src/domains/compositeLayerEditor/messages.ts
@@ -273,4 +273,13 @@ export const MESSAGES = defineMessages({
         id: 'iaso.snt_malaria.compositeLayerEditor.ai.error',
         defaultMessage: 'Error generating composite layer. Please try again.',
     },
+    compositeLayerAIEmptyStateTitle: {
+        id: 'iaso.snt_malaria.compositeLayerEditor.ai.emptyStateTitle',
+        defaultMessage: 'Describe the composite layer you want to create',
+    },
+    compositeLayerAIEmptyStateDescription: {
+        id: 'iaso.snt_malaria.compositeLayerEditor.ai.emptyStateDescription',
+        defaultMessage:
+            'Describe the metrics, formulas and thresholds you want to combine — the AI builds the graph for you.',
+    },
 });

--- a/js/src/domains/compositeLayerEditor/messages.ts
+++ b/js/src/domains/compositeLayerEditor/messages.ts
@@ -261,4 +261,16 @@ export const MESSAGES = defineMessages({
         id: 'iaso.snt_malaria.compositeLayerEditor.firstConnectedLayerPlaceholder',
         defaultMessage: '[First connected layer]',
     },
+    compositeLayerAITitle: {
+        id: 'iaso.snt_malaria.compositeLayerEditor.ai.title',
+        defaultMessage: 'Generate with AI',
+    },
+    compositeLayerAIPlaceholder: {
+        id: 'iaso.snt_malaria.compositeLayerEditor.ai.placeholder',
+        defaultMessage: 'Describe the composite layer you want to create...',
+    },
+    compositeLayerAIError: {
+        id: 'iaso.snt_malaria.compositeLayerEditor.ai.error',
+        defaultMessage: 'Error generating composite layer. Please try again.',
+    },
 });

--- a/js/src/domains/dataLayers/index.tsx
+++ b/js/src/domains/dataLayers/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useMemo, useState } from 'react';
+import React, { FC, useCallback, useMemo, useRef, useState } from 'react';
 import { Card, Stack } from '@mui/material';
 import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
 import TopBar from 'Iaso/components/nav/TopBarComponent';
@@ -19,7 +19,12 @@ import {
 import { SETTINGS_WRITE } from '../../constants/permissions';
 import { baseUrls } from '../../constants/urls';
 import { useOnboarding } from '../../hooks/useOnboarding';
-import { CompositeLayerEditor } from '../compositeLayerEditor';
+import {
+    CompositeLayerEditor,
+    CompositeLayerEditorHandle,
+} from '../compositeLayerEditor';
+import { CompositeLayerAIChat } from '../compositeLayerEditor/compositeLayerChatBot/CompositeLayerAIChat';
+import { GeneratedGraph } from '../compositeLayerEditor/compositeLayerChatBot/types';
 import { useGetCompositeLayers } from '../compositeLayerEditor/hooks/useGetCompositeLayers';
 import { useGetAccountSettings } from '../planning/hooks/useGetAccountSettings';
 import { useGetOrgUnits } from '../planning/hooks/useGetOrgUnits';
@@ -89,6 +94,13 @@ export const DataLayers: FC = () => {
     const [editingCompositeLayerId, setEditingCompositeLayerId] = useState<
         number | undefined
     >(undefined);
+    const compositeLayerEditorRef = useRef<CompositeLayerEditorHandle>(null);
+    const onGenerateCompositeLayerGraph = useCallback(
+        (graph: GeneratedGraph) => {
+            compositeLayerEditorRef.current?.applyGeneratedGraph(graph);
+        },
+        [],
+    );
 
     const { data: compositeLayers } =
         useGetCompositeLayers(showCompositeLayers);
@@ -208,17 +220,20 @@ export const DataLayers: FC = () => {
             <PageContainer>
                 <SidebarLayout>
                     {!sidebarCollapsed && (
-                        <SidebarColumn>
-                            <PaperFullHeight>
+                    <SidebarColumn>
+                        <PaperFullHeight>
+                            {isCompositeEditorOpen ? (
+                                <CompositeLayerAIChat
+                                    onGenerate={onGenerateCompositeLayerGraph}
+                                />
+                            ) : (
                                 <Card sx={styles.card}>
                                     <CardStyled
                                         header={
                                             <DataLayerListHeader
                                                 onCreate={onCreateMetricType}
                                                 onCreateComposite={
-                                                    showCompositeLayers
-                                                        ? onCreateCompositeLayer
-                                                        : undefined
+                                                    onCreateCompositeLayer
                                                 }
                                                 createActionRef={
                                                     onboarding.anchorRefs[0]
@@ -260,6 +275,7 @@ export const DataLayers: FC = () => {
                         <PaperFullHeight>
                             {isCompositeEditorOpen ? (
                                 <CompositeLayerEditor
+                                    ref={compositeLayerEditorRef}
                                     compositeLayerId={editingCompositeLayerId}
                                     onClose={onCloseCompositeEditor}
                                     onSaved={onCompositeSaved}

--- a/js/src/domains/dataLayers/index.tsx
+++ b/js/src/domains/dataLayers/index.tsx
@@ -222,7 +222,8 @@ export const DataLayers: FC = () => {
                     {!sidebarCollapsed && (
                         <SidebarColumn>
                             <PaperFullHeight>
-                                {isCompositeEditorOpen ? (
+                                {isCompositeEditorOpen &&
+                                accountSettings?.has_ai_api_key ? (
                                     <CompositeLayerAIChat
                                         onGenerate={
                                             onGenerateCompositeLayerGraph

--- a/js/src/domains/dataLayers/index.tsx
+++ b/js/src/domains/dataLayers/index.tsx
@@ -220,54 +220,63 @@ export const DataLayers: FC = () => {
             <PageContainer>
                 <SidebarLayout>
                     {!sidebarCollapsed && (
-                    <SidebarColumn>
-                        <PaperFullHeight>
-                            {isCompositeEditorOpen ? (
-                                <CompositeLayerAIChat
-                                    onGenerate={onGenerateCompositeLayerGraph}
-                                />
-                            ) : (
-                                <Card sx={styles.card}>
-                                    <CardStyled
-                                        header={
-                                            <DataLayerListHeader
-                                                onCreate={onCreateMetricType}
-                                                onCreateComposite={
-                                                    onCreateCompositeLayer
-                                                }
-                                                createActionRef={
-                                                    onboarding.anchorRefs[0]
-                                                }
-                                                moreActionsRef={
-                                                    onboarding.anchorRefs[1]
-                                                }
-                                            />
+                        <SidebarColumn>
+                            <PaperFullHeight>
+                                {isCompositeEditorOpen ? (
+                                    <CompositeLayerAIChat
+                                        onGenerate={
+                                            onGenerateCompositeLayerGraph
                                         }
-                                    >
-                                        <DataLayerList
-                                            metricCategories={
-                                                metricCategories || []
+                                    />
+                                ) : (
+                                    <Card sx={styles.card}>
+                                        <CardStyled
+                                            header={
+                                                <DataLayerListHeader
+                                                    onCreate={
+                                                        onCreateMetricType
+                                                    }
+                                                    onCreateComposite={
+                                                        onCreateCompositeLayer
+                                                    }
+                                                    createActionRef={
+                                                        onboarding.anchorRefs[0]
+                                                    }
+                                                    moreActionsRef={
+                                                        onboarding.anchorRefs[1]
+                                                    }
+                                                />
                                             }
-                                            onSelectMetricType={
-                                                setDisplayedMetricType
-                                            }
-                                            selectedMetricTypeId={
-                                                isCompositeEditorOpen
-                                                    ? editedCompositeMetricTypeId
-                                                    : displayedMetricType?.id
-                                            }
-                                            onEditMetricType={onEditMetricType}
-                                            onEditCompositeLayer={
-                                                onEditCompositeLayer
-                                            }
-                                            compositeLayerIdByMetricType={
-                                                compositeLayerIdByMetricType
-                                            }
-                                            deleteMetricType={deleteMetricType}
-                                            editing={isCompositeEditorOpen}
-                                        />
-                                    </CardStyled>
-                                </Card>
+                                        >
+                                            <DataLayerList
+                                                metricCategories={
+                                                    metricCategories || []
+                                                }
+                                                onSelectMetricType={
+                                                    setDisplayedMetricType
+                                                }
+                                                selectedMetricTypeId={
+                                                    isCompositeEditorOpen
+                                                        ? editedCompositeMetricTypeId
+                                                        : displayedMetricType?.id
+                                                }
+                                                onEditMetricType={
+                                                    onEditMetricType
+                                                }
+                                                onEditCompositeLayer={
+                                                    onEditCompositeLayer
+                                                }
+                                                compositeLayerIdByMetricType={
+                                                    compositeLayerIdByMetricType
+                                                }
+                                                deleteMetricType={
+                                                    deleteMetricType
+                                                }
+                                                editing={isCompositeEditorOpen}
+                                            />
+                                        </CardStyled>
+                                    </Card>
+                                )}
                             </PaperFullHeight>
                         </SidebarColumn>
                     )}

--- a/js/src/domains/planning/types/accountSettings.ts
+++ b/js/src/domains/planning/types/accountSettings.ts
@@ -3,4 +3,5 @@ export type AccountSettings = {
     focus_org_unit_type_id?: number;
     intervention_org_unit_type_id?: number;
     default_population_id?: number | null;
+    has_ai_api_key: boolean;
 };

--- a/plugin_settings.py
+++ b/plugin_settings.py
@@ -10,6 +10,7 @@ CONSTANTS = {
     # Paths that IasoLogoutView accepts as ?next=... after logging the user out.
     # Used by the configureAccount wizard's "Restart" link.
     "LOGOUT_NEXT_ALLOWED_PATHS": ["/snt_malaria/public/setupAccount"],
+    "COMPOSITE_LAYER_AI_MODEL": os.environ.get("COMPOSITE_LAYER_AI_MODEL", "claude-opus-4-7"),
 }
 DEFAULT_THROTTLE_RATES = {
     "snt_public_account": os.environ.get("PUBLIC_ACCOUNT_THROTTLE_RATE", "5/hour"),

--- a/tests/api/composite_layer_ai/test_views.py
+++ b/tests/api/composite_layer_ai/test_views.py
@@ -1,0 +1,146 @@
+from unittest.mock import MagicMock, patch
+
+import anthropic
+
+from iaso.models import Account, MetricType
+from plugins.snt_malaria.tests.common_base import SNTMalariaAPITestCase
+
+
+BASE_URL = "/api/snt_malaria/composite_layer_ai/"
+
+
+class CompositeLayerAIAPITestCase(SNTMalariaAPITestCase):
+    auto_create_account = False
+
+    def setUp(self):
+        super().setUp()
+
+        self.account = Account.objects.create(
+            name="Test Account",
+            anthropic_api_key="sk-test-key",
+        )
+        self.account_no_key = Account.objects.create(name="Account Without Key")
+
+        self.user = self.create_user_with_profile(username="user_with_key", account=self.account)
+        self.user_no_key = self.create_user_with_profile(username="user_no_key", account=self.account_no_key)
+
+        self.metric_type = MetricType.objects.create(
+            account=self.account,
+            name="Rainfall",
+            code="rainfall",
+        )
+
+    def _mock_generate_composite_layer_graph(self, with_graph=True):
+        return {
+            "assistant_message": "Here is your composite layer.",
+            "graph": (
+                {
+                    "nodes": [
+                        {
+                            "id": "rainfall",
+                            "type": "dataLayer",
+                            "metric_type_id": str(self.metric_type.id),
+                        },
+                        {
+                            "id": "weighted",
+                            "type": "formula",
+                            "inputs": ["rainfall"],
+                            "formula": "a * 2",
+                        },
+                    ],
+                    "output": {
+                        "source": "weighted",
+                        "name": "Weighted rainfall",
+                        "legend_type": "auto",
+                    },
+                }
+                if with_graph
+                else None
+            ),
+            "conversation_history": [
+                {"role": "user", "content": "Create a composite layer"},
+                {"role": "assistant", "content": "Here is your composite layer."},
+            ],
+        }
+
+    def test_unauthenticated_returns_401(self):
+        response = self.client.post(BASE_URL, {"message": "hi"}, format="json")
+        self.assertEqual(response.status_code, 401)
+
+    def test_missing_api_key_returns_400(self):
+        self.client.force_authenticate(self.user_no_key)
+        response = self.client.post(BASE_URL, {"message": "Create a composite layer"}, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Composite Layer AI API key is not configured", response.data["error"])
+
+    def test_missing_message_returns_400(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.post(BASE_URL, {}, format="json")
+        self.assertEqual(response.status_code, 400)
+
+    @patch("plugins.snt_malaria.api.composite_layer_ai.views.generate_composite_layer_graph")
+    def test_claude_503_returns_503(self, mock_gen):
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        mock_gen.side_effect = anthropic.APIStatusError("service unavailable", response=mock_response, body=None)
+        self.client.force_authenticate(self.user)
+
+        response = self.client.post(BASE_URL, {"message": "Create a composite layer"}, format="json")
+
+        self.assertEqual(response.status_code, 503)
+
+    @patch("plugins.snt_malaria.api.composite_layer_ai.views.generate_composite_layer_graph")
+    def test_successful_generation(self, mock_gen):
+        mock_gen.return_value = self._mock_generate_composite_layer_graph(with_graph=True)
+        self.client.force_authenticate(self.user)
+
+        response = self.client.post(BASE_URL, {"message": "Double the rainfall layer"}, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["assistant_message"], "Here is your composite layer.")
+        self.assertEqual(response.data["graph"]["output"]["name"], "Weighted rainfall")
+        self.assertEqual(len(response.data["graph"]["nodes"]), 2)
+        self.assertEqual(len(response.data["conversation_history"]), 2)
+
+    @patch("plugins.snt_malaria.api.composite_layer_ai.views.generate_composite_layer_graph")
+    def test_conversational_response_has_no_graph(self, mock_gen):
+        mock_gen.return_value = self._mock_generate_composite_layer_graph(with_graph=False)
+        self.client.force_authenticate(self.user)
+
+        response = self.client.post(BASE_URL, {"message": "How are you?"}, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.data["graph"])
+
+    @patch("plugins.snt_malaria.api.composite_layer_ai.views.generate_composite_layer_graph")
+    def test_conversation_history_is_forwarded(self, mock_gen):
+        mock_gen.return_value = self._mock_generate_composite_layer_graph(with_graph=False)
+        self.client.force_authenticate(self.user)
+
+        history = [{"role": "user", "content": "prev"}, {"role": "assistant", "content": "ok"}]
+        self.client.post(
+            BASE_URL,
+            {"message": "next", "conversation_history": history},
+            format="json",
+        )
+
+        call_args = mock_gen.call_args
+        self.assertEqual(call_args[0][1], history)
+
+    @patch("plugins.snt_malaria.api.composite_layer_ai.views.generate_composite_layer_graph")
+    def test_only_non_utility_metric_types_are_sent(self, mock_gen):
+        MetricType.objects.create(
+            account=self.account,
+            name="Population",
+            code="population",
+            is_utility=True,
+        )
+        mock_gen.return_value = self._mock_generate_composite_layer_graph(with_graph=False)
+        self.client.force_authenticate(self.user)
+
+        self.client.post(BASE_URL, {"message": "hi"}, format="json")
+
+        call_args = mock_gen.call_args
+        metric_types_sent = call_args[0][2]
+        self.assertEqual(len(metric_types_sent), 1)
+        self.assertEqual(metric_types_sent[0]["name"], "Rainfall")

--- a/tests/api/composite_layer_ai/test_views.py
+++ b/tests/api/composite_layer_ai/test_views.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock, patch
 
 import anthropic
 
+from rest_framework import status
+
 from iaso.models import Account, MetricType
 from plugins.snt_malaria.permissions import SNT_SETTINGS_WRITE_PERMISSION
 from plugins.snt_malaria.tests.common_base import SNTMalariaAPITestCase
@@ -28,6 +30,8 @@ class CompositeLayerAIAPITestCase(SNTMalariaAPITestCase):
         self.user_no_key = self.create_user_with_profile(
             username="user_no_key", account=self.account_no_key, permissions=[SNT_SETTINGS_WRITE_PERMISSION]
         )
+
+        self.user_no_perm = self.create_user_with_profile(username="user_no_perm", account=self.account, permissions=[])
 
         self.metric_type = MetricType.objects.create(
             account=self.account,
@@ -70,18 +74,23 @@ class CompositeLayerAIAPITestCase(SNTMalariaAPITestCase):
 
     def test_unauthenticated_returns_401(self):
         response = self.client.post(BASE_URL, {"message": "hi"}, format="json")
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_missing_api_key_returns_400(self):
         self.client.force_authenticate(self.user_no_key)
         response = self.client.post(BASE_URL, {"message": "Create a composite layer"}, format="json")
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("Composite Layer AI API key is not configured", response.data["error"])
 
     def test_missing_message_returns_400(self):
         self.client.force_authenticate(self.user)
         response = self.client.post(BASE_URL, {}, format="json")
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_user_no_perm(self):
+        self.client.force_authenticate(self.user_no_perm)
+        response = self.client.post(BASE_URL, {"message": "Create a composite layer"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @patch("plugins.snt_malaria.api.composite_layer_ai.views.generate_composite_layer_graph")
     def test_claude_503_returns_503(self, mock_gen):
@@ -92,7 +101,7 @@ class CompositeLayerAIAPITestCase(SNTMalariaAPITestCase):
 
         response = self.client.post(BASE_URL, {"message": "Create a composite layer"}, format="json")
 
-        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
 
     @patch("plugins.snt_malaria.api.composite_layer_ai.views.generate_composite_layer_graph")
     def test_successful_generation(self, mock_gen):
@@ -101,7 +110,7 @@ class CompositeLayerAIAPITestCase(SNTMalariaAPITestCase):
 
         response = self.client.post(BASE_URL, {"message": "Double the rainfall layer"}, format="json")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["assistant_message"], "Here is your composite layer.")
         self.assertEqual(response.data["graph"]["output"]["name"], "Weighted rainfall")
         self.assertEqual(len(response.data["graph"]["nodes"]), 2)
@@ -114,7 +123,7 @@ class CompositeLayerAIAPITestCase(SNTMalariaAPITestCase):
 
         response = self.client.post(BASE_URL, {"message": "How are you?"}, format="json")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNone(response.data["graph"])
 
     @patch("plugins.snt_malaria.api.composite_layer_ai.views.generate_composite_layer_graph")

--- a/tests/api/composite_layer_ai/test_views.py
+++ b/tests/api/composite_layer_ai/test_views.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import anthropic
 
 from iaso.models import Account, MetricType
+from plugins.snt_malaria.permissions import SNT_SETTINGS_WRITE_PERMISSION
 from plugins.snt_malaria.tests.common_base import SNTMalariaAPITestCase
 
 
@@ -21,8 +22,12 @@ class CompositeLayerAIAPITestCase(SNTMalariaAPITestCase):
         )
         self.account_no_key = Account.objects.create(name="Account Without Key")
 
-        self.user = self.create_user_with_profile(username="user_with_key", account=self.account)
-        self.user_no_key = self.create_user_with_profile(username="user_no_key", account=self.account_no_key)
+        self.user = self.create_user_with_profile(
+            username="user_with_key", account=self.account, permissions=[SNT_SETTINGS_WRITE_PERMISSION]
+        )
+        self.user_no_key = self.create_user_with_profile(
+            username="user_no_key", account=self.account_no_key, permissions=[SNT_SETTINGS_WRITE_PERMISSION]
+        )
 
         self.metric_type = MetricType.objects.create(
             account=self.account,

--- a/tests/services/test_composite_layer.py
+++ b/tests/services/test_composite_layer.py
@@ -901,7 +901,7 @@ class CompositeLayerEvaluatorTestCase(SNTMalariaTestMixin, TestCase):
         # metric_a: ou1=2.0 -> classify "<3" matches -> "1" -> formula "1" + 1 == 2.0
         #           ou2=4.0 -> no rule matches -> default "2" -> formula "2" + 1 == 3.0
         _, values = CompositeGraphEvaluator(self.account, graph, self.org_unit_ids).run()
-        self.assertEqual(values, {self.ou1.id: 2.0, self.ou2.id: 3.0})
+        self.assertEqual(values[None], {self.ou1.id: 2.0, self.ou2.id: 3.0})
 
     def test_classify_without_mappings_raises(self):
         graph = {

--- a/tests/services/test_composite_layer.py
+++ b/tests/services/test_composite_layer.py
@@ -878,6 +878,31 @@ class CompositeLayerEvaluatorTestCase(SNTMalariaTestMixin, TestCase):
         with self.assertRaises(CompositeGraphError):
             CompositeGraphEvaluator(self.account, graph, self.org_unit_ids).run()
 
+    def test_formula_sums_numeric_classify_labels(self):
+        # Classify labels can be numeric-looking strings (e.g. "1"/"2"); a downstream formula must
+        # add them as numbers (3.0), not concatenate them as text ("12").
+        graph = {
+            "layer1": _data_layer_node("layer1", self.metric_a.id, [{"nodeId": "cls", "portName": "a"}]),
+            "cls": _classify_node(
+                "cls",
+                rules=[{"op": "<", "value": 3, "label": "1"}],
+                default="2",
+                input_sources={"a": [{"nodeId": "layer1", "portName": "values"}]},
+                output_targets=[{"nodeId": "formula1", "portName": "a"}],
+            ),
+            "formula1": _formula_node(
+                "formula1",
+                "a + 1",
+                {"a": [{"nodeId": "cls", "portName": "result"}]},
+                [{"nodeId": "out", "portName": "layer"}],
+            ),
+            "out": _output_node("out", "Score", [{"nodeId": "formula1", "portName": "result"}]),
+        }
+        # metric_a: ou1=2.0 -> classify "<3" matches -> "1" -> formula "1" + 1 == 2.0
+        #           ou2=4.0 -> no rule matches -> default "2" -> formula "2" + 1 == 3.0
+        _, values = CompositeGraphEvaluator(self.account, graph, self.org_unit_ids).run()
+        self.assertEqual(values, {self.ou1.id: 2.0, self.ou2.id: 3.0})
+
     def test_classify_without_mappings_raises(self):
         graph = {
             "layer1": _data_layer_node("layer1", self.metric_a.id, [{"nodeId": "cls", "portName": "a"}]),


### PR DESCRIPTION
## What problem is this PR solving?

Introduce a ChatPanel and generate Flume by claude

### Related JIRA tickets

SNT-533

## Changes

- Add a chat panel (only visible if there is an ai key setup for the account)
- Generate flume config by Claude
- Apply flume config from Claude

## How to test

First make sure you have an Anthropic API key set on your account.
Then go to DataLayer and create a new composite layer.
Ask some stuff (I.E. Give me prevalence based on WHO standards) to the chat and verify that flume diagram is generated properly.

## Print screen / video

<img width="1633" height="1207" alt="image" src="https://github.com/user-attachments/assets/e74c4a27-ceda-4a9d-a08c-b6f935deb037" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
