### PR TITLE
fix(frontend): formatBigNumber regression

### DIFF
--- a/js/src/domains/planning/libs/cost-utils.tsx
+++ b/js/src/domains/planning/libs/cost-utils.tsx
@@ -63,7 +63,9 @@ export const formatBigNumber = (value: number, currency?: string) => {
     } else {
         formattedValue = value.toFixed(2);
     }
-    return `${formatCurrencyAmount(formattedValue, currency)}`;
+    return currency
+        ? `${formatCurrencyAmount(formattedValue, currency)}`
+        : formattedValue;
 };
 
 /** Compact quantity formatting: whole units below 1000, else K/M/B, e.g. 534233 -> "534.23K". */


### PR DESCRIPTION
Currency formatting was applied to all formatted values in `formatBigNumber` which lead to the front-end crashing when no currency was passed to `formatBigNumber`.

The fix is to check if `currency` is given and otherwise return the formatted value without passing it through `formatCurrencyAmount`