### PR TITLE
SNT-550 Add CSV export button for metric values

### DIFF
--- a/js/src/constants/api-urls.ts
+++ b/js/src/constants/api-urls.ts
@@ -3,3 +3,5 @@ export const exportScenarioAPIPath =
 
 export const exportMetricValuesTemplateAPIPath =
     '/api/metricvalues/csv_template/';
+
+export const exportMetricValuesAPIPath = '/api/metricvalues/export_csv/';

--- a/js/src/constants/translations/en.json
+++ b/js/src/constants/translations/en.json
@@ -118,6 +118,7 @@
     "iaso.snt_malaria.settings.dataLayers.deleteLayer": "Delete Layer",
     "iaso.snt_malaria.settings.dataLayers.deleteLayerConfirmMessage": "Are you sure you want to delete this layer?",
     "iaso.snt_malaria.settings.dataLayers.downloadCSVTemplate": "Download CSV Template",
+    "iaso.snt_malaria.settings.dataLayers.exportCSV": "Export to CSV",
     "iaso.snt_malaria.settings.dataLayers.importCSV": "Import metric values",
     "iaso.snt_malaria.settings.dataLayers.metricValuesImportSuccess": "Metric values imported successfully",
     "iaso.snt_malaria.settings.dataLayers.metricValuesImportError": "Error importing metric values.",

--- a/js/src/constants/translations/fr.json
+++ b/js/src/constants/translations/fr.json
@@ -117,6 +117,7 @@
     "iaso.snt_malaria.settings.dataLayers.deleteLayer": "Supprimer la couche",
     "iaso.snt_malaria.settings.dataLayers.deleteLayerConfirmMessage": "Êtes-vous sûr de vouloir supprimer ce type de métrique ?",
     "iaso.snt_malaria.settings.dataLayers.downloadCSVTemplate": "Télécharger le Template CSV",
+    "iaso.snt_malaria.settings.dataLayers.exportCSV": "Exporter en CSV",
     "iaso.snt_malaria.settings.dataLayers.importCSV": "Importer les valeurs métriques",
     "iaso.snt_malaria.settings.dataLayers.metricValuesImportSuccess": "Importation des valeurs métriques réussie.",
     "iaso.snt_malaria.settings.dataLayers.metricValuesImportError": "Erreur lors de l'importation des valeurs métriques.",

--- a/js/src/domains/dataLayers/dataLayerMap/DataLayerMapWrapper.tsx
+++ b/js/src/domains/dataLayers/dataLayerMap/DataLayerMapWrapper.tsx
@@ -24,6 +24,7 @@ import { MESSAGES } from '../../messages';
 import { useGetMetricValues } from '../hooks/useGetMetrics';
 import { MetricType, MetricValue } from '../types/metrics';
 import { DataLayerMap } from './DataLayerMap';
+import { ExportMetricValuesCsvButton } from './ExportMetricValuesCsvButton';
 
 const styles = {
     card: {
@@ -128,7 +129,7 @@ export const DataLayerMapWrapper: FC<Props> = ({
                         <Stack
                             direction="row"
                             spacing={2}
-                            alignItems="end"
+                            alignItems="center"
                             sx={{ flexShrink: 0 }}
                         >
                             {yearOptions.length > 0 && (
@@ -170,6 +171,10 @@ export const DataLayerMapWrapper: FC<Props> = ({
                                         {formatMessage(MESSAGES.compositeEditor)}
                                     </Button>
                                 )}
+                            <ExportMetricValuesCsvButton
+                                metricType={metricType}
+                                year={year}
+                            />
                             {(onRemove && (
                                 <IconButton
                                     overrideIcon={CancelOutlinedIcon}

--- a/js/src/domains/dataLayers/dataLayerMap/ExportMetricValuesCsvButton.tsx
+++ b/js/src/domains/dataLayers/dataLayerMap/ExportMetricValuesCsvButton.tsx
@@ -24,7 +24,7 @@ export const ExportMetricValuesCsvButton: FC<Props> = ({
     const params = new URLSearchParams({
         metric_type_ids: metricType.id.toString(),
     });
-    if (year) {
+    if (year && year !== '0') {
         params.set('year', year);
     }
     // Use a plain anchor here, not bluesquare-components' IconButton/react-router Link:

--- a/js/src/domains/dataLayers/dataLayerMap/ExportMetricValuesCsvButton.tsx
+++ b/js/src/domains/dataLayers/dataLayerMap/ExportMetricValuesCsvButton.tsx
@@ -1,0 +1,42 @@
+import React, { FC } from 'react';
+import GetAppIcon from '@mui/icons-material/GetApp';
+import { IconButton, Tooltip } from '@mui/material';
+import { useSafeIntl } from 'bluesquare-components';
+import { exportMetricValuesAPIPath } from '../../../constants/api-urls';
+import { MESSAGES } from '../messages';
+import { MetricType } from '../types/metrics';
+
+type Props = {
+    metricType?: MetricType;
+    year?: string;
+};
+
+export const ExportMetricValuesCsvButton: FC<Props> = ({
+    metricType,
+    year,
+}) => {
+    const { formatMessage } = useSafeIntl();
+
+    if (!metricType) {
+        return null;
+    }
+
+    const params = new URLSearchParams({
+        metric_type_ids: metricType.id.toString(),
+    });
+    if (year) {
+        params.set('year', year);
+    }
+    // Use a plain anchor here, not bluesquare-components' IconButton/react-router Link:
+    // react-router prefixes the router's basename onto `to` even for absolute paths,
+    // which breaks this same-origin backend URL when a basename is active (e.g. dashboards).
+    const url = `${exportMetricValuesAPIPath}?${params.toString()}`;
+
+    return (
+        <Tooltip title={formatMessage(MESSAGES.exportCSV)}>
+            <IconButton component="a" href={url} download size="medium">
+                <GetAppIcon fontSize="medium" />
+            </IconButton>
+        </Tooltip>
+    );
+};

--- a/js/src/domains/dataLayers/messages.ts
+++ b/js/src/domains/dataLayers/messages.ts
@@ -17,6 +17,10 @@ export const MESSAGES = defineMessages({
         id: 'iaso.snt_malaria.scenario.importCSV',
         defaultMessage: 'Import CSV',
     },
+    exportCSV: {
+        id: 'iaso.snt_malaria.settings.dataLayers.exportCSV',
+        defaultMessage: 'Export to CSV',
+    },
     addScaleItem: {
         id: 'iaso.snt_malaria.settings.dataLayers.addScaleItem',
         defaultMessage: 'Add range',


### PR DESCRIPTION
## What problem is this PR solving?

Add an export data layer to CSV button

### Related JIRA tickets

SNT-550

## Changes

- Add an api endpoint to download a list of data layers as CSV for a given year (or none)
- Add a button on DataLayer header to download selected data layer as CSV

## How to test

Go to SNT Malaria, Data layers and try to download two type of data layers: 
Data layers with a given year (mostly custom layers) and data layers with no year (mostly from OH).
It should export the data layer as CSV and match the template format.

Once done, you can try to import that CSV for another year and see if it is the same.

## Print screen / video

<img width="394" height="117" alt="image" src="https://github.com/user-attachments/assets/5e88ec6b-65ed-4932-bcf4-8574e62480d5" />

## Notes

IASO PR https://github.com/BLSQ/iaso/pull/3228

## Doc

N/A
