### PR TITLE
bugfix SNT-560: fix inconsistent timeless data layers

### DIFF
--- a/js/src/domains/dataLayers/hooks/useImportMetricValues.ts
+++ b/js/src/domains/dataLayers/hooks/useImportMetricValues.ts
@@ -11,7 +11,7 @@ export const useImportMetricValues = (): UseMutationResult =>
                 fileData: {
                     file: file,
                 },
-                data: { year },
+                data: year ? { year } : {},
             }),
         invalidateQueryKey: ['metricCategories', 'metricValues'], // We need both as metric categories contain metric values
         snackSuccessMessage: MESSAGES.metricValuesImportSuccess,

--- a/management/commands/support/demo_scenario_seeder.py
+++ b/management/commands/support/demo_scenario_seeder.py
@@ -229,17 +229,17 @@ class DemoScenarioSeeder:
         self.stdout_write(f"Created {len(to_create)} yearly cost assignments for '{scenario.name}'")
 
     def _ensure_population_for_scenario_years(self, scenario):
-        """The metrics dataset has no YEAR column so MetricValues are imported with year=0.
-        The budget calculator queries by exact year, so copy the year=0 baseline values to
-        every year in the scenario range so the calculation produces non-zero results."""
+        """The metrics dataset has no YEAR column so MetricValues are imported as timeless
+        (year=None). The budget calculator queries by exact year, so copy the timeless baseline
+        values to every year in the scenario range so the calculation produces non-zero results."""
         pop_metric_types = MetricType.objects.filter(
             account=scenario.account,
             metric_kind=MetricType.MetricKind.POPULATION,
         )
 
-        base_values = list(MetricValue.objects.filter(metric_type__in=pop_metric_types, year=0))
+        base_values = list(MetricValue.objects.filter(metric_type__in=pop_metric_types, year__isnull=True))
         if not base_values:
-            self.stdout_write("WARNING: no year=0 population values found; budget may be empty")
+            self.stdout_write("WARNING: no timeless population values found; budget may be empty")
             return
 
         to_create = []

--- a/management/commands/support/metrics_importer.py
+++ b/management/commands/support/metrics_importer.py
@@ -7,6 +7,8 @@ into MetricType and MetricValue models, including legend configuration.
 
 import csv
 
+from typing import Optional
+
 from django.core.management.base import CommandError
 from django.db import transaction
 
@@ -29,6 +31,14 @@ class MetricsImporter:
         self.style = style
         self.stdout_write = stdout_writer or print
         self.metric_type_scales = {}
+
+    @staticmethod
+    def _parse_year(row: dict) -> Optional[int]:
+        """Rows with no YEAR column (or an empty value) are timeless - year=None, not 0, so
+        consumers (ScenarioRule.resolve_matched_org_units, the composite evaluator, ...)
+        recognize them as such."""
+        year_raw = row.get("YEAR")
+        return int(year_raw) if year_raw else None
 
     def import_metrics(self, metadata_file_path, dataset_file_path, pop_dataset_file_path=None):
         """Import metrics from CSV files.
@@ -284,7 +294,7 @@ class MetricsImporter:
                             org_unit=org_unit,
                             value=value,
                             string_value=string_value,
-                            year=int(row.get("YEAR", 0)),
+                            year=self._parse_year(row),
                         )
                         value_count += 1
 

--- a/migrations/0060_metricvalue_year_zero_to_null.py
+++ b/migrations/0060_metricvalue_year_zero_to_null.py
@@ -1,0 +1,31 @@
+from django.db import migrations
+
+
+def migrate_year_zero_to_null(apps, schema_editor):
+    """MetricValue.year=0 was written by metrics_importer.py for rows with no YEAR column,
+    instead of the intended NULL ("timeless"). Backfill it to NULL, but where a NULL row already
+    exists for the same (metric_type, org_unit) pair - e.g. from add_pop_metrics.py, which already
+    writes year=None - drop the year=0 duplicate instead of converting it, so we don't end up with
+    two "timeless" rows for the same pair."""
+    MetricValue = apps.get_model("iaso", "MetricValue")
+    db_alias = schema_editor.connection.alias
+
+    null_pairs = set(
+        MetricValue.objects.using(db_alias).filter(year__isnull=True).values_list("metric_type_id", "org_unit_id")
+    )
+    zero_values = MetricValue.objects.using(db_alias).filter(year=0).only("id", "metric_type_id", "org_unit_id")
+    duplicate_ids = [mv.id for mv in zero_values if (mv.metric_type_id, mv.org_unit_id) in null_pairs]
+    if duplicate_ids:
+        MetricValue.objects.using(db_alias).filter(id__in=duplicate_ids).delete()
+
+    MetricValue.objects.using(db_alias).filter(year=0).update(year=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("snt_malaria", "0059_compositelayer_legend_config_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_year_zero_to_null, migrations.RunPython.noop, elidable=True),
+    ]

--- a/migrations/0061_metricvalue_year_zero_to_null.py
+++ b/migrations/0061_metricvalue_year_zero_to_null.py
@@ -23,7 +23,7 @@ def migrate_year_zero_to_null(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("snt_malaria", "0059_compositelayer_legend_config_and_more"),
+        ("snt_malaria", "0060_remove_scenario_reference_year_and_more"),
     ]
 
     operations = [

--- a/tests/management/test_metrics_importer.py
+++ b/tests/management/test_metrics_importer.py
@@ -1,0 +1,14 @@
+from django.test import SimpleTestCase
+
+from plugins.snt_malaria.management.commands.support.metrics_importer import MetricsImporter
+
+
+class ParseYearTestCase(SimpleTestCase):
+    def test_missing_year_column_is_timeless(self):
+        self.assertIsNone(MetricsImporter._parse_year({"ADM2_ID": "1"}))
+
+    def test_empty_year_value_is_timeless(self):
+        self.assertIsNone(MetricsImporter._parse_year({"YEAR": ""}))
+
+    def test_real_year_value_is_parsed(self):
+        self.assertEqual(MetricsImporter._parse_year({"YEAR": "2025"}), 2025)


### PR DESCRIPTION
## What problem is this PR solving?

Timeless data layers were saved with either `year=0` or `year=NULL`

### Related JIRA tickets

SNT-560

## Changes

Changes the all logic to use `year=NULL` for timeless metrics and migrates existing data with `year=0` to `year=NULL`