### PR TITLE
Fix SNT-553: Node looses connector on click

### DIFF
--- a/js/src/domains/compositeLayerEditor/hooks/useCanvasDrop.ts
+++ b/js/src/domains/compositeLayerEditor/hooks/useCanvasDrop.ts
@@ -31,6 +31,12 @@ type UseCanvasDrop = {
     mountCommentsRef: MutableRefObject<FlumeCommentMap | undefined>;
     mountScaleRef: MutableRefObject<number | undefined>;
     handleCanvasDrop: (event: React.DragEvent<HTMLDivElement>) => void;
+    /**
+     * Remount the editor with an arbitrary new graph while keeping the view put (same pan/zoom).
+     * Flume has no imperative graph API, so structural edits (e.g. removing a connection) go through
+     * a remount, like drops.
+     */
+    remountWithGraph: (nextNodes: FlumeGraph) => void;
 };
 
 /**
@@ -100,11 +106,31 @@ export const useCanvasDrop = ({
         setMountNonce(nonce => nonce + 1);
     };
 
+    const remountWithGraph = (nextNodes: FlumeGraph) => {
+        const {
+            nodes: shiftedNodes,
+            comments: shiftedComments,
+            scale: capturedScale,
+        } = shiftGraphForRemount(
+            nextNodes || {},
+            commentsRef.current || {},
+            canvasRef.current,
+        );
+        nodesRef.current = shiftedNodes;
+        commentsRef.current = shiftedComments;
+        mountGraphRef.current = shiftedNodes;
+        mountCommentsRef.current = shiftedComments;
+        mountScaleRef.current = capturedScale;
+        onBeforeRemount?.();
+        setMountNonce(nonce => nonce + 1);
+    };
+
     return {
         mountNonce,
         mountGraphRef,
         mountCommentsRef,
         mountScaleRef,
         handleCanvasDrop,
+        remountWithGraph,
     };
 };

--- a/js/src/domains/compositeLayerEditor/index.tsx
+++ b/js/src/domains/compositeLayerEditor/index.tsx
@@ -56,6 +56,7 @@ import {
     findOutputNode,
     getConnectedDataLayerIds,
     isOutputConnected,
+    removeInputConnection,
 } from './utils/graph';
 
 // Flume adds a default output node for a fresh graph; existing graphs already contain their own.
@@ -173,6 +174,7 @@ export const CompositeLayerEditor = forwardRef<
             mountCommentsRef,
             mountScaleRef,
             handleCanvasDrop,
+            remountWithGraph,
         } = useCanvasDrop({
             canvasRef,
             nodesRef,
@@ -265,6 +267,34 @@ export const CompositeLayerEditor = forwardRef<
             }
             schedulePreview(nodes);
         };
+
+        // Click a connected INPUT port to remove its connection. Handled on `click` (not mousedown)
+        // so grabbing the wire to drag it still works, and after Flume's own mouse-up so there's no
+        // race. Flume's native click leaves the wire in an inconsistent state, so we rebuild the
+        // graph without the connection and remount (keeping the view in place).
+        const handlePortClick = useCallback(
+            (event: React.MouseEvent<HTMLDivElement>) => {
+                const handle = (
+                    event.target as HTMLElement | null
+                )?.closest?.(
+                    '[data-flume-component="port-handle"]',
+                ) as HTMLElement | null;
+                if (!handle || handle.dataset.portTransputType !== 'input') {
+                    return;
+                }
+                const { nodeId, portName } = handle.dataset;
+                if (!nodeId || !portName) return;
+                // Only act if that input is actually wired up (read the graph, not the flaky DOM
+                // flag Flume may have left stale).
+                const sources =
+                    nodesRef.current?.[nodeId]?.connections?.inputs?.[portName];
+                if (!sources?.length) return;
+                remountWithGraph(
+                    removeInputConnection(nodesRef.current, nodeId, portName),
+                );
+            },
+            [remountWithGraph],
+        );
 
         // Initial paint: existing graphs don't emit an onChange, so tag their ports once mounted.
         // Also re-runs after an AI-generated graph forces a remount (`editorGeneration`).
@@ -520,6 +550,7 @@ export const CompositeLayerEditor = forwardRef<
                             event.dataTransfer.dropEffect = 'copy';
                         }}
                         onDrop={handleCanvasDrop}
+                        onClick={handlePortClick}
                     >
                         {/* Faded, not unmounted, while `isFraming` so its DOM sizes stay measurable.
                             `height: 100%` is required: Flume's root fills its parent that way, so

--- a/js/src/domains/compositeLayerEditor/utils/graph.ts
+++ b/js/src/domains/compositeLayerEditor/utils/graph.ts
@@ -12,6 +12,44 @@ export const isOutputConnected = (graph: FlumeGraph): boolean => {
 };
 
 /**
+ * Return a copy of the graph with the connection into a given input port removed on both sides
+ * (the target's `inputs[port]` and each source's matching `outputs[port]` entry). Backs the
+ * drag-an-input-into-empty-space removal gesture (Flume's own port handling is unreliable here).
+ */
+export const removeInputConnection = (
+    graph: FlumeGraph,
+    inputNodeId: string,
+    inputPortName: string,
+): FlumeGraph => {
+    const next: FlumeGraph = JSON.parse(JSON.stringify(graph ?? {}));
+    const inputNode = next[inputNodeId];
+    const sources = inputNode?.connections?.inputs?.[inputPortName];
+    if (!inputNode || !sources?.length) return next;
+
+    delete inputNode.connections.inputs[inputPortName];
+
+    sources.forEach(source => {
+        const sourceNode = next[source.nodeId];
+        const outputs = sourceNode?.connections?.outputs?.[source.portName];
+        if (!outputs) return;
+        const remaining = outputs.filter(
+            target =>
+                !(
+                    target.nodeId === inputNodeId &&
+                    target.portName === inputPortName
+                ),
+        );
+        if (remaining.length) {
+            sourceNode.connections.outputs[source.portName] = remaining;
+        } else {
+            delete sourceNode.connections.outputs[source.portName];
+        }
+    });
+
+    return next;
+};
+
+/**
  * MetricType ids of the data layers wired into the output node, in traversal order (deduped).
  *
  * Walks the graph depth-first from the output node following input connections, so it finds data


### PR DESCRIPTION
## What problem is this PR solving?

Fix, when connected node input ports are clicked, removes the connector for real

### Related JIRA tickets

SNT-553
SNT-546