### PR TITLE
SNT-542: Enable data import for years starting 2000

### DIFF
--- a/js/src/domains/dataLayers/MetricValuesImportDialog.tsx
+++ b/js/src/domains/dataLayers/MetricValuesImportDialog.tsx
@@ -12,8 +12,9 @@ import { noOp } from 'Iaso/utils';
 import { useImportMetricValues } from './hooks/useImportMetricValues';
 import { MESSAGES } from './messages';
 
-const yearOptions = Array.from({ length: 20 }, (_, i) => {
-    const year = 2020 + i;
+const currentYear = new Date().getFullYear();
+const yearOptions = Array.from({ length: currentYear - 2000 + 1 }, (_, i) => {
+    const year = 2000 + i;
     return { label: year.toString(), value: year };
 });
 


### PR DESCRIPTION
## What problem is this PR solving?

Extend year range when importing layers

### Related JIRA tickets

SNT-542

## Changes

N/A

## How to test

Go to snt, data layers and import for 2020, verify that import worked properly

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
